### PR TITLE
Add composer.json and local_paths example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ quick_gen_project_*
 /galette/config/config.inc.php*
 !/galette/config/config.inc.php.dist
 /galette/config/local_*
+!/galette/config/local_*.dist
 /galette/config/behavior.inc.php
 /tests/config/mysql/local_config.inc.php
 /tests/config/pgsql/local_config.inc.php
@@ -75,6 +76,9 @@ galette/includes/tcpdf_*
 galette/includes/Zend*
 galette/includes/Analog*
 galette/password_compat*
+
+# Composer libs
+/vendor/
 
 #Backup files
 *~

--- a/bin/install_deps
+++ b/bin/install_deps
@@ -1,4 +1,3 @@
 #!/bin/sh
-cd galette/includes/
-wget http://download.tuxfamily.org/galette/dev/galette_dev_includes.tar.bz2
-tar xjf galette_dev_includes.tar.bz2
+composer install
+cp galette/config/local_paths.inc.php.dist galette/config/local_paths.inc.php

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,9 @@
+{
+    "require": {
+        "phpmailer/phpmailer": "^5.2",
+        "smarty/smarty": "^3.1",
+        "zendframework/zend-db": "^2.8",
+        "analog/analog": "^1.0",
+        "tecnickcom/tcpdf": "^6.2"
+    }
+}

--- a/galette/config/local_paths.inc.php.dist
+++ b/galette/config/local_paths.inc.php.dist
@@ -1,0 +1,9 @@
+<?php
+define('GALETTE_ANALOG_PATH',     GALETTE_ROOT . '../vendor/analog/analog');
+define('GALETTE_ZEND_PATH',       GALETTE_ROOT . '../vendor/zendframework/zend-db');
+define('GALETTE_PHP_MAILER_PATH', GALETTE_ROOT . '../vendor/phpmailer/phpmailer');
+define('GALETTE_SMARTY_PATH',     GALETTE_ROOT . '../vendor/smarty/smarty/libs');
+define('GALETTE_TCPDF_PATH',      GALETTE_ROOT . '../vendor/tecnickcom/tcpdf');
+
+require GALETTE_ROOT . '../vendor/autoload.php';
+?>


### PR DESCRIPTION
Permet de charger les dépendances en utilisant composer.

**Utilisation :**
```bash
composer install
cp galette/config/local_paths.inc.php.dist galette/config/local_paths.inc.php
```

