### PR TITLE
No longer translate routes

### DIFF
--- a/galette/includes/i18n.inc.php
+++ b/galette/includes/i18n.inc.php
@@ -277,8 +277,12 @@ function _T($string, $domain = 'galette', $nt = true)
 {
     global $language, $installer, $translator;
 
-    if ($domain == 'routes') {
-        $nt = false;
+    if (strpos($domain, 'route') !== false) {
+        Analog::log(
+            'Routes are no longer translated, return string.',
+            Analog::DEBUG
+        );
+        return $string;
     }
 
     if ($translator->translationExists($string, $domain)) {

--- a/galette/includes/main.inc.php
+++ b/galette/includes/main.inc.php
@@ -444,19 +444,20 @@ $app->add(function ($request, $response, $next) use ($i18n) {
 
     if (isset($get['pref_lang'])) {
         $route = $request->getAttribute('route');
-        $uri = $request->getUri();
 
         $route_name = $route->getName();
         $arguments = $route->getArguments();
 
         $this->i18n->changeLanguage($get['pref_lang']);
         $this->session->i18n = $this->i18n;
-        $this->session->changelang_route = [
-            'name'      => $route_name,
-            'arguments' => $arguments
-        ];
 
-        return $response->withRedirect($this->router->pathFor('changeLanguage'), 301);
+        return $response->withRedirect(
+            $this->router->pathFor(
+                $route_name,
+                $arguments
+            ),
+            301
+        );
     }
     return $next($request, $response);
 });

--- a/galette/includes/routes/main.routes.php
+++ b/galette/includes/routes/main.routes.php
@@ -188,19 +188,3 @@ $app->get(
             ->withHeader('Location', $this->router->pathFor('slash'));
     }
 )->setName('unimpersonate')->add($authenticate);
-
-$app->get(
-    '/change-language',
-    function ($request, $response) {
-        $route = $this->session->changelang_route;
-        $this->session->changelang_route = null;
-
-        return $response->withRedirect(
-            $this->router->pathFor(
-                $route['name'],
-                $route['arguments']
-            ),
-            301
-        );
-    }
-)->setName('changeLanguage');


### PR DESCRIPTION
Translations domains that contains "route" are no longer translated,
so this should work for both plugins and core.

Closes #1223