### PR TITLE
Rework extensions and PHP version checks; closes #1225

### DIFF
--- a/galette/config/versions.inc.php
+++ b/galette/config/versions.inc.php
@@ -35,6 +35,7 @@
  * @link      http://galette.tuxfamily.org
  * @since     Available since 0.7dev - 2009-03-13
  */
+define('GALETTE_PHP_MIN', '7.1');
 define('SMARTY_VERSION', '3.1.21');
 define('ZEND_VERSION', '2.3.7');
 define('ANALOG_VERSION', '1.0.7');

--- a/galette/includes/galette.inc.php
+++ b/galette/includes/galette.inc.php
@@ -35,9 +35,13 @@
  * @since     Available since 0.7-dev - 2007-10-07
  */
 
-if (!defined('GALETTE_PHP_MIN')) {
-    define('GALETTE_PHP_MIN', '7.1');
+//define galette's root directory
+if (!defined('GALETTE_ROOT')) {
+    define('GALETTE_ROOT', __DIR__ . '/../');
 }
+
+require_once GALETTE_ROOT . 'config/versions.inc.php';
+require_once GALETTE_ROOT . 'config/paths.inc.php';
 
 // check required PHP version...
 if (version_compare(PHP_VERSION, GALETTE_PHP_MIN, '<')) {
@@ -50,18 +54,10 @@ if (version_compare(PHP_VERSION, GALETTE_PHP_MIN, '<')) {
 $time_start = microtime(true);
 $cron = (PHP_SAPI === 'cli');
 
-//define galette's root directory
-if (!defined('GALETTE_ROOT')) {
-    define('GALETTE_ROOT', __DIR__ . '/../');
-}
-
 // define relative base path templating can use
 if (!defined('GALETTE_BASE_PATH')) {
     define('GALETTE_BASE_PATH', './');
 }
-
-require_once GALETTE_ROOT . 'config/versions.inc.php';
-require_once GALETTE_ROOT . 'config/paths.inc.php';
 
 //we'll only include relevant parts if we work from installer
 if (!isset($installer)) {

--- a/galette/lib/Galette/Core/SysInfos.php
+++ b/galette/lib/Galette/Core/SysInfos.php
@@ -95,11 +95,6 @@ class SysInfos
             $str .= '    ' . stripslashes($g) . "\n";
         }
 
-        $str .= '  May:' . "\n";
-        foreach ($mods->getMays() as $m) {
-            $str .= '    ' . stripslashes($m) . "\n";
-        }
-
         $str .= '  Should:' . "\n";
         foreach ($mods->getShoulds() as $s) {
             $str .= '    ' . stripslashes($s) . "\n";

--- a/galette/webroot/compat_test.php
+++ b/galette/webroot/compat_test.php
@@ -35,6 +35,7 @@
  * @since     Available since 0.7.4dev - 2013-02-03
  */
 
+
 $modules = array();
 $modules['SimpleXML'] = (extension_loaded('SimpleXML')) ? 'Ok' : 'Missing';
 $modules['gd'] = (extension_loaded('gd')) ? 'Ok' : 'Missing';
@@ -44,7 +45,17 @@ $modules['mbstring'] = (extension_loaded('mbstring')) ? 'Ok' : 'Missing';
 $modules['fileinfo'] = (extension_loaded('fileinfo')) ? 'Ok' : 'Missing';
 $modules['intl'] = (extension_loaded('intl')) ? 'Ok' : 'Missing';
 
-$phpok = !version_compare(PHP_VERSION, '7.1', '<');
+
+// check PHP modules
+define('GALETTE_ROOT', __DIR__ . '/../');
+define('GALETTE_THEME_DIR', './themes/default/');
+require_once GALETTE_ROOT . '/vendor/autoload.php';
+require_once GALETTE_ROOT . 'config/versions.inc.php';
+require_once GALETTE_ROOT . 'config/paths.inc.php';
+
+$phpok = !version_compare(PHP_VERSION, GALETTE_PHP_MIN, '<');
+$cm = new Galette\Core\CheckModules(false);
+$cm->doCheck(false); //do not load with translations!
 ?>
 <html>
     <head>
@@ -68,7 +79,12 @@ $phpok = !version_compare(PHP_VERSION, '7.1', '<');
                 margin: 0;
                 padding: 0;
             }
-            span.Missing, span.Ok {
+            li {
+                clear: right;
+                border-bottom: .1em dotted;
+                padding: .2em 0;
+            }
+            li img, span.Missing, span.Ok {
                 font-weight: bold;
                 float: right;
             }
@@ -79,33 +95,38 @@ $phpok = !version_compare(PHP_VERSION, '7.1', '<');
                 color: green;
             }
         </style>
+        <link rel="shortcut icon" href="./themes/default/images/favicon.png" />
     </head>
     <body>
         <h1>
             <img src="themes/default/images/galette.png"/>
             <br/>Compatibility tests
         </h1>
-<?php
-if (!$phpok
-    || in_array('Missing', $modules)
-) {
-            echo '<h2 class="Missing">Something is wrong :(</h2>';
-} else {
-            echo '<h2 class="Ok">Everything is OK :)</h2>';
-}
-?>
+    <?php
+    if (!$phpok
+        || in_array('Missing', $modules)
+    ) {
+                echo '<h2 class="Missing">Something is wrong :(</h2>';
+    } else {
+                echo '<h2 class="Ok">Everything is OK :)</h2>';
+    }
+    ?>
         <div>
             <ul>
-                <li>PHP version: <span class="<?php echo ($phpok) ? 'Ok' : 'Missing'; ?>"><?php echo PHP_VERSION; ?></span></li>
-<?php
-foreach ($modules as $mod => $present) {
-    ?>
+                <li>
+                    PHP version:
+                    <span class="<?php echo ($phpok) ? 'Ok' : 'Missing'; ?>"><?php echo PHP_VERSION; ?></span>
+                </li>
+    <?php
+    echo $cm->toHtml(false);
+    /*foreach ($modules as $mod => $present) {
+        ?>
                 <li>
                     <?php echo $mod . ': <span class="' . $present . '">' . $present . '</span>'; ?>
                 </li>
-    <?php
-}
-?>
+        <?php
+    }*/
+    ?>
             </ul>
         </div>
     </body>

--- a/galette/webroot/index.php
+++ b/galette/webroot/index.php
@@ -40,5 +40,19 @@ if (!defined('GALETTE_BASE_PATH')) {
     define('GALETTE_BASE_PATH', '../');
 }
 
+define('GALETTE_ROOT', __DIR__ . '/../');
+
+// check PHP modules
+require_once GALETTE_ROOT . '/vendor/autoload.php';
+require_once GALETTE_ROOT . 'config/versions.inc.php';
+
+$cm = new Galette\Core\CheckModules(false);
+$cm->doCheck(false); //do not load with translations!
+
+if (version_compare(PHP_VERSION, GALETTE_PHP_MIN, '<') || !$cm->isValid()) {
+    header('location: compat_test.php');
+    die(1);
+}
+
 /** @ignore */
 require_once __DIR__ . '/../includes/main.inc.php';

--- a/galette/webroot/installer.php
+++ b/galette/webroot/installer.php
@@ -48,10 +48,7 @@ define('GALETTE_ROOT', __DIR__ . '/../');
 require_once GALETTE_ROOT . '/vendor/autoload.php';
 require_once GALETTE_ROOT . 'config/versions.inc.php';
 
-$cm = new Galette\Core\CheckModules(false);
-$cm->doCheck(false); //do not load with translations!
-
-if (version_compare(PHP_VERSION, GALETTE_PHP_MIN, '<') || !$cm->isValid()) {
+if (version_compare(PHP_VERSION, GALETTE_PHP_MIN, '<') || !extension_loaded('intl')) {
     header('location: compat_test.php');
     die(1);
 }

--- a/galette/webroot/installer.php
+++ b/galette/webroot/installer.php
@@ -42,6 +42,20 @@ use Analog\Analog;
 //set a flag saying we work from installer
 //that way, in galette.inc.php, we'll only include relevant parts
 $installer = true;
+define('GALETTE_ROOT', __DIR__ . '/../');
+
+// check PHP modules
+require_once GALETTE_ROOT . '/vendor/autoload.php';
+require_once GALETTE_ROOT . 'config/versions.inc.php';
+
+$cm = new Galette\Core\CheckModules(false);
+$cm->doCheck(false); //do not load with translations!
+
+if (version_compare(PHP_VERSION, GALETTE_PHP_MIN, '<') || !$cm->isValid()) {
+    header('location: compat_test.php');
+    die(1);
+}
+
 //specific logfile for installer
 $logfile = 'galette_install';
 define('GALETTE_BASE_PATH', '../');

--- a/tests/Galette/Core/tests/units/CheckModules.php
+++ b/tests/Galette/Core/tests/units/CheckModules.php
@@ -68,9 +68,7 @@ class CheckModules extends atoum
         $this->array($checks->getMissings())
             ->isEmpty();
         $this->array($checks->getShoulds())
-            ->isEmpty();
-        $this->integer(count($checks->getMays()))
-            ->isLessThanOrEqualTo(2);
+            ->isEmpty(2);
         $this->boolean($checks->isGood('mbstring'))
             ->isTrue();
     }
@@ -90,12 +88,10 @@ class CheckModules extends atoum
                     ->then
                         ->array($checks->getGoods())
                             ->hasSize(0)
-                        ->array($checks->getMays())
-                            ->hasSize(2)
                         ->array($checks->getShoulds())
-                            ->hasSize(2)
+                            ->hasSize(4)
                         ->array($checks->getMissings())
-                            ->hasSize(6)
+                            ->hasSize(5)
                         ->string($checks->toHtml())
                             ->notContains('icon-valid.png')
                             ->hasLength(922);

--- a/tests/Galette/Core/tests/units/CheckModules.php
+++ b/tests/Galette/Core/tests/units/CheckModules.php
@@ -94,7 +94,7 @@ class CheckModules extends atoum
                             ->hasSize(5)
                         ->string($checks->toHtml())
                             ->notContains('icon-valid.png')
-                            ->hasLength(922);
+                            ->hasLength(1027);
     }
 
     /**


### PR DESCRIPTION
Checks are done from main entry point, each time:
If some extension is removed, it will be caught.

User is redirected to compat page that is displayed
without any translations (because translations requires
intl module).