### PR TITLE
Modifications pour permettre une recherche sur plusieurs groupes. souhait #907 (https://bugs.galette.eu/issues/907)

### DIFF
--- a/galette/includes/routes/members.routes.php
+++ b/galette/includes/routes/members.routes.php
@@ -492,6 +492,23 @@ $app->post(
                             }
                             $freed = true;
                         }
+/** modification for multiple groups search*/
+                    }  else if ( strpos($k, 'groups_', 0) === 0 ) {
+                        if ( !$grouped ) {
+                              $i = 0; $filters->groups_search_log_op = (int)$post['groups_logical_operator'];
+                              foreach ( $post['groups_search'] as $g ) {
+                                if ( trim($g) !== '') {
+                                  $gs = array(      
+                                  'idx'       => $i,
+                                  'group'     => $g
+                                  );
+                                $filters->groups_search = $gs;
+                                }
+                                $i++;
+                              }
+                              $grouped = true;
+                        }
+/** end of modification for multiple group search */
                     } else {
                         switch ($k) {
                             case 'filter_field':

--- a/galette/templates/default/advanced_search.tpl
+++ b/galette/templates/default/advanced_search.tpl
@@ -25,6 +25,7 @@
                             {html_options options=$filter_accounts_options selected=$filters->account_status_filter}
                         </select>
                     </p>
+{** modification for multiple groups search : no needs for a single group search
                     <p>
                         <label class="bline" for="group_filter">{_T string="Member of group"}</label>
                         <select name="group_filter">
@@ -33,6 +34,7 @@
                             <option value="{$group->getId()}"{if $filters->group_filter eq $group->getId()} selected="selected"{/if}>{$group->getName()}</option>
 {/foreach}
                         </select>
+*}
                     <p>
                         <span class="bline">{_T string="With mail:"}</span>
                         <input type="radio" name="email_filter" id="filter_dc_email" value="{Galette\Repository\Members::FILTER_DC_EMAIL}"{if $filters->email_filter eq constant('Galette\Repository\Members::FILTER_DC_EMAIL')} checked="checked"{/if}>
@@ -44,6 +46,44 @@
                     </p>
                 </div>
             </fieldset>
+{** modification for multiple groups search *}
+            <fieldset class="cssform large">
+                <legend class="ui-state-active ui-corner-top">{_T string="Groups search"}
+                    <a
+                        href="#"
+                        id="addbutton_g"
+                        class="tab-button tooltip"
+                    >
+                        <i class="fas fa-plus-square"></i>
+                        <span class="sr-only">{_T string="Add new group search criteria"}</span>
+                    </a>
+                </legend>
+                <select name="groups_logical_operator" class="operator_selector nochosen">
+                  <option value="{Galette\Filters\AdvancedMembersList::OP_AND}"{if $filters->groups_search_log_op eq constant('Galette\Filters\AdvancedMembersList::OP_AND')} selected="selected"{/if}>{_T string="Dans TOUS ces groupes"}</option>
+                  <option value="{Galette\Filters\AdvancedMembersList::OP_OR}"{if $filters->groups_search_log_op eq constant('Galette\Filters\AdvancedMembersList::OP_OR')} selected="selected"{/if}>{_T string="Dans au moins un de ces groupes"}</option>
+                </select>
+                <ul id="gs_sortable" class="fields_list connectedSortable">
+                {foreach from=$filters->groups_search item=gs}
+                         <li>
+                                <select name="groups_search[]" class="nochosen">
+                                        <option value="">{_T string="Select a group"}</option>
+                                        {foreach from=$filter_groups_options item=group}
+                                        <option value="{$group->getId()}"{if $gs.group eq $group->getId()} selected="selected"{/if}>{$group->getName()}</option>
+                                        {/foreach}
+                                </select>
+                        <a
+                            href="#"
+                            class="fright tooltip delete delcriteria"
+                        >
+                            <i class="fas fa-trash-alt"></i>
+                            <span class="sr-only">{_T string="Remove criteria"}</span>
+                        </a>
+                        </li>
+                 {/foreach}
+                 </ul>
+
+            </fieldset>	
+{** end multiple groups search *}
             <fieldset class="cssform large">
                 <legend class="ui-state-active ui-corner-top">{_T string="Advanced search"}</legend>
                 <div>
@@ -381,6 +421,18 @@
                     _fieldsInSortable();
                     return false;
                 });
+
+{** modification for multiple groups search *}
+               $('#addbutton_g').click(function(){
+                    var _ul = $('#gs_sortable');
+                    var _new = _ul.find('li').last().clone(true);
+                    _newFilter(_new);
+                    _rmFilter(_new);
+                    _ul.append(_new);
+                    _fieldsInSortable();
+                    return false;
+                });
+{** end of modification for multiple groups search *}
 
                 $('.field_selector').change(function () {
                     var _field_id = $(this).val();


### PR DESCRIPTION
templates/default/advanced_search.tpl : suppression de la recherche par groupe simple et ajoût d'un fieldset (inspiré de la recherche libre) pour choisir un opérateur ("et" ou "ou") et un ou des groupes à recherher.
lib/Galette/Filters/AdvancedMembersList.php : déclarations et gestion des variables retournées par le formulair, inspirées de la recherche libre
lib/Galette/Repository/Members.php : la mécanique pour construire la portion de requête SQL correspondante. La bdd est utilisée pendant la phase de construction
includes/routes/members.routes.php : extraction des informations correspondantes du POST

Les principaux commentaires sur la méthode sont dans Members.php
Voir aussi le souhait #907 (https://bugs.galette.eu/issues/907)