### PR TITLE
Make address_continuation work in PDF forms

### DIFF
--- a/galette/lib/Galette/IO/PdfAdhesionForm.php
+++ b/galette/lib/Galette/IO/PdfAdhesionForm.php
@@ -124,7 +124,7 @@ class PdfAdhesionForm
         if ($adh !== null) {
             $address = $adh->address;
             if ($adh->address_continuation != '') {
-                $address .= '<br/>' . $adh->adress_continuation;
+                $address .= '<br/>' . $adh->address_continuation;
             }
 
             if ($adh->isMan()) {


### PR DESCRIPTION
Juste un petit bug qui empêche la 2ème ligne de l'adresse de s'afficher dans les formulaires PDF...