### PR TITLE
typo

### DIFF
--- a/galette/lang/galette_fr_FR.utf8.po
+++ b/galette/lang/galette_fr_FR.utf8.po
@@ -2019,7 +2019,7 @@ msgstr "En retard de %days jours (depuis le %date)"
 
 #: ../lib/Galette/Entity/Adherent.php:802
 msgid "No longer member"
-msgstr "N'est plus adéhrent"
+msgstr "N'est plus adhérent"
 
 #: ../lib/Galette/Entity/Adherent.php:814
 #, php-format


### PR DESCRIPTION
Hi ! 


There is a typographical error line 2022 : 

* should be "N'est plus adhérent" 
* instead of "N'est plus adéhrent"


Thanks ! 