### PR TITLE
For now, ensure jquery is loaded first

### DIFF
--- a/galette/templates/default/elements/header.html.twig
+++ b/galette/templates/default/elements/header.html.twig
@@ -16,6 +16,7 @@
         <link rel="stylesheet" type="text/css" href="{{ base_url() }}/{{ constant('GALETTE_THEME') }}galette_print_local.css" media="print" />
     {% endif %}
         <link rel="shortcut icon" href="{{ base_url() }}/{{ constant('GALETTE_THEME') }}images/favicon.png" />
+        <script type="text/javascript" src="{{ base_url() }}/assets/js/galette-main.bundle.min.js"></script>
 
 {# If some additional headers should be added from plugins, we load the relevant template file
    We have to use a template file, so Twig will do its work (like replacing variables). #}

--- a/galette/templates/default/elements/scripts.html.twig
+++ b/galette/templates/default/elements/scripts.html.twig
@@ -1,4 +1,3 @@
-        <script type="text/javascript" src="{{ base_url() }}/assets/js/galette-main.bundle.min.js"></script>
         <script type="text/javascript" src="{{ base_url() }}/{{ constant('GALETTE_THEME') }}ui/semantic.min.js"></script>
         <script type="text/javascript">
             function csrfSafeMethod(method) {


### PR DESCRIPTION
There are some script inline that uses `$(function() {});` this fails with `Uncaught ReferenceError: $ is not defined` if jQuery is not loaded first.

I guess a better solution would be to properly handle those inline script and add them all at the end, but this is a quite huge work on core and on plugins for now.