### PR TITLE
Add aliases for main menu selection

### DIFF
--- a/galette/lib/Galette/Core/Galette.php
+++ b/galette/lib/Galette/Core/Galette.php
@@ -178,23 +178,21 @@ class Galette
                         'title' => _T("View, search into and filter member's list"),
                         'route' => [
                             'name' => 'members',
-                            'args' => []
+                            'aliases' => ['editMember']
                         ]
                     ],
                     [
                         'label' => _T("Advanced search"),
                         'title' => _T("Perform advanced search into members list"),
                         'route' => [
-                            'name' => 'advanced-search',
-                            'args' => []
+                            'name' => 'advanced-search'
                         ]
                     ],
                     [
                         'label' => _T("Saved searches"),
                         'title' => _T("Saved searches"),
                         'route' => [
-                            'name' => 'searches',
-                            'args' => []
+                            'name' => 'searches'
                         ]
                     ]
                 ];
@@ -224,7 +222,8 @@ class Galette
                             'title' => _T("View and filter contributions"),
                             'route' => [
                                 'name' => 'contributions',
-                                'args' => ['type' => 'contributions']
+                                'args' => ['type' => 'contributions'],
+                                'aliases' => ['editContribution']
                             ]
                         ],
                         [
@@ -232,7 +231,8 @@ class Galette
                             'title' => _T("View and filter transactions"),
                             'route' => [
                                 'name' => 'contributions',
-                                'args' => ['type' => 'transactions']
+                                'args' => ['type' => 'transactions'],
+                                'aliases' => ['editTransaction']
                             ]
                         ],
                         [
@@ -297,8 +297,7 @@ class Galette
                             'label' => _T("Manage mailings"),
                             'title' => _T("Manage mailings that has been sent"),
                             'route' => [
-                                'name' => 'mailings',
-                                'aliases' => ['mailing']
+                                'name' => 'mailings'
                             ]
                         ],
                         [
@@ -312,7 +311,8 @@ class Galette
                             'label' => _T("Imports"),
                             'title' => _T("Import members from CSV files"),
                             'route' => [
-                                'name' => 'import'
+                                'name' => 'import',
+                                'aliases' => ['importModel']
                             ]
                         ],
                         [
@@ -364,7 +364,7 @@ class Galette
                                 'title' => _T("Manage additional fields for various forms"),
                                 'route' => [
                                     'name' => 'configureDynamicFields',
-                                    'alias' => 'editDynamicField'
+                                    'aliases' => ['editDynamicField'],
                                 ]
                             ],
                             [
@@ -379,7 +379,9 @@ class Galette
                                 'title' => _T("Manage statuses"),
                                 'route' => [
                                     'name' => 'entitleds',
-                                    'args' => ['class' => 'status']
+                                    'args' => ['class' => 'status'],
+                                    'aliases' => ['editEntitled'],
+                                    'sub_select' => false
                                 ]
                             ],
                             [
@@ -401,7 +403,8 @@ class Galette
                                 'label' => _T("Titles"),
                                 'title' => _T("Manage titles"),
                                 'route' => [
-                                    'name' => 'titles'
+                                    'name' => 'titles',
+                                    'aliases' => ['editTitle']
                                 ]
                             ],
                             [
@@ -415,7 +418,8 @@ class Galette
                                 'label' => _T("Payment types"),
                                 'title' => _T("Manage payment types"),
                                 'route' => [
-                                    'name' => 'paymentTypes'
+                                    'name' => 'paymentTypes',
+                                    'aliases' => ['editPaymentType']
                                 ]
                             ],
                             [

--- a/galette/lib/Galette/Core/Galette.php
+++ b/galette/lib/Galette/Core/Galette.php
@@ -240,7 +240,7 @@ class Galette
                             'title' => _T("Add new membership fee in database"),
                             'route' => [
                                 'name' => 'addContribution',
-                                'args' => ['type' => 'fee']
+                                'args' => ['type' => \Galette\Entity\Contribution::TYPE_FEE]
                             ]
                         ],
                         [
@@ -248,7 +248,7 @@ class Galette
                             'title' => _T("Add new donation in database"),
                             'route' => [
                                 'name' => 'addContribution',
-                                'args' => ['type' => 'donation']
+                                'args' => ['type' => \Galette\Entity\Contribution::TYPE_DONATION]
                             ]
                         ],
                         [

--- a/galette/templates/default/macros.twig
+++ b/galette/templates/default/macros.twig
@@ -1,7 +1,7 @@
 {% macro renderMenu(title, icon, items) %}
     {% set my_routes = [] %}
     {% for item in items %}
-        {% set my_routes = my_routes|merge([item.route.name]) %}
+        {% set my_routes = my_routes|merge([item.route.name])|merge(item.route.aliases ?? []) %}
     {% endfor %}
     <div class="item">
         <div class="image header title{% if cur_route in my_routes %} active{% endif %}">
@@ -19,7 +19,7 @@
 
 {% macro renderMenuItem(label, title, route, icon, class, tips_position) %}
     {% if class is empty %}
-        {% if is_current_path(route.name, route.args|default([])) %}
+        {% if is_current_path(route.name, route.args|default([])) or (cur_route in route.aliases ?? [] and route.sub_select ?? true == true) %}
             {% set class = "active item" %}
         {% else %}
             {% set class = "item" %}

--- a/galette/templates/default/pages/contributions_list.html.twig
+++ b/galette/templates/default/pages/contributions_list.html.twig
@@ -145,6 +145,26 @@
     {{ parent() }}
 {% endblock %}
 
+{% block infoline_actions %}
+    {% if login.isAdmin() or login.isStaff() %}
+        <a
+            class="button"
+            href="{{ path_for("addContribution", {type: constant('Galette\\Entity\\Contribution::TYPE_FEE')}) }}"
+        >
+            <i class="ui cookie circle icon" aria-hidden="true"></i>
+            {{ _T("Add a membership fee") }}
+        </a>
+        <a
+            class="button"
+            href="{{ path_for("addContribution", {type: constant('Galette\\Entity\\Contribution::TYPE_DONATION')}) }}"
+        >
+            <i class="ui gift circle icon" aria-hidden="true"></i>
+            {{ _T("Add a donation") }}
+        </a>
+
+    {% endif %}
+{% endblock %}
+
 {% block header %}
     {% set columns = [
         {'label': '#', 'order': constant("Galette\\Filters\\ContributionsList::ORDERBY_ID")},

--- a/galette/templates/default/pages/members_list.html.twig
+++ b/galette/templates/default/pages/members_list.html.twig
@@ -32,6 +32,18 @@
     {{ parent() }}
 {% endblock %}
 
+{% block infoline_actions %}
+    {% if login.isAdmin() or login.isStaff() or (login.isGroupManager() and preferences.pref_bool_groupsmanagers_create_member) %}
+        <a
+                class="button"
+                href="{{ path_for("addMember") }}"
+        >
+            <i class="ui plus circle icon" aria-hidden="true"></i>
+            {{ _T("Add a member") }}
+        </a>
+    {% endif %}
+{% endblock %}
+
 {% block header %}
     {% set columns = [] %}
     {% for column in galette_list %}

--- a/galette/templates/default/pages/transactions_list.html.twig
+++ b/galette/templates/default/pages/transactions_list.html.twig
@@ -93,6 +93,18 @@
     {{ parent() }}
 {% endblock %}
 
+{% block infoline_actions %}
+    {% if login.isAdmin() or login.isStaff() %}
+        <a
+                class="button"
+                href="{{ path_for("addTransaction") }}"
+        >
+            <i class="ui plus circle icon" aria-hidden="true"></i>
+            {{ _T("Add a transaction") }}
+        </a>
+    {% endif %}
+{% endblock %}
+
 {% block header %}
     {% set columns = [
         {'label': '#', 'order': constant("Galette\\Filters\\TransactionsList::ORDERBY_ID")},


### PR DESCRIPTION
The goal is to open the main menu correct entry, and to select (or not) the corresponding entry. With current menu, when editing a member, a contribution, a title, any of entitleds, etc. the main menu is completely closed, and no entry is selected.

The new parameter `aliases` sets up aliases that will always open the corresponding main menu.
The new parameter `sub_select` will prevent menu item to be selected in some cases.