### PR TITLE
Few fixes on groups permissions

### DIFF
--- a/galette/lib/Galette/Controllers/Crud/GroupsController.php
+++ b/galette/lib/Galette/Controllers/Crud/GroupsController.php
@@ -213,6 +213,9 @@ class GroupsController extends CrudController
         $post = $request->getParsedBody();
         $id = $post['id_group'];
         $group = new Group((int)$id);
+        if (!$group->canEdit($this->login)) {
+            throw new \RuntimeException('Trying to edit group without appropriate permissions');
+        }
 
         $groups = new Groups($this->zdb, $this->login);
 
@@ -337,6 +340,9 @@ class GroupsController extends CrudController
     {
         $post = $request->getParsedBody();
         $group = new Group($id);
+        if (!$group->canEdit($this->login)) {
+            throw new \RuntimeException('Trying to edit group without appropriate permissions');
+        }
 
         $group->setName($post['group_name']);
         try {

--- a/galette/lib/Galette/Entity/Group.php
+++ b/galette/lib/Galette/Entity/Group.php
@@ -904,4 +904,28 @@ class Group
         $this->login = $login;
         return $this;
     }
+
+    /**
+     * Can current logged-in user edit group
+     *
+     * @param Login $login Login instance
+     *
+     * @return boolean
+     */
+    public function canEdit(Login $login): bool
+    {
+        global $preferences;
+
+        //admin and staff users can edit
+        if ($login->isAdmin() || $login->isStaff()) {
+            return true;
+        }
+
+        //group managers can edit groups they manage when pref is on
+        if ($preferences->pref_bool_groupsmanagers_edit_member && $this->isManager($login)) {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/galette/templates/default/elements/group.html.twig
+++ b/galette/templates/default/elements/group.html.twig
@@ -1,4 +1,4 @@
-{% set can_edit = login.isGroupManager() and preferences.pref_bool_groupsmanagers_edit_groups or login.isAdmin() or login.isStaff() %}
+{% set can_edit = group.canEdit(login) %}
 
 {% set managers = group.getManagers() %}
 {% set members = group.getMembers() %}


### PR DESCRIPTION
closes #1647

Add canEdit method on groups
Server-side permission check for group editions
Group detail display only for managers
Group template uses canEdit method