### PR TITLE
Prevent the use of base64 images; fixes #1659

### DIFF
--- a/galette/templates/default/elements/scripts.html.twig
+++ b/galette/templates/default/elements/scripts.html.twig
@@ -91,7 +91,13 @@
                     ],
                     styleTags: [
                         'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'
-                    ]
+                    ],
+                    callbacks: {
+                        onImageUpload: function (data) {
+                            //prevent image copypaste
+                            data.pop();
+                        }
+                    }
                 });
                 $('#mailing_corps').summernote('focus');
             }

--- a/galette/templates/default/elements/scripts.html.twig
+++ b/galette/templates/default/elements/scripts.html.twig
@@ -80,6 +80,7 @@
 
                 $('#mailing_corps').summernote({
                     lang: '{{ i18n.getID()|replace({'_': '-'}) }}',
+                    disableDragAndDrop: true,
                     height: 240,
                     toolbar: [
                         ['style', ['style']],
@@ -105,6 +106,8 @@
                 $('#summernote_toggler').html('<a class="ui blue tertiary button" href="javascript:deactivateMailingEditor(\'mailing_corps\');" id="deactivate_editor">{{ _T("Deactivate HTML editor") }}</a>');
 
                 $('#mailing_corps').summernote({
+                    lang: '{{ i18n.getID()|replace({'_': '-'}) }}',
+                    disableDragAndDrop: true,
                     height: 240,
                     toolbar: [
                         ['style', ['style']],

--- a/galette/templates/default/elements/scripts.html.twig
+++ b/galette/templates/default/elements/scripts.html.twig
@@ -69,14 +69,14 @@
         <script type="text/javascript" src="{{ base_url() }}/assets/js/summernote.min.js"></script>
         <script type="text/javascript" src="{{ base_url() }}/assets/js/lang/summernote-{{ i18n.getID()|replace({'_': '-'}) }}.min.js"></script>
         <script language="javascript">
-            function activateMailingEditor(id) {
+            function activateMailingEditor() {
                 if(!$('#mailing_html').attr('checked')){
                     $('#mailing_html').attr('checked', true);
                 }
 
                 $('input#html_editor_active').attr('value', '1');
                 $('#activate_editor').remove();
-                $('#summernote_toggler').html('<a class="ui blue tertiary button" href="javascript:deactivateMailingEditor(\'mailing_corps\');" id="deactivate_editor">{{ _T("Deactivate HTML editor") }}</a>');
+                $('#summernote_toggler').html('<a class="ui blue tertiary button" href="javascript:deactivateMailingEditor();" id="deactivate_editor">{{ _T("Deactivate HTML editor") }}</a>');
 
                 $('#mailing_corps').summernote({
                     lang: '{{ i18n.getID()|replace({'_': '-'}) }}',
@@ -101,32 +101,14 @@
                 });
                 $('#mailing_corps').summernote('focus');
             }
-            function deactivateMailingEditor(id) {
+            function deactivateMailingEditor() {
                 $('#mailing_corps').summernote('destroy');
                 $('#deactivate_editor').remove();
-                $('#summernote_toggler').html('<a class="ui blue tertiary button" href="javascript:activateMailingEditor(\'mailing_corps\');" id="activate_editor">{{ _T("Activate HTML editor") }}</a>');
+                $('#summernote_toggler').html('<a class="ui blue tertiary button" href="javascript:activateMailingEditor();" id="activate_editor">{{ _T("Activate HTML editor") }}</a>');
             }
         {% if html_editor_active == 1 %}
             $(function(){
-                $('#activate_editor').remove();
-                $('#summernote_toggler').html('<a class="ui blue tertiary button" href="javascript:deactivateMailingEditor(\'mailing_corps\');" id="deactivate_editor">{{ _T("Deactivate HTML editor") }}</a>');
-
-                $('#mailing_corps').summernote({
-                    lang: '{{ i18n.getID()|replace({'_': '-'}) }}',
-                    disableDragAndDrop: true,
-                    height: 240,
-                    toolbar: [
-                        ['style', ['style']],
-                        ['font', ['bold', 'italic', 'strikethrough', 'clear']],
-                        ['para', ['ul', 'ol', 'paragraph']],
-                        ['insert', ['link', 'picture']],
-                        ['view', ['codeview', 'help']]
-                    ],
-                    styleTags: [
-                        'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'
-                    ]
-                });
-                $('#mailing_corps').summernote('focus');
+                activateMailingEditor();
             });
         {% endif %}
         </script>

--- a/ui/semantic/galette/globals/site.overrides
+++ b/ui/semantic/galette/globals/site.overrides
@@ -239,21 +239,33 @@ footer .ui.horizontal.list > .item{
     Fix Summernote modal display
 ----------------------------------*/
 
-.note-modal-backdrop {
+.note-modal-backdrop,
+.note-modal .note-group-select-from-files {
   display: none !important;
 }
 .note-modal.open {
   background: rgba(0,0,0,0.5);
 }
-.note-modal-content {
+.note-modal .note-modal-content {
   position: fixed;
   top: 50%;
   left: 50%;
   transform: translateX(-50%) translateY(-50%);
+  margin: 30px 0;
+}
+:not(.selectize-input).required .note-editable {
+  font-weight: normal;
+}
+.note-modal .note-modal-footer {
+  height: 62px;
 }
 .note-modal .note-btn {
-  margin-bottom: 1rem;
   padding: 10px;
+}
+@media only screen and (min-width: 768px) {
+  .note-modal-content {
+    margin: 0;
+  }
 }
 
 /*-------------


### PR DESCRIPTION
There is no option in summernote editor to disable embeded images :(

So this PR only hides the corresponding field with CSS (some display issues were also fixed at the same time).

Drag and drop of images in the editor has been disabled too.
However, a known issue is preventing this option to work properly at the moment : https://github.com/summernote/summernote/issues/3944#issuecomment-1005459721

I also tried to disable pasting images in the editor without success. The recommended way to achieve this is to use a callback, but I didn't manage to make it work : https://github.com/summernote/summernote/issues/2132