### PR TITLE
Fix missing existing value on search input

### DIFF
--- a/galette/templates/default/components/forms/search.html.twig
+++ b/galette/templates/default/components/forms/search.html.twig
@@ -6,7 +6,6 @@
         disabled: entry.disabled,
         label: entry.label,
         autocomplete: "off",
-        value: null,
         search_id: entry.field_id ~ '_field',
         elt_class: 'prompt'
     }


### PR DESCRIPTION
Is there a reason why the value of the search input is set to `null` here ?

Otherwise, without throwing errors when adding a new member, removing this line easily fixes the missing "city" and "place of birth" that are missing when editing a member.