### PR TITLE
Feature/paginated search dropdown

### DIFF
--- a/galette/templates/default/elements/js/choose_adh.js.twig
+++ b/galette/templates/default/elements/js/choose_adh.js.twig
@@ -4,7 +4,6 @@
     var _adhselect = function() {
         $('{{ js_chosen_id }}').dropdown({
             match: 'text',
-            placeholder: '{{ _T("Search for name or ID and pick member") }}',
             apiSettings: {
                 url: '{{ url_for("contributionMembers", {"page": 1, "search": "{query}"}) }}',
                 method: 'post',
@@ -22,12 +21,36 @@
                         modal_classname: "redalert",
                     } %}
                 }
+            },
+            onShow: function() {
+                $('{{ js_chosen_id }} .chevron.circle.right.icon').on('click', function() {
+                    $.ajax({
+                        // TODO : get next page number.
+                        {% set next_page = 2 %}
+                        url: '{{ url_for("contributionMembers", {"page": next_page }) }}',
+                        method: 'post',
+                        {% include "elements/js/loader.js.twig" with {
+                            loader: "action",
+                            loader_text: "",
+                            selector: ".menu.visible"
+                        } %},
+                        success: function(res) {
+                            var _values = Object.values(res)[0];
+                            $('{{ js_chosen_id }}').dropdown('change values', _values);
+                        },
+                        error: function() {
+                            {% include "elements/js/modal.js.twig" with {
+                                modal_title_twig: _T("An error occurred :(")|e("js"),
+                                modal_without_content: true,
+                                modal_class: "mini",
+                                modal_deny_only: true,
+                                modal_cancel_text: _T("Close")|e("js"),
+                                modal_classname: "redalert",
+                            } %}
+                        }
+                    });
+                });
             }
-        });
-
-        $('#reset-contributor').on('click', function() {
-            $('{{ js_chosen_id }}').dropdown('restore defaults');
-            $('{{ js_chosen_id }}').dropdown('refresh');
         });
     }
 

--- a/galette/templates/default/elements/js/choose_adh.js.twig
+++ b/galette/templates/default/elements/js/choose_adh.js.twig
@@ -27,7 +27,7 @@
                     $.ajax({
                         // TODO : get next page number.
                         {% set next_page = 2 %}
-                        url: '{{ url_for("contributionMembers", {"page": next_page }) }}',
+                        url: '{{ url_for("contributionMembers", {"page": next_page}) }}',
                         method: 'post',
                         {% include "elements/js/loader.js.twig" with {
                             loader: "action",

--- a/galette/templates/default/elements/js/choose_adh.js.twig
+++ b/galette/templates/default/elements/js/choose_adh.js.twig
@@ -1,6 +1,132 @@
 {% if js_chosen_id is not defined %}
     {% set js_chosen_id = "#id_adh" %}
 {% endif %}
+    var _current_page = 1;
+
+    var _chosenPages = function() {
+            // Hide or enable pagination buttons.
+            {% if members.filters.pages is defined and members.filters.pages > 1 %}
+                $('.next-results').removeClass('disabled');
+                $('.next-results, .prev-results').removeClass('displaynone');
+            {% else %}
+                $('.next-results, .prev-results').addClass('displaynone');
+            {% endif %}
+
+            // Next results
+            $('{{ js_chosen_id }} .next-results').off().on('click', function() {
+                var _data = {
+                    page: _current_page + 1,
+                };
+                var _selected_value = $('{{ js_chosen_id }}').dropdown('get value');
+                var _selected_text = $('{{ js_chosen_id }}').dropdown('get text');
+                {% if members.filters.pages is defined %}
+                    var _pages = {{ members.filters.pages }};
+                {% endif %}
+
+                $.ajax({
+                    url: '{{ url_for("contributionMembers") }}',
+                    method: 'post',
+                    data: _data,
+                    {% include "elements/js/loader.js.twig" with {
+                        loader: "action",
+                        loader_text: "",
+                        selector: ".menu.visible",
+                        extra_beforesend: "$('.next-results').addClass('disabled');",
+                        extra_complete: "if (_pages > _current_page) {$('.next-results').removeClass('disabled');}"
+                    } %},
+                    success: function(res) {
+                        // Reload dropdown's items with new results.
+                        var _values = Object.values(res)[0];
+                        $('{{ js_chosen_id }}').dropdown('change values', _values);
+
+                        // Restore selected item.
+                        if (_selected_value != '') {
+                            $('{{ js_chosen_id }}').dropdown('set value', _selected_value);
+                            $('{{ js_chosen_id }}').dropdown('set text', _selected_text);
+                        }
+
+                        // New current page number.
+                        _current_page += 1;
+
+                        // Disable/Enable required pagination buttons.
+                        if (_pages == _current_page) {
+                            $('.next-results').addClass('disabled');
+                        }
+                        if (_current_page > 1) {
+                            $('.prev-results').removeClass('disabled');
+                        }
+                    },
+                    error: function() {
+                        {% include "elements/js/modal.js.twig" with {
+                            modal_title_twig: _T("An error occurred retrieving members :(")|e("js"),
+                            modal_without_content: true,
+                            modal_class: "mini",
+                            modal_deny_only: true,
+                            modal_cancel_text: _T("Close")|e("js"),
+                            modal_classname: "redalert",
+                        } %}
+                    }
+                });
+            });
+
+            // Previous results
+            $('{{ js_chosen_id }} .prev-results').off().on('click', function() {
+                var _data = {
+                    page: _current_page - 1,
+                };
+                var _selected_value = $('{{ js_chosen_id }}').dropdown('get value');
+                var _selected_text = $('{{ js_chosen_id }}').dropdown('get text');
+                {% if members.filters.pages is defined %}
+                    var _pages = {{ members.filters.pages }};
+                {% endif %}
+
+                $.ajax({
+                    url: '{{ url_for("contributionMembers") }}',
+                    method: 'post',
+                    data: _data,
+                    {% include "elements/js/loader.js.twig" with {
+                        loader: "action",
+                        loader_text: "",
+                        selector: ".menu.visible",
+                        extra_beforesend: "$('.prev-results').addClass('disabled');",
+                        extra_complete: "if (_current_page > 1) {$('.prev-results').removeClass('disabled');}"
+                    } %},
+                    success: function(res) {
+                        // Reload dropdown's items with new results.
+                        var _values = Object.values(res)[0];
+                        $('{{ js_chosen_id }}').dropdown('change values', _values);
+
+                        // Restore selected item.
+                        if (_selected_value != '') {
+                            $('{{ js_chosen_id }}').dropdown('set value', _selected_value);
+                            $('{{ js_chosen_id }}').dropdown('set text', _selected_text);
+                        }
+
+                        // New current page number.
+                        _current_page -= 1;
+
+                        // Disable/Enable required pagination buttons.
+                        if (_pages > _current_page) {
+                            $('.next-results').removeClass('disabled');
+                        }
+                        if (_current_page == 1) {
+                            $('.prev-results').addClass('disabled');
+                        }
+                    },
+                    error: function() {
+                        {% include "elements/js/modal.js.twig" with {
+                            modal_title_twig: _T("An error occurred retrieving members :(")|e("js"),
+                            modal_without_content: true,
+                            modal_class: "mini",
+                            modal_deny_only: true,
+                            modal_cancel_text: _T("Close")|e("js"),
+                            modal_classname: "redalert",
+                        } %}
+                    }
+                });
+            });
+    }
+
     var _adhselect = function() {
         $('{{ js_chosen_id }}').dropdown({
             match: 'text',
@@ -23,34 +149,16 @@
                 }
             },
             onShow: function() {
-                $('{{ js_chosen_id }} .chevron.circle.right.icon').on('click', function() {
-                    $.ajax({
-                        // TODO : get next page number.
-                        {% set next_page = 2 %}
-                        url: '{{ url_for("contributionMembers", {"page": next_page}) }}',
-                        method: 'post',
-                        {% include "elements/js/loader.js.twig" with {
-                            loader: "action",
-                            loader_text: "",
-                            selector: ".menu.visible"
-                        } %},
-                        success: function(res) {
-                            var _values = Object.values(res)[0];
-                            $('{{ js_chosen_id }}').dropdown('change values', _values);
-                        },
-                        error: function() {
-                            {% include "elements/js/modal.js.twig" with {
-                                modal_title_twig: _T("An error occurred :(")|e("js"),
-                                modal_without_content: true,
-                                modal_class: "mini",
-                                modal_deny_only: true,
-                                modal_cancel_text: _T("Close")|e("js"),
-                                modal_classname: "redalert",
-                            } %}
-                        }
-                    });
-                });
-            }
+                _chosenPages();
+            },
+            onChange: function() {
+                _chosenPages();
+            },
+            onHide: function() {
+                // Reset to defaults.
+                _current_page = 1;
+                $('.next-results, .prev-results').addClass('disabled');
+            },
         });
     }
 

--- a/galette/templates/default/elements/js/loader.js.twig
+++ b/galette/templates/default/elements/js/loader.js.twig
@@ -68,6 +68,10 @@
     $('{{ loader_parent }}').append(_loader);
 {% endif %}
 
+{% if extra_beforesend is defined %}
+        {{ extra_beforesend|raw }}
+{% endif %}
+
     },
     complete: function() {
 
@@ -79,6 +83,10 @@
     {% elseif (loader ends with 'loader') %}
         $('{{ loader_parent }} .loader').remove();
     {% endif %}
+{% endif %}
+
+{% if extra_complete is defined %}
+        {{ extra_complete|raw }}
 {% endif %}
 
     }

--- a/galette/templates/default/pages/contribution_form.html.twig
+++ b/galette/templates/default/pages/contribution_form.html.twig
@@ -28,7 +28,8 @@
                                 <div id="id_adh" class="jsonly search-dropdown ui input nochosen paginated">
                                     <input id="id_adh_input" type="text" name="id_adh" value="{{ contribution.member is not null ? contribution.member }}" placeholder="{{ _T("Member ID") }}">
                                     <i class="jsonly displaynone dropdown icon"></i>
-                                    <i class="jsonly displaynone chevron circle right icon tooltip" title="{{ _T("Next results") }}"></i>
+                                    <span class="ui mini compact icon disabled button prev-results"><i class="jsonly displaynone chevron circle left icon disabled button tooltip" title="{{ _T("Load previous members...") }}"></i></span>
+                                    <span class="ui mini compact icon disabled button next-results"><i class="jsonly displaynone chevron circle right icon disabled button tooltip" title="{{ _T("Load following members...") }}"></i></span>
                                     <div class="jsonly displaynone default text">{% if adh_selected == 0 %}{{ _T("Search for name or ID and pick member") }}{% endif %}</div>
                                 </div>
                             </div>

--- a/galette/templates/default/pages/contribution_form.html.twig
+++ b/galette/templates/default/pages/contribution_form.html.twig
@@ -31,6 +31,11 @@
                                     <span class="ui mini compact icon disabled button prev-results"><i class="jsonly displaynone chevron circle left icon disabled button tooltip" title="{{ _T("Load previous members...") }}"></i></span>
                                     <span class="ui mini compact icon disabled button next-results"><i class="jsonly displaynone chevron circle right icon disabled button tooltip" title="{{ _T("Load following members...") }}"></i></span>
                                     <div class="jsonly displaynone default text">{% if adh_selected == 0 %}{{ _T("Search for name or ID and pick member") }}{% endif %}</div>
+                                    <div class="jsonly displaynone menu">
+                            {% for k, v in members.list %}
+                                        <div class="item" data-value="{{ k }}">{{ v }}</div>
+                            {% endfor %}
+                                    </div>
                                 </div>
                             </div>
     {% endif %}

--- a/galette/templates/default/pages/contribution_form.html.twig
+++ b/galette/templates/default/pages/contribution_form.html.twig
@@ -25,17 +25,12 @@
     {% if not require_mass %}
                             <div class="inline field">
                                 <label for="id_adh">{{ _T("Contributor:") }}</label>
-                                <div id="id_adh" class="jsonly search-dropdown ui input nochosen">
+                                <div id="id_adh" class="jsonly search-dropdown ui input nochosen paginated">
                                     <input id="id_adh_input" type="text" name="id_adh" value="{{ contribution.member is not null ? contribution.member }}" placeholder="{{ _T("Member ID") }}">
                                     <i class="jsonly displaynone dropdown icon"></i>
+                                    <i class="jsonly displaynone chevron circle right icon tooltip" title="{{ _T("Next results") }}"></i>
                                     <div class="jsonly displaynone default text">{% if adh_selected == 0 %}{{ _T("Search for name or ID and pick member") }}{% endif %}</div>
-                                    <div class="jsonly displaynone menu">
-                            {% for k, v in members.list %}
-                                        <div class="item" data-value="{{ k }}">{{ v }}</div>
-                            {% endfor %}
-                                    </div>
                                 </div>
-                                <div class="tooltip jsonly displaynone ui tiny icon button" id="reset-contributor" title="{{ _T("Reset") }}"><i class="redo icon"></i><span class="displaynone">{{ _T("Reset") }}</span></div>
                             </div>
     {% endif %}
                             <div class="inline field">

--- a/galette/templates/default/pages/member_form.html.twig
+++ b/galette/templates/default/pages/member_form.html.twig
@@ -62,17 +62,12 @@
                         <label for="attach"><i class="linkify icon"></i> {{ _T("Attach member") }}</label>
                     </div>
                     <span id="parent_id_elt" class="">
-                        <div id="parent_id" class="jsonly search-dropdown ui input nochosen">
+                        <div id="parent_id" class="jsonly search-dropdown ui input nochosen paginated">
                             <input id="parent_id_input" type="text" name="parent_id" value="{{ member.isDuplicate() and member.parent is defined and member.parent is not null ? member.parent.id }}" placeholder="{{ _T("Member ID") }}">
                             <i class="jsonly displaynone dropdown icon"></i>
+                            <i class="jsonly displaynone chevron circle right icon tooltip" title="{{ _T("Next results") }}"></i>
                             <div class="jsonly displaynone default text">{{ _T("Search for name or ID and pick member") }}</div>
-                            <div class="jsonly displaynone menu">
-            {% for k, v in members.list %}
-                                <div class="item" data-value="{{ k }}">{{ v }}</div>
-            {% endfor %}
-                            </div>
                         </div>
-                        <div class="jsonly displaynone ui tiny icon button tooltip" id="reset-contributor" title="{{ _T("Reset") }}"><i class="redo icon"></i><span class="displaynone">{{ _T("Reset") }}</span></div>
                     </span>
             {% if member.isDuplicate() %}
                     <input type="hidden" name="duplicate" value="1" />

--- a/galette/templates/default/pages/member_form.html.twig
+++ b/galette/templates/default/pages/member_form.html.twig
@@ -68,6 +68,11 @@
                             <span class="ui mini compact icon disabled button prev-results"><i class="jsonly displaynone chevron circle left icon disabled button tooltip" title="{{ _T("Load previous members...") }}"></i></span>
                             <span class="ui mini compact icon disabled button next-results"><i class="jsonly displaynone chevron circle right icon disabled button tooltip" title="{{ _T("Load following members...") }}"></i></span>
                             <div class="jsonly displaynone default text">{{ _T("Search for name or ID and pick member") }}</div>
+                            <div class="jsonly displaynone menu">
+            {% for k, v in members.list %}
+                                <div class="item" data-value="{{ k }}">{{ v }}</div>
+            {% endfor %}
+                            </div>
                         </div>
                     </span>
             {% if member.isDuplicate() %}

--- a/galette/templates/default/pages/member_form.html.twig
+++ b/galette/templates/default/pages/member_form.html.twig
@@ -65,7 +65,8 @@
                         <div id="parent_id" class="jsonly search-dropdown ui input nochosen paginated">
                             <input id="parent_id_input" type="text" name="parent_id" value="{{ member.isDuplicate() and member.parent is defined and member.parent is not null ? member.parent.id }}" placeholder="{{ _T("Member ID") }}">
                             <i class="jsonly displaynone dropdown icon"></i>
-                            <i class="jsonly displaynone chevron circle right icon tooltip" title="{{ _T("Next results") }}"></i>
+                            <span class="ui mini compact icon disabled button prev-results"><i class="jsonly displaynone chevron circle left icon disabled button tooltip" title="{{ _T("Load previous members...") }}"></i></span>
+                            <span class="ui mini compact icon disabled button next-results"><i class="jsonly displaynone chevron circle right icon disabled button tooltip" title="{{ _T("Load following members...") }}"></i></span>
                             <div class="jsonly displaynone default text">{{ _T("Search for name or ID and pick member") }}</div>
                         </div>
                     </span>

--- a/galette/templates/default/pages/transaction_form.html.twig
+++ b/galette/templates/default/pages/transaction_form.html.twig
@@ -16,17 +16,12 @@
                         </div>
                         <div class="field inline">
                             <label for="id_adh" >{{ _T("Originator:") }}</label>
-                            <div id="id_adh" class="jsonly search-dropdown ui input nochosen"{% if required.id_adh == 1 %} required="required"{% endif %}>
+                            <div id="id_adh" class="jsonly search-dropdown ui input nochosen paginated"{% if required.id_adh == 1 %} required="required"{% endif %}>
                                 <input id="id_adh_input" type="text" name="id_adh" value="{{ transaction.member is not null ? transaction.member }}" placeholder="{{ _T("Member ID") }}">
                                 <i class="jsonly displaynone dropdown icon"></i>
+                                <i class="jsonly displaynone chevron circle right icon tooltip" title="{{ _T("Next results") }}"></i>
                                 <div class="jsonly displaynone default text">{% if not transaction.member %}{{ _T("Search for name or ID and pick member") }}{% endif %}</div>
-                                <div class="jsonly displaynone menu">
-    {% for k, v in members.list %}
-                                    <div class="item" data-value="{{ k }}">{{ v }}</div>
-    {% endfor %}
-                                </div>
                             </div>
-                            <div class="tooltip jsonly displaynone ui tiny icon button" id="reset-contributor" title="{{ _T("Reset") }}"><i class="redo icon"></i><span class="displaynone">{{ _T("Reset") }}</span></div>
                         </div>
                         <div class="field inline">
                             <label for="trans_date">{{ _T("Date:") }}</label>

--- a/galette/templates/default/pages/transaction_form.html.twig
+++ b/galette/templates/default/pages/transaction_form.html.twig
@@ -22,6 +22,11 @@
                                 <span class="ui mini compact icon disabled button prev-results"><i class="jsonly displaynone chevron circle left icon disabled button tooltip" title="{{ _T("Load previous members...") }}"></i></span>
                                 <span class="ui mini compact icon disabled button next-results"><i class="jsonly displaynone chevron circle right icon disabled button tooltip" title="{{ _T("Load following members...") }}"></i></span>
                                 <div class="jsonly displaynone default text">{% if not transaction.member %}{{ _T("Search for name or ID and pick member") }}{% endif %}</div>
+                                <div class="jsonly displaynone menu">
+    {% for k, v in members.list %}
+                                    <div class="item" data-value="{{ k }}">{{ v }}</div>
+    {% endfor %}
+                                </div>
                             </div>
                         </div>
                         <div class="field inline">

--- a/galette/templates/default/pages/transaction_form.html.twig
+++ b/galette/templates/default/pages/transaction_form.html.twig
@@ -19,7 +19,8 @@
                             <div id="id_adh" class="jsonly search-dropdown ui input nochosen paginated"{% if required.id_adh == 1 %} required="required"{% endif %}>
                                 <input id="id_adh_input" type="text" name="id_adh" value="{{ transaction.member is not null ? transaction.member }}" placeholder="{{ _T("Member ID") }}">
                                 <i class="jsonly displaynone dropdown icon"></i>
-                                <i class="jsonly displaynone chevron circle right icon tooltip" title="{{ _T("Next results") }}"></i>
+                                <span class="ui mini compact icon disabled button prev-results"><i class="jsonly displaynone chevron circle left icon disabled button tooltip" title="{{ _T("Load previous members...") }}"></i></span>
+                                <span class="ui mini compact icon disabled button next-results"><i class="jsonly displaynone chevron circle right icon disabled button tooltip" title="{{ _T("Load following members...") }}"></i></span>
                                 <div class="jsonly displaynone default text">{% if not transaction.member %}{{ _T("Search for name or ID and pick member") }}{% endif %}</div>
                             </div>
                         </div>

--- a/ui/js/common.js
+++ b/ui/js/common.js
@@ -166,7 +166,7 @@ $(function() {
     $('.jsenabled .jsonly.displaynone').removeClass('displaynone');
     $('.jsenabled .jsonly.disabled').removeClass('disabled');
     $('.jsenabled .jsonly.read-only').removeClass('read-only');
-    $('.jsenabled .jsonly.search-dropdown').removeClass('search-dropdown').addClass('search selection dropdown');
+    $('.jsenabled .jsonly.search-dropdown').removeClass('search-dropdown').addClass('search clearable selection dropdown');
 
     $('#login').focus();
 

--- a/ui/semantic/galette/modules/dropdown.overrides
+++ b/ui/semantic/galette/modules/dropdown.overrides
@@ -13,31 +13,36 @@
      Search dropdown
 -------------------------*/
 .ui.search.selection.paginated.dropdown {
-    &.clearable .text {
-        margin-right: 2.5em;
-    }
-    > .chevron.circle.right.icon {
+    > .ui.mini.button {
         display: none;
     }
-    &.visible > .chevron.circle.right.icon {
+    > input.search {
+        width: 100%;
+    }
+    &.visible > .ui.mini.button {
         display: block;
-        cursor: pointer;
+        margin-right: 0;
+        //cursor: pointer;
         font-size: .85714286em;
-        margin: -.78571429em;
-        padding: .91666667em;
-        top: .78571429em;
-        right: 3.5em;
         position: absolute;
+        top: .3rem;
         opacity: .6;
         z-index: 3;
         &:hover {
             opacity: 1;
         }
+        &.next-results {
+            right: 2.5em;
+        }
+        &.prev-results {
+            right: 5em;
+        }
     }
     &.visible > .remove.icon {
-        right: 5em;
+        right: 8.5em;
     }
-    > input.search {
-        padding: .67857143em 5em .67857143em 1em;
-    }
+}
+.ui.search.selection.paginated.dropdown,
+.ui.search.selection.paginated.dropdown > input.search {
+    padding: .67857143em 6.5em .67857143em 1em;
 }

--- a/ui/semantic/galette/modules/dropdown.overrides
+++ b/ui/semantic/galette/modules/dropdown.overrides
@@ -8,3 +8,36 @@
 .nojs select[multiple].ui.dropdown {
   height: 7rem;
 }
+
+/*------------------------
+     Search dropdown
+-------------------------*/
+.ui.search.selection.paginated.dropdown {
+    &.clearable .text {
+        margin-right: 2.5em;
+    }
+    > .chevron.circle.right.icon {
+        display: none;
+    }
+    &.visible > .chevron.circle.right.icon {
+        display: block;
+        cursor: pointer;
+        font-size: .85714286em;
+        margin: -.78571429em;
+        padding: .91666667em;
+        top: .78571429em;
+        right: 3.5em;
+        position: absolute;
+        opacity: .6;
+        z-index: 3;
+        &:hover {
+            opacity: 1;
+        }
+    }
+    &.visible > .remove.icon {
+        right: 5em;
+    }
+    > input.search {
+        padding: .67857143em 5em .67857143em 1em;
+    }
+}


### PR DESCRIPTION
Now using FUI's clearable function on search dropdowns.

It was not possible to add an item at the end of the results to load the next ones.
So a trigger icon has been added on the input field next to the reset button when the dropdown is opened.

![Capture d’écran de 2023-03-01 11-40-02](https://user-images.githubusercontent.com/107203963/222117471-679fa224-66e8-4b00-903f-f319cea3b716.png)

However, I don't see how to get the next page number.

I searched in the master branch to see how it is done at the moment. But it seems the next results button doesn't exist in master neither :confused: 
