### PR TITLE
fix pref-postal-address values in preferences pane

### DIFF
--- a/galette/templates/default/pages/preferences.html.twig
+++ b/galette/templates/default/pages/preferences.html.twig
@@ -109,11 +109,11 @@
                         <div class="inline fields">
                             <div class="field">
                                 <label for="pref_postal_adress_0">{{ _T("from preferences") }}</label>
-                                <input type="radio" name="pref_postal_adress" id="pref_postal_adress_0" value=" {{ constant('Galette\\Core\\Preferences::POSTAL_ADDRESS_FROM_PREFS') }}}" {% if pref.pref_postal_adress == constant('Galette\\Core\\Preferences::POSTAL_ADDRESS_FROM_PREFS') %}checked="checked"{% endif %}/>
+                                <input type="radio" name="pref_postal_adress" id="pref_postal_adress_0" value="{{ constant('Galette\\Core\\Preferences::POSTAL_ADDRESS_FROM_PREFS') }}" {% if pref.pref_postal_adress == constant('Galette\\Core\\Preferences::POSTAL_ADDRESS_FROM_PREFS') %}checked="checked"{% endif %}/>
                             </div>
                             <div class="field">
                                 <label for="pref_postal_adress_1">{{ _T("from a staff user") }}</label>
-                                <input type="radio" name="pref_postal_adress" id="pref_postal_adress_1" value=" {{ constant('Galette\\Core\\Preferences::POSTAL_ADDRESS_FROM_STAFF') }}}" {% if pref.pref_postal_adress == constant('Galette\\Core\\Preferences::POSTAL_ADDRESS_FROM_STAFF') %}checked="checked"{% endif %}/>
+                                <input type="radio" name="pref_postal_adress" id="pref_postal_adress_1" value="{{ constant('Galette\\Core\\Preferences::POSTAL_ADDRESS_FROM_STAFF') }}" {% if pref.pref_postal_adress == constant('Galette\\Core\\Preferences::POSTAL_ADDRESS_FROM_STAFF') %}checked="checked"{% endif %}/>
                             </div>
                         </div>
                         <label for="pref_postal_staff_member">{{ _T("Staff member") }}</label>


### PR DESCRIPTION
removed blank spaces & additional curly braces that lead to weird behavior when trying to switch postal address sources (preferences or member)

Prior to these changes, the form would pass `pref_postal_adress:  0}` or `pref_postal_adress:  1}` as form data to `/preferences` endpoint
<img width="1680" alt="2023-03-02-15 45 54" src="https://user-images.githubusercontent.com/97628193/222461488-80dd45e7-dd6c-4e69-802f-caaa570c857a.png">

