### PR TITLE
Required for plugin-event

### DIFF
--- a/galette/includes/core_acls.php
+++ b/galette/includes/core_acls.php
@@ -65,6 +65,7 @@ $core_acls = [
     'contributions'                     => 'member',
     'printContribution'                 => 'member',
     'myContributions'                   => 'member',
+    'contributionMembers'               => 'groupmanager',
     '/(.+)?contribution(.+)?/i'         => 'staff',
     '/(.+)?transaction(.+)?/i'          => 'staff',
     // /Contributions rules

--- a/galette/templates/default/elements/js/choose_adh.js.twig
+++ b/galette/templates/default/elements/js/choose_adh.js.twig
@@ -131,6 +131,7 @@
         $('{{ js_chosen_id }}').dropdown({
             match: 'text',
             apiSettings: {
+                {% if js_chosen_cache is defined and js_chosen_cache == false %}cache: false,{% endif %}
                 url: '{{ url_for("contributionMembers", {"page": 1, "search": "{query}"}) }}',
                 method: 'post',
                 beforeSend: function (settings) {


### PR DESCRIPTION
- Related to https://bugs.galette.eu/issues/1707
- https://github.com/galette/plugin-events/pull/33 required

Groupmanagers require permission to request `contributionMembers` to select a member on the booking form.