### PR TITLE
Fix member form layout display issues

### DIFF
--- a/galette/templates/default/pages/member_form.html.twig
+++ b/galette/templates/default/pages/member_form.html.twig
@@ -2,11 +2,12 @@
 
 {% block content %}
 <form action="{% if self_adh %}{{ url_for("storeselfmembers") }}{% elseif not member.id %}{{ url_for("doAddMember") }}{% else %}{{ url_for("doEditMember", {"id": member.id}) }}{% endif %}" method="post" enctype="multipart/form-data" id="form" class="ui form{% if member.id %} edit-member{% endif %}">
-    {% if member.id %}
+    {% if member.id or not self_adh %}
 <div class="ui stackable grid">
     <div class="row">
         <div class="sixteen wide tablet six wide computer five wide widescreen column order-2">
             <div class="position-sticky">
+        {% if member.id %}
                 <div class="ui basic clearing horizontally fitted segment">
 
                     <div class="ui left floated basic fitted segment">
@@ -31,70 +32,75 @@
                     </div>
                 </div>
                 {% include "elements/member_card.html.twig" %}
+        {% endif %}
     {% endif %}
 
     {% if not self_adh %}
-                <div class="ui{% if not member.id %} compact{% endif %} segment">
+                <div class="ui basic horizontally fitted segment">
+                    <div class="ui segment">
         {% if member.hasParent() and not member.isDuplicate() %}
-                    <div class="field">
-                        <div class="ui label">
-                            <i class="linkify icon"></i>
-                            {{ _T("Attached to:") }}
-                        </div>
-                        <div class="ui celled list">
-                            <a href="{{ url_for("member", {"id": member.parent.id}) }}" class="item">{{ member.parent.sfullname }}</a>
-                        </div>
+                        <div class="field">
+                            <div class="ui label">
+                                <i class="linkify icon"></i>
+                                {{ _T("Attached to:") }}
+                            </div>
+                            <div class="ui celled list">
+                                <a href="{{ url_for("member", {"id": member.parent.id}) }}" class="item">{{ member.parent.sfullname }}</a>
+                            </div>
             {% if not member.id %}
-                        <input type="hidden" name="parent_id" value="{{ member.parent.id }}"/>
+                            <input type="hidden" name="parent_id" value="{{ member.parent.id }}"/>
             {% endif %}
-                    </div>
-            {% if login.isAdmin() or login.isStaff() and (addchild is not defined or not addchild) %}
-                    <div class="field">
-                        <div class="ui toggle checkbox">
-                            <input type="checkbox" name="detach_parent" id="detach_parent" value="1"/>
-                            <label for="detach_parent">{{ _T("Detach?") }}</label>
                         </div>
-                    </div>
+            {% if login.isAdmin() or login.isStaff() and (addchild is not defined or not addchild) %}
+                        <div class="field">
+                            <div class="ui toggle checkbox">
+                                <input type="checkbox" name="detach_parent" id="detach_parent" value="1"/>
+                                <label for="detach_parent">{{ _T("Detach?") }}</label>
+                            </div>
+                        </div>
             {% endif %}
         {% elseif (login.isAdmin() or login.isStaff()) and not member.hasChildren() and members.list is defined %}
-                    <div id="attach-checkbox" class="ui{% if member.isDuplicate() %} checked{% endif %} toggle checkbox">
-                        <input type="checkbox" name="attach" id="attach" value="1"{% if member.isDuplicate() %} checked="checked"{% endif %}/>
-                        <label for="attach"><i class="linkify icon"></i> {{ _T("Attach member") }}</label>
-                    </div>
-                    <span id="parent_id_elt" class="">
-                        <div id="parent_id" class="jsonly search-dropdown ui input nochosen paginated">
-                            <input id="parent_id_input" type="text" name="parent_id" value="{{ member.isDuplicate() and member.parent is defined and member.parent is not null ? member.parent.id }}" placeholder="{{ _T("Member ID") }}">
-                            <i class="jsonly displaynone dropdown icon"></i>
-                            <span class="ui mini compact icon disabled button prev-results"><i class="jsonly displaynone chevron circle left icon disabled button tooltip" title="{{ _T("Load previous members...") }}"></i></span>
-                            <span class="ui mini compact icon disabled button next-results"><i class="jsonly displaynone chevron circle right icon disabled button tooltip" title="{{ _T("Load following members...") }}"></i></span>
-                            <div class="jsonly displaynone default text">{{ _T("Search for name or ID and pick member") }}</div>
-                            <div class="jsonly displaynone menu">
+                        <div class="field">
+                            <div id="attach-checkbox" class="ui{% if member.isDuplicate() %} checked{% endif %} toggle checkbox">
+                                <input type="checkbox" name="attach" id="attach" value="1"{% if member.isDuplicate() %} checked="checked"{% endif %}/>
+                                <label for="attach"><i class="linkify icon"></i> {{ _T("Attach member") }}</label>
+                            </div>
+                        </div>
+                        <span id="parent_id_elt" class="">
+                            <div id="parent_id" class="jsonly search-dropdown ui input nochosen paginated">
+                                <input id="parent_id_input" type="text" name="parent_id" value="{{ member.isDuplicate() and member.parent is defined and member.parent is not null ? member.parent.id }}" placeholder="{{ _T("Member ID") }}">
+                                <i class="jsonly displaynone dropdown icon"></i>
+                                <span class="ui mini compact icon disabled button prev-results"><i class="jsonly displaynone chevron circle left icon disabled button tooltip" title="{{ _T("Load previous members...") }}"></i></span>
+                                <span class="ui mini compact icon disabled button next-results"><i class="jsonly displaynone chevron circle right icon disabled button tooltip" title="{{ _T("Load following members...") }}"></i></span>
+                                <div class="jsonly displaynone default text">{{ _T("Search for name or ID and pick member") }}</div>
+                                <div class="jsonly displaynone menu">
             {% for k, v in members.list %}
-                                <div class="item" data-value="{{ k }}">{{ v }}</div>
+                                    <div class="item" data-value="{{ k }}">{{ v }}</div>
+            {% endfor %}
+                                </div>
+                            </div>
+                        </span>
+            {% if member.isDuplicate() %}
+                        <input type="hidden" name="duplicate" value="1" />
+            {% endif %}
+        {% elseif member.hasChildren() %}
+                        <div class="field">
+                            <div class="ui label">
+                                <i class="linkify icon"></i>
+                                {{ _T("Parent of:") }}
+                            </div>
+                            <div class="ui celled list">
+            {% for child in member.children %}
+                                <a href="{{ url_for("member", {"id": child.id}) }}" class="item">{{ child.sfullname }}</a>
             {% endfor %}
                             </div>
                         </div>
-                    </span>
-            {% if member.isDuplicate() %}
-                    <input type="hidden" name="duplicate" value="1" />
-            {% endif %}
-        {% elseif member.hasChildren() %}
-                    <div class="field">
-                        <div class="ui label">
-                            <i class="linkify icon"></i>
-                            {{ _T("Parent of:") }}
-                        </div>
-                        <div class="ui celled list">
-            {% for child in member.children %}
-                            <a href="{{ url_for("member", {"id": child.id}) }}" class="item">{{ child.sfullname }}</a>
-            {% endfor %}
-                        </div>
-                    </div>
         {% endif %}
+                    </div>
                 </div>
     {% endif %}
 
-    {% if member.id %}
+    {% if member.id or not self_adh %}
             </div>
         </div>
         <div class="sixteen wide tablet ten wide computer eleven wide widescreen column">
@@ -181,7 +187,7 @@
             {% include "components/forms/csrf.html.twig" %}
             </div>
 
-    {% if member.id %}
+    {% if member.id or not self_adh %}
         </div>
     </div>
 </div>


### PR DESCRIPTION
Targets the widget to attach a parent.
Adds spacings and properly displays it on the right with sticky position.

Before : 
![Capture d’écran de 2023-09-29 16-55-14](https://github.com/galette/galette/assets/107203963/c6ebe35e-e1b0-40e1-9e3d-0eefe2aa2a4d)

After : 
![Capture d’écran de 2023-09-29 16-56-45](https://github.com/galette/galette/assets/107203963/37788055-f92c-4e46-9213-c537c9773c33)
