### PR TITLE
Don't replace legend link with check links when empty

### DIFF
--- a/galette/templates/default/elements/list.html.twig
+++ b/galette/templates/default/elements/list.html.twig
@@ -183,7 +183,9 @@
             {% endif %}
                     }
                 });
-                $('.batch-selection').after({% if _legend_block is not empty %}_legendlink{% else %}_checklinks{% endif %});
+            {% if _legend_block is not empty %}
+                $('.batch-selection').after(_legendlink);
+            {% endif %}
                 _bind_check('entries_sel');
         {% endif %}
             }


### PR DESCRIPTION
It's unnecessary : 
* check links are already above and below the list
* as a result, on small screens, there's a bit too much of thoses links next to each other :sweat_smile: 