### PR TITLE
Fix/1764

### DIFF
--- a/galette/lib/Galette/Entity/Group.php
+++ b/galette/lib/Galette/Entity/Group.php
@@ -551,6 +551,22 @@ class Group
     }
 
     /**
+     * Get parents as an array
+     *
+     * @return array
+     */
+    public function getParents(): array
+    {
+        $parents = [];
+        $group = $this;
+        while($group = $group->getParentGroup()) {
+            $parents[] = $group->getName();
+        }
+        return $parents;
+    }
+
+
+    /**
      * Get the indented short name of the group "  >> bar"
      *
      * @return string

--- a/galette/lib/Galette/Entity/Group.php
+++ b/galette/lib/Galette/Entity/Group.php
@@ -559,7 +559,7 @@ class Group
     {
         $parents = [];
         $group = $this;
-        while($group = $group->getParentGroup()) {
+        while ($group = $group->getParentGroup()) {
             $parents[] = $group->getName();
         }
         return $parents;

--- a/galette/templates/default/elements/group.html.twig
+++ b/galette/templates/default/elements/group.html.twig
@@ -5,12 +5,11 @@
 
 <div class="ui stackable pointing inverted menu tabbed">
     <div class="item header">
-        <i class="users cog icon" aria-hidden="true"></i>
         {{ group.getFullName() }} :
     </div>
     <a href="{{ url_for('groups', {'id': group.getId()}) }}?tab=group_information" class="item{{ tab == 'group_information' ? ' active' }}" data-tab="group_information">{{ _T("Information") }}</a>
-    <a href="{{ url_for('groups', {'id': group.getId()}) }}?tab=group_managers" class="item{{ tab == 'group_managers' ? ' active' }}" data-tab="group_managers">{{ _T("Managers") }} ({{ managers|length }})</a>
-    <a href="{{ url_for('groups', {'id': group.getId()}) }}?tab=group_members" class="item{{ tab == 'group_members' ? ' active' }}" data-tab="group_members">{{ _T("Members") }} ({{ members|length }})</a>
+    <a href="{{ url_for('groups', {'id': group.getId()}) }}?tab=group_managers" class="item{{ tab == 'group_managers' ? ' active' }}" data-tab="group_managers"><i class="user shield icon" aria-hidden="true"></i>{{ _T("Managers") }} ({{ managers|length }})</a>
+    <a href="{{ url_for('groups', {'id': group.getId()}) }}?tab=group_members" class="item{{ tab == 'group_members' ? ' active' }}" data-tab="group_members"><i class="user icon" aria-hidden="true"></i>{{ _T("Members") }} ({{ members|length }})</a>
 </div>
 <form class="ui form" action="{{ url_for("doEditGroup", {"id": group.getId()}) }}" method="post" enctype="multipart/form-data" id="group_form">
     <div class="ui{{ tab == 'group_information' ? ' active' }} tab segment" data-tab="group_information">

--- a/galette/templates/default/elements/group.html.twig
+++ b/galette/templates/default/elements/group.html.twig
@@ -7,10 +7,10 @@
     <div class="item header">
         <div class="ui inverted breadcrumb">
             {% for parent in group.parents %}
-                <a class="section">{{ parent }}</a>
+                <span class="section">{{ parent }}</span>
                 <i class="right angle icon divider"></i>
             {% endfor %}
-            <a class="section active">{{ group.getName() }}</a>
+            <span class="section active">{{ group.getName() }}</span>
         </div>
     </div>
     <a href="{{ url_for('groups', {'id': group.getId()}) }}?tab=group_information" class="item{{ tab == 'group_information' ? ' active' }}" data-tab="group_information">{{ _T("Information") }}</a>

--- a/galette/templates/default/elements/group.html.twig
+++ b/galette/templates/default/elements/group.html.twig
@@ -5,7 +5,7 @@
 
 <div class="ui stackable pointing inverted menu tabbed">
     <div class="item header">
-        <div class="ui inverted breadcrumb">
+        <div class="ui breadcrumb">
             {% for parent in group.parents %}
                 <span class="section">{{ parent }}</span>
                 <i class="right angle icon divider"></i>

--- a/galette/templates/default/elements/group.html.twig
+++ b/galette/templates/default/elements/group.html.twig
@@ -5,7 +5,13 @@
 
 <div class="ui stackable pointing inverted menu tabbed">
     <div class="item header">
-        {{ group.getFullName() }} :
+        <div class="ui inverted breadcrumb">
+            {% for parent in group.parents %}
+                <a class="section">{{ parent }}</a>
+                <i class="right angle icon divider"></i>
+            {% endfor %}
+            <a class="section active">{{ group.getName() }}</a>
+        </div>
     </div>
     <a href="{{ url_for('groups', {'id': group.getId()}) }}?tab=group_information" class="item{{ tab == 'group_information' ? ' active' }}" data-tab="group_information">{{ _T("Information") }}</a>
     <a href="{{ url_for('groups', {'id': group.getId()}) }}?tab=group_managers" class="item{{ tab == 'group_managers' ? ' active' }}" data-tab="group_managers"><i class="user shield icon" aria-hidden="true"></i>{{ _T("Managers") }} ({{ managers|length }})</a>

--- a/galette/templates/default/elements/group_persons.html.twig
+++ b/galette/templates/default/elements/group_persons.html.twig
@@ -70,7 +70,7 @@
     {% endif %}
 {% else %}
                             <tr>
-                                <td colspan="2">
+                                <td colspan="{% if login.isSuperAdmin() %}3{% else %}2{% endif %}">
     {% if person_mode == 'members' %}
                                     {{ _T("No member attached") }}
     {% else %}

--- a/galette/templates/default/pages/groups_list.html.twig
+++ b/galette/templates/default/pages/groups_list.html.twig
@@ -2,18 +2,18 @@
 
 {% set can_export = login.isGroupManager() and preferences.pref_bool_groupsmanagers_exports or login.isAdmin() or login.isStaff() %}
 
-{% macro group_item(login, group, opened, selected) %}
-    <div class="{% if group.getGroups()|length > 0 %}title{% if group.getName() in opened %} active{% endif %}{% else %}nochild{% endif %}">
+{% macro group_item(login, group, parents, selected) %}
+    <div class="{% if group.getGroups()|length > 0 %}title{% if group.getName() in parents %} active{% endif %}{% else %}nochild{% endif %}">
         <i class="{% if group.getGroups()|length > 0 %}dropdown{% else %}empty{% endif %} icon" aria-hidden="true"></i>
         <a class="ui{% if group.getName() == selected %} primary{% endif %}{% if not login.isGroupManager(group.getId()) %} disabled{% endif %} label" href="{% if login.isGroupManager(group.getId()) %}{{ url_for("groups", {"id": group.getId()}) }}{% else %}#{% endif %}">
             {{ group.getName() }}
         </a>
     </div>
     {% if group.getGroups()|length > 0 %}
-    <div class="content{% if group.getName() in opened %} active{% endif %}">
+    <div class="content{% if group.getName() in parents %} active{% endif %}">
         <div class="accordion">
         {% for child_group in group.getGroups() %}
-            {{ _self.group_item(login, child_group, opened, selected) }}
+            {{ _self.group_item(login, child_group, parents, selected) }}
         {% endfor %}
         </div>
     </div>
@@ -21,8 +21,8 @@
 {% endmacro %}
 
 {% block content %}
-    {% set opened = group.getFullName()|split(' / ') %}
-    {% set selected = opened|last %}
+    {% set parents = group.getParents() %}
+    {% set selected = group.getName() %}
     <div class="ui stackable grid">
         <div class="three wide column">
     {% if group.getId() %}
@@ -30,7 +30,7 @@
             <div class="ui attached accordion-styled scrolling segment loader_selector">
                 <div class="ui tree accordion">
                 {% for group in groups_root %}
-                    {{ _self.group_item(login, group, opened, selected) }}
+                    {{ _self.group_item(login, group, parents, selected) }}
                 {% endfor %}
                 </div>
             </div>


### PR DESCRIPTION
Another proposal to fix issue 1764; replacing  #388 and #389

Using code to concatenate a string, and then another piece of code to split the concatenated string seems a bit dumb (and causes issues).

My proposal is to use a new method that returns directly all parents groups names as an array (https://github.com/galette/galette/commit/fd02a4e6b14b67cb8de2f8d9f434745a141e7b67).

Also, indeed display with a "/" is impossible to understand currently. In my mind, using a FUI breadcrumb was the solution (see commit https://github.com/galette/galette/commit/4149c9043a62b7ebfd49219bae520fc3db30138e), but display is not OK at the moment (I'm not sure I did things right; it may requires some changes in FUI Galette config).

Other commits are minor changes.

Note for myself: unit tests must be added on the new method.