### PR TITLE
Fix elements on groups list

### DIFF
--- a/galette/lib/Galette/Entity/Group.php
+++ b/galette/lib/Galette/Entity/Group.php
@@ -560,7 +560,7 @@ class Group
         $parents = [];
         $group = $this;
         while ($group = $group->getParentGroup()) {
-            $parents[] = $group->getName();
+            array_unshift($parents, $group->getName());
         }
         return $parents;
     }

--- a/galette/templates/default/elements/group.html.twig
+++ b/galette/templates/default/elements/group.html.twig
@@ -45,7 +45,7 @@
                         {{ pgroup.getName() }}
                         <input type="hidden" name="parent_group" value="{{ pgroup.getId() }}"/>
                     {% else %}
-                        <div class="ui search selection dropdown nochosen">
+                        <div class="ui search compact selection dropdown nochosen">
                             <input type="hidden" name="parent_group" id="parent_group" value="{% if pgroup is defined %}{{ pgroup.getId() }}{% endif %}">
                             <i class="dropdown icon" aria-hidden="true"></i>
                             <div class="text">{% if pgroup is defined %}{{ pgroup.getName() }}{% endif %}</div>

--- a/tests/Galette/Entity/tests/units/Group.php
+++ b/tests/Galette/Entity/tests/units/Group.php
@@ -263,7 +263,7 @@ class Group extends GaletteTestCase
         $this->assertSame($child_id_2, $group->getParentGroup()->getId());
 
         $group = new \Galette\Entity\Group($child_id_3);
-        $this->assertSame(['Another child group', 'A parent group'], $group->getParents());
+        $this->assertSame(['A parent group', 'Another child group'], $group->getParents());
         $this->assertTrue($group->detach());
     }
 


### PR DESCRIPTION
1. parents in the breadcrumbs are not displayed in the correct order :
   * before : 
     ![Capture d’écran de 2023-12-30 14-08-02](https://github.com/galette/galette/assets/107203963/fa136d3b-bd4a-4628-b641-c2bbdb5a066b)
   * after :
     ![Capture d’écran de 2023-12-30 14-08-46](https://github.com/galette/galette/assets/107203963/7ed93c5e-2522-4468-ba35-85827bb46ea3)

2. parent group dropdown width when opened is not constant :
   * before : 
     ![Capture d’écran de 2023-12-30 14-08-21](https://github.com/galette/galette/assets/107203963/c7d018d5-d064-4adc-bb57-fd752c83d584)
   * after :
     ![Capture d’écran de 2023-12-30 14-09-20](https://github.com/galette/galette/assets/107203963/9975b490-3b3b-45c0-8edd-80668d7c6e0c)
