### PR TITLE
Give doctrine ORM a try

### DIFF
--- a/bin/orm
+++ b/bin/orm
@@ -1,0 +1,70 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Copyright © 2003-2024 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Tools\Console\ConsoleRunner;
+use Doctrine\ORM\Tools\Console\EntityManagerProvider\SingleManagerProvider;
+
+if (!isset($basepath)) {
+    if (file_exists('../galette/index.php')) {
+        $basepath = '../galette/';
+    } elseif (file_exists('galette/index.php')) {
+        $basepath = 'galette/';
+    } else {
+        die('Unable to define GALETTE_BASE_PATH :\'(');
+    }
+}
+define('GALETTE_BASE_PATH', $basepath);
+
+$logfile = 'galette_orm';
+require_once GALETTE_BASE_PATH . 'includes/galette.inc.php';
+
+$session_name = 'galette_cli';
+$session = new \RKA\SessionMiddleware([
+    'name'      => $session_name,
+    'lifetime'  => 0
+]);
+$session->start();
+
+$gapp =  new \Galette\Core\SlimApp();
+$app = $gapp->getApp();
+$app->add($session);
+
+require_once GALETTE_BASE_PATH . 'includes/dependencies.php';
+
+// replace with path to your own project bootstrap file
+//require_once 'bootstrap.php';
+
+// replace with mechanism to retrieve EntityManager in your app
+$entityManager = $container->get(EntityManager::class);
+
+$commands = [
+    // If you want to add your own custom console commands,
+    // you can do so here.
+];
+
+ConsoleRunner::run(
+    new SingleManagerProvider($entityManager),
+    $commands
+);

--- a/galette/composer.json
+++ b/galette/composer.json
@@ -57,7 +57,9 @@
         "symfony/yaml": "^6.2",
         "guzzlehttp/guzzle": "^7.8",
         "twig/string-extra": "^3.8",
-        "symfony/console": "^7.1"
+        "symfony/console": "^7.1",
+        "doctrine/orm": "^2.20",
+        "symfony/cache": "^7.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.7",

--- a/galette/composer.lock
+++ b/galette/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "42f8e075abfae815f3bec1d88b311ca9",
+    "content-hash": "5ddea0fa49f7d080f8539d8f9f1d3b6a",
     "packages": [
         {
             "name": "akrabat/rka-slim-session-middleware",
@@ -204,6 +204,387 @@
             "time": "2024-09-05T10:15:52+00:00"
         },
         {
+            "name": "doctrine/cache",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "1ca8f21980e770095a31456042471a57bc4c68fb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/1ca8f21980e770095a31456042471a57bc4c68fb",
+                "reference": "1ca8f21980e770095a31456042471a57bc4c68fb",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4"
+            },
+            "require-dev": {
+                "cache/integration-tests": "dev-master",
+                "doctrine/coding-standard": "^9",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "psr/cache": "^1.0 || ^2.0 || ^3.0",
+                "symfony/cache": "^4.4 || ^5.4 || ^6",
+                "symfony/var-exporter": "^4.4 || ^5.4 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Cache library is a popular cache implementation that supports many different drivers such as redis, memcache, apc, mongodb and others.",
+            "homepage": "https://www.doctrine-project.org/projects/cache.html",
+            "keywords": [
+                "abstraction",
+                "apcu",
+                "cache",
+                "caching",
+                "couchdb",
+                "memcached",
+                "php",
+                "redis",
+                "xcache"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/cache/issues",
+                "source": "https://github.com/doctrine/cache/tree/2.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fcache",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-05-20T20:07:39+00:00"
+        },
+        {
+            "name": "doctrine/collections",
+            "version": "2.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/collections.git",
+                "reference": "d8af7f248c74f195f7347424600fd9e17b57af59"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/d8af7f248c74f195f7347424600fd9e17b57af59",
+                "reference": "d8af7f248c74f195f7347424600fd9e17b57af59",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^12",
+                "ext-json": "*",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^10.5",
+                "vimeo/psalm": "^5.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Collections\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Collections library that adds additional functionality on top of PHP arrays.",
+            "homepage": "https://www.doctrine-project.org/projects/collections.html",
+            "keywords": [
+                "array",
+                "collections",
+                "iterators",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/collections/issues",
+                "source": "https://github.com/doctrine/collections/tree/2.2.2"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fcollections",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-04-18T06:56:21+00:00"
+        },
+        {
+            "name": "doctrine/common",
+            "version": "3.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/common.git",
+                "reference": "d9ea4a54ca2586db781f0265d36bea731ac66ec5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/d9ea4a54ca2586db781f0265d36bea731ac66ec5",
+                "reference": "d9ea4a54ca2586db781f0265d36bea731ac66ec5",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/persistence": "^2.0 || ^3.0 || ^4.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9.0 || ^10.0",
+                "doctrine/collections": "^1",
+                "phpstan/phpstan": "^1.4.1",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5.20 || ^8.5 || ^9.0",
+                "squizlabs/php_codesniffer": "^3.0",
+                "symfony/phpunit-bridge": "^6.1",
+                "vimeo/psalm": "^4.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Common project is a library that provides additional functionality that other Doctrine projects depend on such as better reflection support, proxies and much more.",
+            "homepage": "https://www.doctrine-project.org/projects/common.html",
+            "keywords": [
+                "common",
+                "doctrine",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/common/issues",
+                "source": "https://github.com/doctrine/common/tree/3.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fcommon",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-01-01T22:12:03+00:00"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "3.9.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "ec16c82f20be1a7224e65ac67144a29199f87959"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/ec16c82f20be1a7224e65ac67144a29199f87959",
+                "reference": "ec16c82f20be1a7224e65ac67144a29199f87959",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2",
+                "doctrine/cache": "^1.11|^2.0",
+                "doctrine/deprecations": "^0.5.3|^1",
+                "doctrine/event-manager": "^1|^2",
+                "php": "^7.4 || ^8.0",
+                "psr/cache": "^1|^2|^3",
+                "psr/log": "^1|^2|^3"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "12.0.0",
+                "fig/log-test": "^1",
+                "jetbrains/phpstorm-stubs": "2023.1",
+                "phpstan/phpstan": "2.1.1",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "9.6.22",
+                "slevomat/coding-standard": "8.13.1",
+                "squizlabs/php_codesniffer": "3.10.2",
+                "symfony/cache": "^5.4|^6.0|^7.0",
+                "symfony/console": "^4.4|^5.4|^6.0|^7.0"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "bin": [
+                "bin/doctrine-dbal"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\DBAL\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.",
+            "homepage": "https://www.doctrine-project.org/projects/dbal.html",
+            "keywords": [
+                "abstraction",
+                "database",
+                "db2",
+                "dbal",
+                "mariadb",
+                "mssql",
+                "mysql",
+                "oci8",
+                "oracle",
+                "pdo",
+                "pgsql",
+                "postgresql",
+                "queryobject",
+                "sasql",
+                "sql",
+                "sqlite",
+                "sqlserver",
+                "sqlsrv"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/dbal/issues",
+                "source": "https://github.com/doctrine/dbal/tree/3.9.4"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdbal",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-01-16T08:28:55+00:00"
+        },
+        {
             "name": "doctrine/deprecations",
             "version": "1.1.4",
             "source": {
@@ -247,6 +628,258 @@
                 "source": "https://github.com/doctrine/deprecations/tree/1.1.4"
             },
             "time": "2024-12-07T21:18:45+00:00"
+        },
+        {
+            "name": "doctrine/event-manager",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/event-manager.git",
+                "reference": "b680156fa328f1dfd874fd48c7026c41570b9c6e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/b680156fa328f1dfd874fd48c7026c41570b9c6e",
+                "reference": "b680156fa328f1dfd874fd48c7026c41570b9c6e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "conflict": {
+                "doctrine/common": "<2.9"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^12",
+                "phpstan/phpstan": "^1.8.8",
+                "phpunit/phpunit": "^10.5",
+                "vimeo/psalm": "^5.24"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "The Doctrine Event Manager is a simple PHP event system that was built to be used with the various Doctrine projects.",
+            "homepage": "https://www.doctrine-project.org/projects/event-manager.html",
+            "keywords": [
+                "event",
+                "event dispatcher",
+                "event manager",
+                "event system",
+                "events"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/event-manager/issues",
+                "source": "https://github.com/doctrine/event-manager/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fevent-manager",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-22T20:47:39+00:00"
+        },
+        {
+            "name": "doctrine/inflector",
+            "version": "2.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/inflector.git",
+                "reference": "5817d0659c5b50c9b950feb9af7b9668e2c436bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/5817d0659c5b50c9b950feb9af7b9668e2c436bc",
+                "reference": "5817d0659c5b50c9b950feb9af7b9668e2c436bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^11.0",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.3",
+                "phpunit/phpunit": "^8.5 || ^9.5",
+                "vimeo/psalm": "^4.25 || ^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Inflector\\": "lib/Doctrine/Inflector"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Inflector is a small library that can perform string manipulations with regard to upper/lowercase and singular/plural forms of words.",
+            "homepage": "https://www.doctrine-project.org/projects/inflector.html",
+            "keywords": [
+                "inflection",
+                "inflector",
+                "lowercase",
+                "manipulation",
+                "php",
+                "plural",
+                "singular",
+                "strings",
+                "uppercase",
+                "words"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/inflector/issues",
+                "source": "https://github.com/doctrine/inflector/tree/2.0.10"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finflector",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-02-18T20:23:39+00:00"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^11",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-12-30T00:23:10+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -325,6 +958,204 @@
                 }
             ],
             "time": "2024-02-05T11:35:39+00:00"
+        },
+        {
+            "name": "doctrine/orm",
+            "version": "2.20.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/orm.git",
+                "reference": "e3cabade99ebccc6ba078884c1c5f250866a494e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/e3cabade99ebccc6ba078884c1c5f250866a494e",
+                "reference": "e3cabade99ebccc6ba078884c1c5f250866a494e",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2",
+                "doctrine/cache": "^1.12.1 || ^2.1.1",
+                "doctrine/collections": "^1.5 || ^2.1",
+                "doctrine/common": "^3.0.3",
+                "doctrine/dbal": "^2.13.1 || ^3.2",
+                "doctrine/deprecations": "^0.5.3 || ^1",
+                "doctrine/event-manager": "^1.2 || ^2",
+                "doctrine/inflector": "^1.4 || ^2.0",
+                "doctrine/instantiator": "^1.3 || ^2",
+                "doctrine/lexer": "^2 || ^3",
+                "doctrine/persistence": "^2.4 || ^3",
+                "ext-ctype": "*",
+                "php": "^7.1 || ^8.0",
+                "psr/cache": "^1 || ^2 || ^3",
+                "symfony/console": "^4.2 || ^5.0 || ^6.0 || ^7.0",
+                "symfony/polyfill-php72": "^1.23",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "conflict": {
+                "doctrine/annotations": "<1.13 || >= 3.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.13 || ^2",
+                "doctrine/coding-standard": "^9.0.2 || ^12.0",
+                "phpbench/phpbench": "^0.16.10 || ^1.0",
+                "phpstan/extension-installer": "~1.1.0 || ^1.4",
+                "phpstan/phpstan": "~1.4.10 || 2.0.3",
+                "phpstan/phpstan-deprecation-rules": "^1 || ^2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6",
+                "psr/log": "^1 || ^2 || ^3",
+                "squizlabs/php_codesniffer": "3.7.2",
+                "symfony/cache": "^4.4 || ^5.4 || ^6.4 || ^7.0",
+                "symfony/var-exporter": "^4.4 || ^5.4 || ^6.2 || ^7.0",
+                "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "ext-dom": "Provides support for XSD validation for XML mapping files",
+                "symfony/cache": "Provides cache support for Setup Tool with doctrine/cache 2.0",
+                "symfony/yaml": "If you want to use YAML Metadata Mapping Driver"
+            },
+            "bin": [
+                "bin/doctrine"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\ORM\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "Object-Relational-Mapper for PHP",
+            "homepage": "https://www.doctrine-project.org/projects/orm.html",
+            "keywords": [
+                "database",
+                "orm"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/orm/issues",
+                "source": "https://github.com/doctrine/orm/tree/2.20.1"
+            },
+            "time": "2024-12-19T06:48:36+00:00"
+        },
+        {
+            "name": "doctrine/persistence",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/persistence.git",
+                "reference": "0ea965320cec355dba75031c1b23d4c78362e3ff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/persistence/zipball/0ea965320cec355dba75031c1b23d4c78362e3ff",
+                "reference": "0ea965320cec355dba75031c1b23d4c78362e3ff",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/event-manager": "^1 || ^2",
+                "php": "^7.2 || ^8.0",
+                "psr/cache": "^1.0 || ^2.0 || ^3.0"
+            },
+            "conflict": {
+                "doctrine/common": "<2.10"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^12",
+                "doctrine/common": "^3.0",
+                "phpstan/phpstan": "1.12.7",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "phpunit/phpunit": "^8.5.38 || ^9.5",
+                "symfony/cache": "^4.4 || ^5.4 || ^6.0 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Persistence\\": "src/Persistence"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "The Doctrine Persistence project is a set of shared interfaces and functionality that the different Doctrine object mappers share.",
+            "homepage": "https://www.doctrine-project.org/projects/persistence.html",
+            "keywords": [
+                "mapper",
+                "object",
+                "odm",
+                "orm",
+                "persistence"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/persistence/issues",
+                "source": "https://github.com/doctrine/persistence/tree/3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fpersistence",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-10-30T19:48:12+00:00"
         },
         {
             "name": "ezyang/htmlpurifier",
@@ -2593,6 +3424,180 @@
             "time": "2023-01-06T09:28:15+00:00"
         },
         {
+            "name": "symfony/cache",
+            "version": "v7.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/cache.git",
+                "reference": "e7e983596b744c4539f31e79b0350a6cf5878a20"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/e7e983596b744c4539f31e79b0350a6cf5878a20",
+                "reference": "e7e983596b744c4539f31e79b0350a6cf5878a20",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/cache": "^2.0|^3.0",
+                "psr/log": "^1.1|^2|^3",
+                "symfony/cache-contracts": "^2.5|^3",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/var-exporter": "^6.4|^7.0"
+            },
+            "conflict": {
+                "doctrine/dbal": "<3.6",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/http-kernel": "<6.4",
+                "symfony/var-dumper": "<6.4"
+            },
+            "provide": {
+                "psr/cache-implementation": "2.0|3.0",
+                "psr/simple-cache-implementation": "1.0|2.0|3.0",
+                "symfony/cache-implementation": "1.1|2.0|3.0"
+            },
+            "require-dev": {
+                "cache/integration-tests": "dev-master",
+                "doctrine/dbal": "^3.6|^4",
+                "predis/predis": "^1.1|^2.0",
+                "psr/simple-cache": "^1.0|^2.0|^3.0",
+                "symfony/clock": "^6.4|^7.0",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/filesystem": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Cache\\": ""
+                },
+                "classmap": [
+                    "Traits/ValueWrapper.php"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides extended PSR-6, PSR-16 (and tags) implementations",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "caching",
+                "psr6"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/cache/tree/v7.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-12-07T08:08:50+00:00"
+        },
+        {
+            "name": "symfony/cache-contracts",
+            "version": "v3.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/cache-contracts.git",
+                "reference": "15a4f8e5cd3bce9aeafc882b1acab39ec8de2c1b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/15a4f8e5cd3bce9aeafc882b1acab39ec8de2c1b",
+                "reference": "15a4f8e5cd3bce9aeafc882b1acab39ec8de2c1b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/cache": "^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Cache\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to caching",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/cache-contracts/tree/v3.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:20:29+00:00"
+        },
+        {
             "name": "symfony/console",
             "version": "v7.2.1",
             "source": {
@@ -3071,6 +4076,71 @@
             "time": "2024-09-09T11:45:10+00:00"
         },
         {
+            "name": "symfony/polyfill-php72",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php72.git",
+                "reference": "fa2ae56c44f03bed91a39bfc9822e31e7c5c38ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/fa2ae56c44f03bed91a39bfc9822e31e7c5c38ce",
+                "reference": "fa2ae56c44f03bed91a39bfc9822e31e7c5c38ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "metapackage",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php72/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
             "name": "symfony/polyfill-php80",
             "version": "v1.31.0",
             "source": {
@@ -3473,6 +4543,82 @@
                 }
             ],
             "time": "2024-09-25T14:20:29+00:00"
+        },
+        {
+            "name": "symfony/var-exporter",
+            "version": "v7.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-exporter.git",
+                "reference": "1a6a89f95a46af0f142874c9d650a6358d13070d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/1a6a89f95a46af0f142874c9d650a6358d13070d",
+                "reference": "1a6a89f95a46af0f142874c9d650a6358d13070d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "symfony/property-access": "^6.4|^7.0",
+                "symfony/serializer": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\VarExporter\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows exporting any serializable PHP data structure to plain PHP code",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clone",
+                "construct",
+                "export",
+                "hydrate",
+                "instantiate",
+                "lazy-loading",
+                "proxy",
+                "serialize"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/var-exporter/tree/v7.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-10-18T07:58:17+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -5966,12 +7112,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.1"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/galette/includes/dependencies.php
+++ b/galette/includes/dependencies.php
@@ -63,7 +63,7 @@ $container->set(
             $dbParams['charset'] = 'utf8mb4';
         }
 
-        $evm = new \Doctrine\Common\EventManager;
+        $evm = new \Doctrine\Common\EventManager();
 
         // Table Prefix
         $tablePrefix = new \Galette\ORM\TablePrefix(PREFIX_DB);

--- a/galette/includes/dependencies.php
+++ b/galette/includes/dependencies.php
@@ -73,6 +73,10 @@ $container->set(
         $evm->addEventListener(\Doctrine\ORM\Tools\ToolEvents::postGenerateSchema, $tablePrefix);
 
         $config = \Doctrine\ORM\ORMSetup::createAttributeMetadataConfiguration($paths, $isDevMode);
+        //FIXME: should be correct with DBAL v4, will use serial before (I prefer to keep sequences)
+        /*$config->setIdentityGenerationPreferences([
+            \Doctrine\DBAL\Platforms\PostgreSQLPlatform::class => \Doctrine\ORM\Mapping\ClassMetadataInfo::GENERATOR_TYPE_IDENTITY,
+        ]);*/
         $connection = \Doctrine\DBAL\DriverManager::getConnection($dbParams, $config);
         $entityManager = new \Doctrine\ORM\EntityManager($connection, $config, $evm);
         return $entityManager;

--- a/galette/includes/dependencies.php
+++ b/galette/includes/dependencies.php
@@ -73,10 +73,14 @@ $container->set(
         $evm->addEventListener(\Doctrine\ORM\Tools\ToolEvents::postGenerateSchema, $tablePrefix);
 
         $config = \Doctrine\ORM\ORMSetup::createAttributeMetadataConfiguration($paths, $isDevMode);
-        //FIXME: should be correct with DBAL v4, will use serial before (I prefer to keep sequences)
-        /*$config->setIdentityGenerationPreferences([
-            \Doctrine\DBAL\Platforms\PostgreSQLPlatform::class => \Doctrine\ORM\Mapping\ClassMetadataInfo::GENERATOR_TYPE_IDENTITY,
-        ]);*/
+        //FIXME: to remove. Temporary filter form ORM to work only with "PREFIX_DB_orm" tables
+        $config->setSchemaAssetsFilter(function (string|\Doctrine\DBAL\Schema\AbstractAsset $assetName): bool {
+            if ($assetName instanceof \Doctrine\DBAL\Schema\AbstractAsset) {
+                $assetName = $assetName->getName();
+            }
+
+            return str_starts_with($assetName, PREFIX_DB . '_orm_');
+        });
         $connection = \Doctrine\DBAL\DriverManager::getConnection($dbParams, $config);
         $entityManager = new \Doctrine\ORM\EntityManager($connection, $config, $evm);
         return $entityManager;

--- a/galette/lib/Galette/Entity/Adherent.php
+++ b/galette/lib/Galette/Entity/Adherent.php
@@ -26,6 +26,9 @@ namespace Galette\Entity;
 use ArrayObject;
 use DateInterval;
 use DateTime;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\ManyToOne;
 use Galette\Core\I18n;
 use Galette\Events\GaletteEvent;
 use Galette\Features\HasEvent;
@@ -109,6 +112,8 @@ use Galette\Features\Dynamics;
  * @property-read bool $self_adh
  * @property ?string $region
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'orm_adherents')]
 class Adherent
 {
     use Dynamics;
@@ -129,19 +134,44 @@ class Adherent
     public const AFTER_ADD_LIST = 4;
     public const AFTER_ADD_HOME = 5;
 
+    #[ORM\Id]
+    #[ORM\Column(name: 'id_adh', type: 'integer', options: ['unsigned' => true])]
+    #[ORM\GeneratedValue]
     private ?int $id;
     //Identity
+    #[ORM\Column(name: 'titre_adh', type: 'integer', options: ['unsigned' => true])]
     private Title|string|null $title = null; //@phpstan-ignore-line
+    #[ORM\Column(name: 'societe_adh', type: 'string', length: 200, nullable: true)]
     private ?string $company_name;
+    #[ORM\Column(name: 'nom_adh', type: 'string', length: 50)]
     private ?string $name;
+    #[ORM\Column(name: 'prenom_adh', type: 'string', length: 50)]
     private ?string $surname;
+    #[ORM\Column(name: 'pseudo_adh', type: 'string', length: 20)]
     private ?string $nickname;
+    #[ORM\Column(name: 'ddn_adh', type: 'date')]
     private ?string $birthdate;
+    #[ORM\Column(name: 'lieu_naissance', type: 'string', length: 65536)]
     private ?string $birth_place;
+    #[ORM\Column(name: 'sexe_adh', type: 'smallint')]
     private int $gender;
+    #[ORM\Column(name: 'prof_adh', type: 'string', length: 150)]
     private ?string $job;
+    #[ORM\Column(name: 'pref_lang', type: 'string', length: 20)]
     private string $language;
+    #[ORM\Column(name: 'activite_adh', type: 'boolean')]
     private bool $active;
+    #[ManyToOne(targetEntity: Status::class)]
+    #[JoinColumn(
+        name: 'id_statut',
+        referencedColumnName: 'id_statut',
+        onDelete: 'restrict',
+        nullable: false,
+        options: [
+            'default' => 4,
+            'unsigned' => true
+        ]
+    )]
     private int $status;
     //Contact information
     private ?string $address = null;

--- a/galette/lib/Galette/Entity/Adherent.php
+++ b/galette/lib/Galette/Entity/Adherent.php
@@ -26,6 +26,7 @@ namespace Galette\Entity;
 use ArrayObject;
 use DateInterval;
 use DateTime;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Galette\Core\I18n;
 use Galette\Events\GaletteEvent;
@@ -133,7 +134,7 @@ class Adherent
     public const AFTER_ADD_HOME = 5;
 
     #[ORM\Id]
-    #[ORM\Column(name: 'id_adh', type: 'integer', options: ['unsigned' => true])]
+    #[ORM\Column(name: 'id_adh', type: Types::INTEGER, options: ['unsigned' => true])]
     #[ORM\GeneratedValue]
     private ?int $id;
     //Identity
@@ -148,25 +149,25 @@ class Adherent
         ]
     )]
     private Title|string|null $title = null;
-    #[ORM\Column(name: 'societe_adh', type: 'string', length: 200, nullable: true)]
+    #[ORM\Column(name: 'societe_adh', type: Types::STRING, length: 200, nullable: true)]
     private ?string $company_name;
-    #[ORM\Column(name: 'nom_adh', type: 'string', length: 50, options: ['default' => ''])]
+    #[ORM\Column(name: 'nom_adh', type: Types::STRING, length: 50, options: ['default' => ''])]
     private ?string $name;
-    #[ORM\Column(name: 'prenom_adh', type: 'string', length: 50, options: ['default' => ''])]
+    #[ORM\Column(name: 'prenom_adh', type: Types::STRING, length: 50, options: ['default' => ''])]
     private ?string $surname;
-    #[ORM\Column(name: 'pseudo_adh', type: 'string', length: 20, options: ['default' => ''])]
+    #[ORM\Column(name: 'pseudo_adh', type: Types::STRING, length: 20, options: ['default' => ''])]
     private ?string $nickname;
-    #[ORM\Column(name: 'ddn_adh', type: 'date')]
+    #[ORM\Column(name: 'ddn_adh', type: Types::DATE_MUTABLE)]
     private ?string $birthdate;
-    #[ORM\Column(name: 'lieu_naissance', type: 'text')]
+    #[ORM\Column(name: 'lieu_naissance', type: Types::TEXT)]
     private ?string $birth_place;
-    #[ORM\Column(name: 'sexe_adh', type: 'smallint')]
+    #[ORM\Column(name: 'sexe_adh', type: Types::SMALLINT)]
     private int $gender;
-    #[ORM\Column(name: 'prof_adh', type: 'string', length: 150, nullable: true)]
+    #[ORM\Column(name: 'prof_adh', type: Types::STRING, length: 150, nullable: true)]
     private ?string $job;
-    #[ORM\Column(name: 'pref_lang', type: 'string', length: 20)]
+    #[ORM\Column(name: 'pref_lang', type: Types::STRING, length: 20)]
     private string $language;
-    #[ORM\Column(name: 'activite_adh', type: 'boolean', options: ['default' => false])]
+    #[ORM\Column(name: 'activite_adh', type: Types::BOOLEAN, options: ['default' => false])]
     private bool $active;
     #[ORM\ManyToOne(targetEntity: Status::class)]
     #[ORM\JoinColumn(
@@ -181,47 +182,47 @@ class Adherent
     )]
     private int $status;
     //Contact information
-    #[ORM\Column(name: 'adresse_adh', type: 'text')]
+    #[ORM\Column(name: 'adresse_adh', type: Types::TEXT)]
     private ?string $address = null;
-    #[ORM\Column(name: 'cp_adh', type: 'string', length: 10, options: ['default' => ''])]
+    #[ORM\Column(name: 'cp_adh', type: Types::STRING, length: 10, options: ['default' => ''])]
     private ?string $zipcode = null;
-    #[ORM\Column(name: 'ville_adh', type: 'string', length: 200, options: ['default' => ''])]
+    #[ORM\Column(name: 'ville_adh', type: Types::STRING, length: 200, options: ['default' => ''])]
     private ?string $town = null;
-    #[ORM\Column(name: 'region_adh', type: 'string', length: 200, options: ['default' => ''])]
+    #[ORM\Column(name: 'region_adh', type: Types::STRING, length: 200, options: ['default' => ''])]
     private ?string $region = null;
-    #[ORM\Column(name: 'pays_adh', type: 'string', length: 200, nullable: true)]
+    #[ORM\Column(name: 'pays_adh', type: Types::STRING, length: 200, nullable: true)]
     private ?string $country = null;
-    #[ORM\Column(name: 'tel_adh', type: 'string', length: 50, nullable: true)]
+    #[ORM\Column(name: 'tel_adh', type: Types::STRING, length: 50, nullable: true)]
     private ?string $phone;
-    #[ORM\Column(name: 'gsm_adh', type: 'string', length: 50, nullable: true)]
+    #[ORM\Column(name: 'gsm_adh', type: Types::STRING, length: 50, nullable: true)]
     private ?string $gsm;
-    #[ORM\Column(name: 'email_adh', type: 'string', length: 255, nullable: true)]
+    #[ORM\Column(name: 'email_adh', type: Types::STRING, length: 255, nullable: true)]
     private ?string $email;
-    #[ORM\Column(name: 'gpgid', type: 'text', nullable: true)]
+    #[ORM\Column(name: 'gpgid', type: Types::TEXT, nullable: true)]
     private ?string $gnupgid;
-    #[ORM\Column(name: 'fingerprint', type: 'string', length: 255, nullable: true)]
+    #[ORM\Column(name: 'fingerprint', type: Types::STRING, length: 255, nullable: true)]
     private ?string $fingerprint;
     //Galette relative information
-    #[ORM\Column(name: 'bool_display_info', type: 'boolean', options: ['default' => false])]
+    #[ORM\Column(name: 'bool_display_info', type: Types::BOOLEAN, options: ['default' => false])]
     private bool $appears_in_list;
-    #[ORM\Column(name: 'bool_admin_adh', type: 'boolean', options: ['default' => false])]
+    #[ORM\Column(name: 'bool_admin_adh', type: Types::BOOLEAN, options: ['default' => false])]
     private bool $admin;
     private bool $staff = false;
-    #[ORM\Column(name: 'bool_exempt_adh', type: 'boolean', options: ['default' => false])]
+    #[ORM\Column(name: 'bool_exempt_adh', type: Types::BOOLEAN, options: ['default' => false])]
     private bool $due_free;
-    #[ORM\Column(name: 'login_adh', type: 'string', length: 200, options: ['default' => ''])]
+    #[ORM\Column(name: 'login_adh', type: Types::STRING, length: 200, options: ['default' => ''])]
     private ?string $login;
-    #[ORM\Column(name: 'mdp_adh', type: 'string', length: 255, options: ['default' => ''])]
+    #[ORM\Column(name: 'mdp_adh', type: Types::STRING, length: 255, options: ['default' => ''])]
     private ?string $password;
-    #[ORM\Column(name: 'date_crea_adh', type: 'date')]
+    #[ORM\Column(name: 'date_crea_adh', type: Types::DATE_MUTABLE)]
     private string $creation_date;
-    #[ORM\Column(name: 'date_modif_adh', type: 'date')]
+    #[ORM\Column(name: 'date_modif_adh', type: Types::DATE_MUTABLE)]
     private string $modification_date;
-    #[ORM\Column(name: 'date_echeance', type: 'date', nullable: true)]
+    #[ORM\Column(name: 'date_echeance', type: Types::DATE_MUTABLE, nullable: true)]
     private ?string $due_date;
-    #[ORM\Column(name: 'info_public_adh', type: 'text')]
+    #[ORM\Column(name: 'info_public_adh', type: Types::TEXT)]
     private ?string $others_infos;
-    #[ORM\Column(name: 'info_adh', type: 'text')]
+    #[ORM\Column(name: 'info_adh', type: Types::TEXT)]
     private ?string $others_infos_admin;
     private ?Picture $picture = null;
     private int $oldness;
@@ -238,7 +239,7 @@ class Adherent
     private bool $duplicate = false;
     /** @var array<int,Social> */
     private array $socials;
-    #[ORM\Column(name: 'num_adh', type: 'string', length: 255, nullable: true)]
+    #[ORM\Column(name: 'num_adh', type: Types::STRING, length: 255, nullable: true)]
     private ?string $number = null;
 
     private string $row_classes;

--- a/galette/lib/Galette/Entity/Adherent.php
+++ b/galette/lib/Galette/Entity/Adherent.php
@@ -166,7 +166,7 @@ class Adherent
     private ?string $job;
     #[ORM\Column(name: 'pref_lang', type: 'string', length: 20)]
     private string $language;
-    #[ORM\Column(name: 'activite_adh', type: 'boolean')]
+    #[ORM\Column(name: 'activite_adh', type: 'boolean', options: ['default' => false])]
     private bool $active;
     #[ORM\ManyToOne(targetEntity: Status::class)]
     #[ORM\JoinColumn(
@@ -181,26 +181,47 @@ class Adherent
     )]
     private int $status;
     //Contact information
+    #[ORM\Column(name: 'adresse_adh', type: 'text')]
     private ?string $address = null;
+    #[ORM\Column(name: 'cp_adh', type: 'string', length: 10, options: ['default' => ''])]
     private ?string $zipcode = null;
+    #[ORM\Column(name: 'ville_adh', type: 'string', length: 200, options: ['default' => ''])]
     private ?string $town = null;
+    #[ORM\Column(name: 'region_adh', type: 'string', length: 200, options: ['default' => ''])]
+    private ?string $region = null;
+    #[ORM\Column(name: 'pays_adh', type: 'string', length: 200, nullable: true)]
     private ?string $country = null;
+    #[ORM\Column(name: 'tel_adh', type: 'string', length: 50, nullable: true)]
     private ?string $phone;
+    #[ORM\Column(name: 'gsm_adh', type: 'string', length: 50, nullable: true)]
     private ?string $gsm;
+    #[ORM\Column(name: 'email_adh', type: 'string', length: 255, nullable: true)]
     private ?string $email;
+    #[ORM\Column(name: 'gpgid', type: 'text', nullable: true)]
     private ?string $gnupgid;
+    #[ORM\Column(name: 'fingerprint', type: 'string', length: 255, nullable: true)]
     private ?string $fingerprint;
     //Galette relative information
+    #[ORM\Column(name: 'bool_display_info', type: 'boolean', options: ['default' => false])]
     private bool $appears_in_list;
+    #[ORM\Column(name: 'bool_admin_adh', type: 'boolean', options: ['default' => false])]
     private bool $admin;
     private bool $staff = false;
+    #[ORM\Column(name: 'bool_exempt_adh', type: 'boolean', options: ['default' => false])]
     private bool $due_free;
+    #[ORM\Column(name: 'login_adh', type: 'string', length: 200, options: ['default' => ''])]
     private ?string $login;
+    #[ORM\Column(name: 'mdp_adh', type: 'string', length: 255, options: ['default' => ''])]
     private ?string $password;
+    #[ORM\Column(name: 'date_crea_adh', type: 'date')]
     private string $creation_date;
+    #[ORM\Column(name: 'date_modif_adh', type: 'date')]
     private string $modification_date;
+    #[ORM\Column(name: 'date_echeance', type: 'date', nullable: true)]
     private ?string $due_date;
+    #[ORM\Column(name: 'info_public_adh', type: 'text')]
     private ?string $others_infos;
+    #[ORM\Column(name: 'info_adh', type: 'text')]
     private ?string $others_infos_admin;
     private ?Picture $picture = null;
     private int $oldness;
@@ -215,8 +236,8 @@ class Adherent
     private bool $duplicate = false;
     /** @var array<int,Social> */
     private array $socials;
+    #[ORM\Column(name: 'num_adh', type: 'string', length: 255, nullable: true)]
     private ?string $number = null;
-    private ?string $region = null;
 
     private string $row_classes;
 

--- a/galette/lib/Galette/Entity/Adherent.php
+++ b/galette/lib/Galette/Entity/Adherent.php
@@ -135,8 +135,6 @@ class Adherent
     #[ORM\Id]
     #[ORM\Column(name: 'id_adh', type: 'integer', options: ['unsigned' => true])]
     #[ORM\GeneratedValue]
-    //FIXME: does not works :/
-    //#[ORM\SequenceGenerator(sequenceName: 'galette_adherents_id_seq', initialValue: 1)]
     private ?int $id;
     //Identity
     #[ORM\ManyToOne(targetEntity: Title::class)]

--- a/galette/lib/Galette/Entity/Adherent.php
+++ b/galette/lib/Galette/Entity/Adherent.php
@@ -170,8 +170,8 @@ class Adherent
     private bool $active;
     #[ORM\ManyToOne(targetEntity: Status::class)]
     #[ORM\JoinColumn(
-        name: 'id_statut',
-        referencedColumnName: 'id_statut',
+        name: Status::PK,
+        referencedColumnName: Status::PK,
         nullable: false,
         onDelete: 'restrict',
         options: [

--- a/galette/lib/Galette/Entity/Adherent.php
+++ b/galette/lib/Galette/Entity/Adherent.php
@@ -135,25 +135,36 @@ class Adherent
     #[ORM\Id]
     #[ORM\Column(name: 'id_adh', type: 'integer', options: ['unsigned' => true])]
     #[ORM\GeneratedValue]
+    //FIXME: does not works :/
+    //#[ORM\SequenceGenerator(sequenceName: 'galette_adherents_id_seq', initialValue: 1)]
     private ?int $id;
     //Identity
-    #[ORM\Column(name: 'titre_adh', type: 'integer', options: ['unsigned' => true])]
-    private Title|string|null $title = null; //@phpstan-ignore-line
+    #[ORM\ManyToOne(targetEntity: Title::class)]
+    #[ORM\JoinColumn(
+        name: 'titre_adh',
+        referencedColumnName: Title::PK,
+        nullable: true,
+        onDelete: 'restrict',
+        options: [
+            'unsigned' => true
+        ]
+    )]
+    private Title|string|null $title = null;
     #[ORM\Column(name: 'societe_adh', type: 'string', length: 200, nullable: true)]
     private ?string $company_name;
-    #[ORM\Column(name: 'nom_adh', type: 'string', length: 50)]
+    #[ORM\Column(name: 'nom_adh', type: 'string', length: 50, options: ['default' => ''])]
     private ?string $name;
-    #[ORM\Column(name: 'prenom_adh', type: 'string', length: 50)]
+    #[ORM\Column(name: 'prenom_adh', type: 'string', length: 50, options: ['default' => ''])]
     private ?string $surname;
-    #[ORM\Column(name: 'pseudo_adh', type: 'string', length: 20)]
+    #[ORM\Column(name: 'pseudo_adh', type: 'string', length: 20, options: ['default' => ''])]
     private ?string $nickname;
     #[ORM\Column(name: 'ddn_adh', type: 'date')]
     private ?string $birthdate;
-    #[ORM\Column(name: 'lieu_naissance', type: 'string', length: 65536)]
+    #[ORM\Column(name: 'lieu_naissance', type: 'text')]
     private ?string $birth_place;
     #[ORM\Column(name: 'sexe_adh', type: 'smallint')]
     private int $gender;
-    #[ORM\Column(name: 'prof_adh', type: 'string', length: 150)]
+    #[ORM\Column(name: 'prof_adh', type: 'string', length: 150, nullable: true)]
     private ?string $job;
     #[ORM\Column(name: 'pref_lang', type: 'string', length: 20)]
     private string $language;

--- a/galette/lib/Galette/Entity/Adherent.php
+++ b/galette/lib/Galette/Entity/Adherent.php
@@ -27,8 +27,6 @@ use ArrayObject;
 use DateInterval;
 use DateTime;
 use Doctrine\ORM\Mapping as ORM;
-use Doctrine\ORM\Mapping\JoinColumn;
-use Doctrine\ORM\Mapping\ManyToOne;
 use Galette\Core\I18n;
 use Galette\Events\GaletteEvent;
 use Galette\Features\HasEvent;
@@ -161,12 +159,12 @@ class Adherent
     private string $language;
     #[ORM\Column(name: 'activite_adh', type: 'boolean')]
     private bool $active;
-    #[ManyToOne(targetEntity: Status::class)]
-    #[JoinColumn(
+    #[ORM\ManyToOne(targetEntity: Status::class)]
+    #[ORM\JoinColumn(
         name: 'id_statut',
         referencedColumnName: 'id_statut',
-        onDelete: 'restrict',
         nullable: false,
+        onDelete: 'restrict',
         options: [
             'default' => 4,
             'unsigned' => true

--- a/galette/lib/Galette/Entity/Contribution.php
+++ b/galette/lib/Galette/Entity/Contribution.php
@@ -92,17 +92,58 @@ class Contribution
 
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(name: self::PK, type: 'integer')]
+    #[ORM\Column(name: self::PK, type: 'integer', options: ['unsigned' => true])]
     private int $id;
+    #[ORM\Column(name: 'date_enreg', type: 'date')]
     private ?string $date = null;
+    #[ORM\ManyToOne(targetEntity: Adherent::class)]
+    #[ORM\JoinColumn(
+        name: Adherent::PK,
+        referencedColumnName: Adherent::PK,
+        onDelete: 'restrict',
+        options: [
+            'unsigned' => true
+        ]
+    )]
     private ?int $member = null;
+    #[ORM\ManyToOne(targetEntity: ContributionsTypes::class)]
+    #[ORM\JoinColumn(
+        name: ContributionsTypes::PK,
+        referencedColumnName: ContributionsTypes::PK,
+        onDelete: 'restrict',
+        options: [
+            'unsigned' => true
+        ]
+    )]
     private ?ContributionsTypes $type = null;
+    #[ORM\Column(name: 'montant_cotis', type: 'decimal', precision: 15, scale: 2)]
     private ?float $amount = null;
+    #[ORM\ManyToOne(targetEntity: PaymentType::class)]
+    #[ORM\JoinColumn(
+        name: 'type_paiement_cotis',
+        referencedColumnName: PaymentType::PK,
+        onDelete: 'restrict',
+        options: [
+            'unsigned' => true
+        ]
+    )]
     private ?int $payment_type;
     private ?float $orig_amount = null;
+    #[ORM\Column(name: 'info_cotis', type: 'text')]
     private ?string $info = null;
+    #[ORM\Column(name: 'date_debut_cotis', type: 'date')]
     private ?string $begin_date = null;
+    #[ORM\Column(name: 'date_fin_cotis', type: 'date')]
     private ?string $end_date = null;
+    #[ORM\ManyToOne(targetEntity: Transaction::class)]
+    #[ORM\JoinColumn(
+        name: Transaction::PK,
+        referencedColumnName: Transaction::PK,
+        onDelete: 'restrict',
+        options: [
+            'unsigned' => true
+        ]
+    )]
     private ?Transaction $transaction = null;
     private bool $is_cotis;
     private ?int $extension = null;

--- a/galette/lib/Galette/Entity/Contribution.php
+++ b/galette/lib/Galette/Entity/Contribution.php
@@ -93,8 +93,6 @@ class Contribution
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(name: self::PK, type: 'integer')]
-    //FIXME: does not works :/
-    //#[ORM\SequenceGenerator(sequenceName: 'galette_cotisations_id_seq', initialValue: 1)]
     private int $id;
     private ?string $date = null;
     private ?int $member = null;

--- a/galette/lib/Galette/Entity/Contribution.php
+++ b/galette/lib/Galette/Entity/Contribution.php
@@ -26,6 +26,7 @@ namespace Galette\Entity;
 use ArrayObject;
 use DateInterval;
 use DateTime;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Galette\Events\GaletteEvent;
 use Galette\Features\HasEvent;
@@ -92,9 +93,9 @@ class Contribution
 
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(name: self::PK, type: 'integer', options: ['unsigned' => true])]
+    #[ORM\Column(name: self::PK, type: Types::INTEGER, options: ['unsigned' => true])]
     private int $id;
-    #[ORM\Column(name: 'date_enreg', type: 'date')]
+    #[ORM\Column(name: 'date_enreg', type: Types::DATE_MUTABLE)]
     private ?string $date = null;
     #[ORM\ManyToOne(targetEntity: Adherent::class)]
     #[ORM\JoinColumn(onDelete: 'restrict')]
@@ -102,7 +103,7 @@ class Contribution
     #[ORM\ManyToOne(targetEntity: ContributionsTypes::class)]
     #[ORM\JoinColumn(onDelete: 'restrict')]
     private ?ContributionsTypes $type = null;
-    #[ORM\Column(name: 'montant_cotis', type: 'decimal', precision: 15, scale: 2)]
+    #[ORM\Column(name: 'montant_cotis', type: Types::DECIMAL, precision: 15, scale: 2)]
     private ?float $amount = null;
     #[ORM\ManyToOne(targetEntity: PaymentType::class)]
     #[ORM\JoinColumn(
@@ -115,11 +116,11 @@ class Contribution
     )]
     private ?int $payment_type;
     private ?float $orig_amount = null;
-    #[ORM\Column(name: 'info_cotis', type: 'text')]
+    #[ORM\Column(name: 'info_cotis', type: Types::TEXT)]
     private ?string $info = null;
-    #[ORM\Column(name: 'date_debut_cotis', type: 'date')]
+    #[ORM\Column(name: 'date_debut_cotis', type: Types::DATE_MUTABLE)]
     private ?string $begin_date = null;
-    #[ORM\Column(name: 'date_fin_cotis', type: 'date')]
+    #[ORM\Column(name: 'date_fin_cotis', type: Types::DATE_MUTABLE)]
     private ?string $end_date = null;
     #[ORM\ManyToOne(targetEntity: Transaction::class)]
     #[ORM\JoinColumn(

--- a/galette/lib/Galette/Entity/Contribution.php
+++ b/galette/lib/Galette/Entity/Contribution.php
@@ -97,24 +97,10 @@ class Contribution
     #[ORM\Column(name: 'date_enreg', type: 'date')]
     private ?string $date = null;
     #[ORM\ManyToOne(targetEntity: Adherent::class)]
-    #[ORM\JoinColumn(
-        name: Adherent::PK,
-        referencedColumnName: Adherent::PK,
-        onDelete: 'restrict',
-        options: [
-            'unsigned' => true
-        ]
-    )]
+    #[ORM\JoinColumn(onDelete: 'restrict')]
     private ?int $member = null;
     #[ORM\ManyToOne(targetEntity: ContributionsTypes::class)]
-    #[ORM\JoinColumn(
-        name: ContributionsTypes::PK,
-        referencedColumnName: ContributionsTypes::PK,
-        onDelete: 'restrict',
-        options: [
-            'unsigned' => true
-        ]
-    )]
+    #[ORM\JoinColumn(onDelete: 'restrict')]
     private ?ContributionsTypes $type = null;
     #[ORM\Column(name: 'montant_cotis', type: 'decimal', precision: 15, scale: 2)]
     private ?float $amount = null;

--- a/galette/lib/Galette/Entity/Contribution.php
+++ b/galette/lib/Galette/Entity/Contribution.php
@@ -26,6 +26,7 @@ namespace Galette\Entity;
 use ArrayObject;
 use DateInterval;
 use DateTime;
+use Doctrine\ORM\Mapping as ORM;
 use Galette\Events\GaletteEvent;
 use Galette\Features\HasEvent;
 use Throwable;
@@ -64,6 +65,8 @@ use Galette\Helpers\EntityHelper;
  * @property integer $model
  * @property array<string, array<string, string>> $fields
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'orm_cotisations')]
 class Contribution
 {
     use Dynamics;
@@ -87,6 +90,11 @@ class Contribution
     public const STATUS_LATE = 4;
     public const STATUS_OLD = 5;
 
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(name: self::PK, type: 'integer')]
+    //FIXME: does not works :/
+    //#[ORM\SequenceGenerator(sequenceName: 'galette_cotisations_id_seq', initialValue: 1)]
     private int $id;
     private ?string $date = null;
     private ?int $member = null;

--- a/galette/lib/Galette/Entity/ContributionsTypes.php
+++ b/galette/lib/Galette/Entity/ContributionsTypes.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Galette\Entity;
 
 use Analog\Analog;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Galette\Core\Db;
 use ArrayObject;
@@ -59,13 +60,13 @@ class ContributionsTypes
 
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(name: self::PK, type: 'integer', options: ['unsigned' => true])]
+    #[ORM\Column(name: self::PK, type: Types::INTEGER, options: ['unsigned' => true])]
     private int $id;
-    #[ORM\Column(name: 'libelle_type_cotis', type: 'string', length: 255, options: ['default' => ''])]
+    #[ORM\Column(name: 'libelle_type_cotis', type: Types::STRING, length: 255, options: ['default' => ''])]
     private string $label;
-    #[ORM\Column(name: 'amount', type: 'decimal', precision: 15, scale: 2, nullable: true)]
+    #[ORM\Column(name: 'amount', type: Types::DECIMAL, precision: 15, scale: 2, nullable: true)]
     private ?float $amount; //@phpstan-ignore-line
-    #[ORM\Column(name: 'cotis_extension', type: 'integer', options: ['default' => 0])]
+    #[ORM\Column(name: 'cotis_extension', type: Types::INTEGER, options: ['default' => 0])]
     private int $extension;
 
     public const ID_NOT_EXITS = -1;

--- a/galette/lib/Galette/Entity/ContributionsTypes.php
+++ b/galette/lib/Galette/Entity/ContributionsTypes.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Galette\Entity;
 
 use Analog\Analog;
+use Doctrine\ORM\Mapping as ORM;
 use Galette\Core\Db;
 use ArrayObject;
 use Galette\Features\I18n;
@@ -42,6 +43,8 @@ use Throwable;
  * @property int $extension
  */
 
+#[ORM\Entity]
+#[ORM\Table(name: 'orm_types_cotisation')]
 class ContributionsTypes
 {
     use I18n;
@@ -54,9 +57,17 @@ class ContributionsTypes
 
     private Db $zdb;
 
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(name: self::PK, type: 'integer', options: ['unsigned' => true])]
+    //FIXME: does not works :/
+    //#[ORM\SequenceGenerator(sequenceName: 'galette_types_cotisation_id_seq', initialValue: 1)]
     private int $id;
+    #[ORM\Column(name: 'libelle_type_cotis', type: 'string', length: 255, options: ['default' => ''])]
     private string $label;
+    #[ORM\Column(name: 'amount', type: 'decimal', precision: 15, scale: 2, nullable: true)]
     private ?float $amount; //@phpstan-ignore-line
+    #[ORM\Column(name: 'cotis_extension', type: 'integer', options: ['default' => 0])]
     private int $extension;
 
     public const ID_NOT_EXITS = -1;

--- a/galette/lib/Galette/Entity/ContributionsTypes.php
+++ b/galette/lib/Galette/Entity/ContributionsTypes.php
@@ -60,8 +60,6 @@ class ContributionsTypes
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(name: self::PK, type: 'integer', options: ['unsigned' => true])]
-    //FIXME: does not works :/
-    //#[ORM\SequenceGenerator(sequenceName: 'galette_types_cotisation_id_seq', initialValue: 1)]
     private int $id;
     #[ORM\Column(name: 'libelle_type_cotis', type: 'string', length: 255, options: ['default' => ''])]
     private string $label;

--- a/galette/lib/Galette/Entity/PaymentType.php
+++ b/galette/lib/Galette/Entity/PaymentType.php
@@ -57,7 +57,7 @@ class PaymentType
     //#[ORM\SequenceGenerator(sequenceName: 'galette_paymenttypes_id_seq', initialValue: 1)]
     private int $id;
     #[ORM\Column(name: 'type_name', type: 'string', length: 255)]
-    protected ?string $name;
+    protected ?string $name = null;
 
     public const SCHEDULED = 7;
     public const OTHER = 6;

--- a/galette/lib/Galette/Entity/PaymentType.php
+++ b/galette/lib/Galette/Entity/PaymentType.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Galette\Entity;
 
 use ArrayObject;
+use Doctrine\ORM\Mapping as ORM;
 use Throwable;
 use Galette\Core\Db;
 use Analog\Analog;
@@ -38,7 +39,8 @@ use Galette\Features\Translatable;
  * @property integer $id
  * @property string $name
  */
-
+#[ORM\Entity]
+#[ORM\Table(name: 'orm_paymenttypes')]
 class PaymentType
 {
     use Translatable;
@@ -48,7 +50,14 @@ class PaymentType
     public const PK = 'type_id';
 
     private Db $zdb;
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(name: self::PK, type: 'integer')]
+    //FIXME: does not works :/
+    //#[ORM\SequenceGenerator(sequenceName: 'galette_paymenttypes_id_seq', initialValue: 1)]
     private int $id;
+    #[ORM\Column(name: 'type_name', type: 'string', length: 255)]
+    protected ?string $name;
 
     public const SCHEDULED = 7;
     public const OTHER = 6;

--- a/galette/lib/Galette/Entity/PaymentType.php
+++ b/galette/lib/Galette/Entity/PaymentType.php
@@ -53,8 +53,6 @@ class PaymentType
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(name: self::PK, type: 'integer')]
-    //FIXME: does not works :/
-    //#[ORM\SequenceGenerator(sequenceName: 'galette_paymenttypes_id_seq', initialValue: 1)]
     private int $id;
     #[ORM\Column(name: 'type_name', type: 'string', length: 255)]
     protected ?string $name = null;

--- a/galette/lib/Galette/Entity/PaymentType.php
+++ b/galette/lib/Galette/Entity/PaymentType.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Galette\Entity;
 
 use ArrayObject;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Throwable;
 use Galette\Core\Db;
@@ -52,9 +53,9 @@ class PaymentType
     private Db $zdb;
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(name: self::PK, type: 'integer', options: ['unsigned' => true])]
+    #[ORM\Column(name: self::PK, type: Types::INTEGER, options: ['unsigned' => true])]
     private int $id;
-    #[ORM\Column(name: 'type_name', type: 'string', length: 255)]
+    #[ORM\Column(name: 'type_name', type: Types::STRING, length: 255)]
     protected ?string $name = null;
 
     public const SCHEDULED = 7;

--- a/galette/lib/Galette/Entity/PaymentType.php
+++ b/galette/lib/Galette/Entity/PaymentType.php
@@ -52,7 +52,7 @@ class PaymentType
     private Db $zdb;
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(name: self::PK, type: 'integer')]
+    #[ORM\Column(name: self::PK, type: 'integer', options: ['unsigned' => true])]
     private int $id;
     #[ORM\Column(name: 'type_name', type: 'string', length: 255)]
     protected ?string $name = null;

--- a/galette/lib/Galette/Entity/PdfModel.php
+++ b/galette/lib/Galette/Entity/PdfModel.php
@@ -54,7 +54,6 @@ use Laminas\Db\Sql\Expression;
  * @property-read string $hbody
  * @property string $styles
  * @property string $hstyles
- * @property ?integer $parent_id
  * @property PdfMain $parent
  */
 #[ORM\Entity]
@@ -93,7 +92,6 @@ abstract class PdfModel
     private ?string $styles = '';
     #[ORM\OneToOne(targetEntity: self::class)]
     #[ORM\JoinColumn(name: 'model_parent', referencedColumnName: self::PK)]
-    private ?int $parent_id = null;
     private ?PdfModel $parent = null;
 
     /**

--- a/galette/lib/Galette/Entity/PdfModel.php
+++ b/galette/lib/Galette/Entity/PdfModel.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Galette\Entity;
 
 use ArrayObject;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Slim\Routing\RouteParser;
 use Throwable;
@@ -71,24 +72,24 @@ abstract class PdfModel
     public const ADHESION_FORM_MODEL = 4;
 
     #[ORM\Id]
-    #[ORM\Column(name: 'model_id', type: 'integer', options: ['unsigned' => true])]
+    #[ORM\Column(name: 'model_id', type: Types::INTEGER, options: ['unsigned' => true])]
     #[ORM\GeneratedValue]
     private ?int $id = null;
-    #[ORM\Column(name: 'model_name', type: 'string', length: 50)]
+    #[ORM\Column(name: 'model_name', type: Types::STRING, length: 50)]
     private string $name;
-    #[ORM\Column(name: 'model_type', type: 'smallint')]
+    #[ORM\Column(name: 'model_type', type: Types::SMALLINT)]
     private int $type;
-    #[ORM\Column(name: 'model_header', type: 'text')]
+    #[ORM\Column(name: 'model_header', type: Types::TEXT)]
     private ?string $header;
-    #[ORM\Column(name: 'model_footer', type: 'text')]
+    #[ORM\Column(name: 'model_footer', type: Types::TEXT)]
     private ?string $footer;
-    #[ORM\Column(name: 'model_title', type: 'string', length: 250)]
+    #[ORM\Column(name: 'model_title', type: Types::STRING, length: 250)]
     private ?string $title;
-    #[ORM\Column(name: 'model_subtitle', type: 'string', length: 250)]
+    #[ORM\Column(name: 'model_subtitle', type: Types::STRING, length: 250)]
     private ?string $subtitle;
-    #[ORM\Column(name: 'model_body', type: 'text')]
+    #[ORM\Column(name: 'model_body', type: Types::TEXT)]
     private ?string $body;
-    #[ORM\Column(name: 'model_styles', type: 'text')]
+    #[ORM\Column(name: 'model_styles', type: Types::TEXT)]
     private ?string $styles = '';
     #[ORM\OneToOne(targetEntity: self::class)]
     #[ORM\JoinColumn(name: 'model_parent', referencedColumnName: self::PK)]

--- a/galette/lib/Galette/Entity/PdfModel.php
+++ b/galette/lib/Galette/Entity/PdfModel.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Galette\Entity;
 
 use ArrayObject;
+use Doctrine\ORM\Mapping as ORM;
 use Slim\Routing\RouteParser;
 use Throwable;
 use Galette\Core\Db;
@@ -53,9 +54,11 @@ use Laminas\Db\Sql\Expression;
  * @property-read string $hbody
  * @property string $styles
  * @property string $hstyles
+ * @property ?integer $parent_id
  * @property PdfMain $parent
  */
-
+#[ORM\Entity]
+#[ORM\Table(name: 'orm_pdfmodels')]
 abstract class PdfModel
 {
     use Replacements;
@@ -68,15 +71,29 @@ abstract class PdfModel
     public const RECEIPT_MODEL = 3;
     public const ADHESION_FORM_MODEL = 4;
 
+    #[ORM\Id]
+    #[ORM\Column(name: 'model_id', type: 'integer', options: ['unsigned' => true])]
+    #[ORM\GeneratedValue]
     private ?int $id = null;
+    #[ORM\Column(name: 'model_name', type: 'string', length: 50)]
     private string $name;
+    #[ORM\Column(name: 'model_type', type: 'smallint')]
     private int $type;
+    #[ORM\Column(name: 'model_header', type: 'text')]
     private ?string $header;
+    #[ORM\Column(name: 'model_footer', type: 'text')]
     private ?string $footer;
+    #[ORM\Column(name: 'model_title', type: 'string', length: 250)]
     private ?string $title;
+    #[ORM\Column(name: 'model_subtitle', type: 'string', length: 250)]
     private ?string $subtitle;
+    #[ORM\Column(name: 'model_body', type: 'text')]
     private ?string $body;
+    #[ORM\Column(name: 'model_styles', type: 'text')]
     private ?string $styles = '';
+    #[ORM\OneToOne(targetEntity: self::class)]
+    #[ORM\JoinColumn(name: 'model_parent', referencedColumnName: self::PK)]
+    private ?int $parent_id = null;
     private ?PdfModel $parent = null;
 
     /**

--- a/galette/lib/Galette/Entity/Reminder.php
+++ b/galette/lib/Galette/Entity/Reminder.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Galette\Entity;
 
 use ArrayObject;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Galette\Features\Replacements;
 use Throwable;
@@ -54,9 +55,9 @@ class Reminder
 
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(name: self::PK, type: 'integer', options: ['unsigned' => true])]
+    #[ORM\Column(name: self::PK, type: Types::INTEGER, options: ['unsigned' => true])]
     private int $id;
-    #[ORM\Column(name: 'reminder_type', type: 'integer')]
+    #[ORM\Column(name: 'reminder_type', type: Types::INTEGER)]
     private int $type;
     #[ORM\ManyToOne(targetEntity: Adherent::class)]
     #[ORM\JoinColumn(
@@ -69,13 +70,13 @@ class Reminder
         ]
     )]
     private Adherent $dest;
-    #[ORM\Column(name: 'reminder_date', type: 'datetime')]
+    #[ORM\Column(name: 'reminder_date', type: Types::DATETIME_MUTABLE)]
     private string $date;
-    #[ORM\Column(name: 'reminder_success', type: 'boolean', options: ['default' => false])]
+    #[ORM\Column(name: 'reminder_success', type: Types::BOOLEAN, options: ['default' => false])]
     private bool $success = false;
-    #[ORM\Column(name: 'reminder_nomail', type: 'boolean', options: ['default' => true])]
+    #[ORM\Column(name: 'reminder_nomail', type: Types::BOOLEAN, options: ['default' => true])]
     private bool $nomail;
-    #[ORM\Column(name: 'reminder_comment', type: 'text')]
+    #[ORM\Column(name: 'reminder_comment', type: Types::TEXT)]
     private string $comment;
     private string $msg;
 

--- a/galette/lib/Galette/Entity/Reminder.php
+++ b/galette/lib/Galette/Entity/Reminder.php
@@ -55,8 +55,6 @@ class Reminder
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(name: self::PK, type: 'integer', options: ['unsigned' => true])]
-    //FIXME: does not works :/
-    //#[ORM\SequenceGenerator(sequenceName: 'galette_reminders_id_seq', initialValue: 1)]
     private int $id;
     #[ORM\Column(name: 'reminder_type', type: 'integer')]
     private int $type;

--- a/galette/lib/Galette/Entity/Reminder.php
+++ b/galette/lib/Galette/Entity/Reminder.php
@@ -68,7 +68,6 @@ class Reminder
             'unsigned' => true
         ]
     )]
-    private int $dest_id;
     private Adherent $dest;
     #[ORM\Column(name: 'reminder_date', type: 'datetime')]
     private string $date;
@@ -141,8 +140,7 @@ class Reminder
             $pk = self::PK;
             $this->id = (int)$rs->$pk;
             $this->type = (int)$rs->reminder_type;
-            $this->dest_id = (int)$rs->reminder_dest;
-            $this->dest = new Adherent($zdb, $this->dest_id);
+            $this->dest = new Adherent($zdb, (int)$rs->reminder_dest);
             $this->date = $rs->reminder_date;
             $this->success = $rs->reminder_success == 1;
             $this->nomail = $rs->reminder_nomail == 1;

--- a/galette/lib/Galette/Entity/SavedSearch.php
+++ b/galette/lib/Galette/Entity/SavedSearch.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Galette\Entity;
 
 use ArrayObject;
+use Doctrine\ORM\Mapping as ORM;
 use Galette\Core\Galette;
 use Throwable;
 use Galette\Core\Db;
@@ -43,18 +44,39 @@ use Analog\Analog;
  * @property string $form
  */
 
+#[ORM\Entity]
+#[ORM\Table(name: 'orm_searches')]
 class SavedSearch
 {
     public const TABLE = 'searches';
     public const PK = 'search_id';
 
     private Db $zdb;
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(name: self::PK, type: 'integer', options: ['unsigned' => true])]
+    //FIXME: does not works :/
+    //#[ORM\SequenceGenerator(sequenceName: 'galette_searches_id_seq', initialValue: 1)]
     private int $id;
+    #[ORM\Column(name: 'name', type: 'string', length: 100, nullable: true)]
     private string $name;
     /** @var array<string, mixed> */
+    #[ORM\Column(name: 'parameters', type: 'json')]
     private array $parameters = [];
+    #[ORM\ManyToOne(targetEntity: Adherent::class)]
+    #[ORM\JoinColumn(
+        name: Adherent::PK,
+        referencedColumnName: Adherent::PK,
+        nullable: false,
+        onDelete: 'restrict',
+        options: [
+            'unsigned' => true
+        ]
+    )]
     private ?int $author_id = null;
+    #[ORM\Column(name: 'creation_date', type: 'datetime')]
     private ?string $creation_date;
+    #[ORM\Column(name: 'form', type: 'string', length: 50)]
     private string $form;
 
     private Login $login;

--- a/galette/lib/Galette/Entity/SavedSearch.php
+++ b/galette/lib/Galette/Entity/SavedSearch.php
@@ -55,8 +55,6 @@ class SavedSearch
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(name: self::PK, type: 'integer', options: ['unsigned' => true])]
-    //FIXME: does not works :/
-    //#[ORM\SequenceGenerator(sequenceName: 'galette_searches_id_seq', initialValue: 1)]
     private int $id;
     #[ORM\Column(name: 'name', type: 'string', length: 100, nullable: true)]
     private string $name;

--- a/galette/lib/Galette/Entity/SavedSearch.php
+++ b/galette/lib/Galette/Entity/SavedSearch.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Galette\Entity;
 
 use ArrayObject;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Galette\Core\Galette;
 use Throwable;
@@ -54,12 +55,12 @@ class SavedSearch
     private Db $zdb;
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(name: self::PK, type: 'integer', options: ['unsigned' => true])]
+    #[ORM\Column(name: self::PK, type: Types::INTEGER, options: ['unsigned' => true])]
     private int $id;
-    #[ORM\Column(name: 'name', type: 'string', length: 100, nullable: true)]
+    #[ORM\Column(name: 'name', type: Types::STRING, length: 100, nullable: true)]
     private string $name;
     /** @var array<string, mixed> */
-    #[ORM\Column(name: 'parameters', type: 'json')]
+    #[ORM\Column(name: 'parameters', type: Types::JSON)]
     private array $parameters = [];
     #[ORM\ManyToOne(targetEntity: Adherent::class)]
     #[ORM\JoinColumn(
@@ -72,9 +73,9 @@ class SavedSearch
         ]
     )]
     private ?int $author_id = null;
-    #[ORM\Column(name: 'creation_date', type: 'datetime')]
+    #[ORM\Column(name: 'creation_date', type: Types::DATETIME_MUTABLE)]
     private ?string $creation_date;
-    #[ORM\Column(name: 'form', type: 'string', length: 50)]
+    #[ORM\Column(name: 'form', type: Types::STRING, length: 50)]
     private string $form;
 
     private Login $login;

--- a/galette/lib/Galette/Entity/ScheduledPayment.php
+++ b/galette/lib/Galette/Entity/ScheduledPayment.php
@@ -52,8 +52,6 @@ class ScheduledPayment
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(name: 'id_schedule', type: 'integer')]
-    //FIXME: does not works :/
-    //#[ORM\SequenceGenerator(sequenceName: 'galette_payments_schedules_id_seq', initialValue: 1)]
     private int $id;
     #[ORM\ManyToOne(targetEntity: Contribution::class)]
     #[ORM\JoinColumn(

--- a/galette/lib/Galette/Entity/ScheduledPayment.php
+++ b/galette/lib/Galette/Entity/ScheduledPayment.php
@@ -51,18 +51,10 @@ class ScheduledPayment
     private Db $zdb;
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(name: 'id_schedule', type: 'integer')]
+    #[ORM\Column(name: 'id_schedule', type: 'integer', options: ['unsigned' => true])]
     private int $id;
     #[ORM\ManyToOne(targetEntity: Contribution::class)]
-    #[ORM\JoinColumn(
-        name: Contribution::PK,
-        referencedColumnName: Contribution::PK,
-        nullable: false,
-        onDelete: 'cascade',
-        options: [
-            'unsigned' => true
-        ]
-    )]
+    #[ORM\JoinColumn(onDelete: 'cascade')]
     private int $id_contribution;
     private Contribution $contribution;
     #[ORM\ManyToOne(targetEntity: PaymentType::class)]

--- a/galette/lib/Galette/Entity/ScheduledPayment.php
+++ b/galette/lib/Galette/Entity/ScheduledPayment.php
@@ -25,6 +25,7 @@ namespace Galette\Entity;
 
 use ArrayObject;
 use DateTime;
+use Doctrine\ORM\Mapping as ORM;
 use Galette\Helpers\EntityHelper;
 use Laminas\Db\Sql\Expression;
 use Laminas\Db\Sql\Predicate\IsNull;
@@ -39,7 +40,8 @@ use Analog\Analog;
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>
  */
-
+#[ORM\Entity]
+#[ORM\Table(name: 'orm_payments_schedules')]
 class ScheduledPayment
 {
     use EntityHelper;
@@ -47,13 +49,45 @@ class ScheduledPayment
     public const TABLE = 'payments_schedules';
     public const PK = 'id_schedule';
     private Db $zdb;
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(name: 'id_schedule', type: 'integer')]
+    //FIXME: does not works :/
+    //#[ORM\SequenceGenerator(sequenceName: 'galette_payments_schedules_id_seq', initialValue: 1)]
     private int $id;
+    #[ORM\ManyToOne(targetEntity: Contribution::class)]
+    #[ORM\JoinColumn(
+        name: Contribution::PK,
+        referencedColumnName: Contribution::PK,
+        nullable: false,
+        onDelete: 'cascade',
+        options: [
+            'unsigned' => true
+        ]
+    )]
+    private int $id_contribution;
     private Contribution $contribution;
+    #[ORM\ManyToOne(targetEntity: PaymentType::class)]
+    #[ORM\JoinColumn(
+        name: PaymentType::PK,
+        referencedColumnName: PaymentType::PK,
+        nullable: false,
+        onDelete: 'restrict',
+        options: [
+            'unsigned' => true
+        ]
+    )]
+    private int $id_paymenttype;
     private PaymentType $payment_type;
+    #[ORM\Column(name: 'creation_date', type: 'date')]
     private string $creation_date;
+    #[ORM\Column(name: 'scheduled_date', type: 'date')]
     private string $scheduled_date;
+    #[ORM\Column(name: 'amount', type: 'decimal', precision: 15, scale: 2)]
     private float $amount;
+    #[ORM\Column(name: 'paid', type: 'boolean', options: ['default' => false])]
     private bool $is_paid = false;
+    #[ORM\Column(name: 'comment', type: 'text', nullable: true)]
     private ?string $comment = null;
     /** @var string[] */
     private array $errors = [];
@@ -124,8 +158,12 @@ class ScheduledPayment
 
         $pk = self::PK;
         $this->id = (int)$rs->$pk;
-        $this->contribution = new Contribution($this->zdb, $login, (int)$rs->{Contribution::PK});
-        $this->payment_type = new PaymentType($this->zdb, (int)$rs->id_paymenttype);
+        $this->id_contribution = (int)$rs->{Contribution::PK};
+        $this->contribution = new Contribution($this->zdb, $login, $this->id_contribution);
+        $this->id_paymenttype = (int)$rs->id_paymenttype;
+        $this->payment_type = new PaymentType($this->zdb, $this->id_paymenttype);
+        $this->id_paymenttype = $rs->id_paymenttype;
+        $this->payment_type = new PaymentType($this->zdb, $this->id_paymenttype);
         $this->creation_date = $rs->creation_date;
         $this->scheduled_date = $rs->scheduled_date;
         $this->amount = (float)$rs->amount;
@@ -322,6 +360,7 @@ class ScheduledPayment
         } else {
             $this->contribution = $contribution;
         }
+        $this->id_contribution = $this->contribution->id;
         return $this;
     }
 
@@ -364,7 +403,7 @@ class ScheduledPayment
         } else {
             $this->payment_type = $payment_type;
         }
-
+        $this->id_paymenttype = $this->payment_type->id;
         return $this;
     }
 

--- a/galette/lib/Galette/Entity/ScheduledPayment.php
+++ b/galette/lib/Galette/Entity/ScheduledPayment.php
@@ -162,8 +162,6 @@ class ScheduledPayment
         $this->contribution = new Contribution($this->zdb, $login, $this->id_contribution);
         $this->id_paymenttype = (int)$rs->id_paymenttype;
         $this->payment_type = new PaymentType($this->zdb, $this->id_paymenttype);
-        $this->id_paymenttype = $rs->id_paymenttype;
-        $this->payment_type = new PaymentType($this->zdb, $this->id_paymenttype);
         $this->creation_date = $rs->creation_date;
         $this->scheduled_date = $rs->scheduled_date;
         $this->amount = (float)$rs->amount;

--- a/galette/lib/Galette/Entity/ScheduledPayment.php
+++ b/galette/lib/Galette/Entity/ScheduledPayment.php
@@ -69,7 +69,7 @@ class ScheduledPayment
     private Contribution $contribution;
     #[ORM\ManyToOne(targetEntity: PaymentType::class)]
     #[ORM\JoinColumn(
-        name: PaymentType::PK,
+        name: 'id_paymenttype',
         referencedColumnName: PaymentType::PK,
         nullable: false,
         onDelete: 'restrict',

--- a/galette/lib/Galette/Entity/ScheduledPayment.php
+++ b/galette/lib/Galette/Entity/ScheduledPayment.php
@@ -25,6 +25,7 @@ namespace Galette\Entity;
 
 use ArrayObject;
 use DateTime;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Galette\Helpers\EntityHelper;
 use Laminas\Db\Sql\Expression;
@@ -51,7 +52,7 @@ class ScheduledPayment
     private Db $zdb;
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(name: 'id_schedule', type: 'integer', options: ['unsigned' => true])]
+    #[ORM\Column(name: 'id_schedule', type: Types::INTEGER, options: ['unsigned' => true])]
     private int $id;
     #[ORM\ManyToOne(targetEntity: Contribution::class)]
     #[ORM\JoinColumn(onDelete: 'cascade')]
@@ -67,15 +68,15 @@ class ScheduledPayment
         ]
     )]
     private PaymentType $payment_type;
-    #[ORM\Column(name: 'creation_date', type: 'date')]
+    #[ORM\Column(name: 'creation_date', type: Types::DATE_MUTABLE)]
     private string $creation_date;
-    #[ORM\Column(name: 'scheduled_date', type: 'date')]
+    #[ORM\Column(name: 'scheduled_date', type: Types::DATE_MUTABLE)]
     private string $scheduled_date;
-    #[ORM\Column(name: 'amount', type: 'decimal', precision: 15, scale: 2)]
+    #[ORM\Column(name: 'amount', type: Types::DECIMAL, precision: 15, scale: 2)]
     private float $amount;
-    #[ORM\Column(name: 'paid', type: 'boolean', options: ['default' => false])]
+    #[ORM\Column(name: 'paid', type: Types::BOOLEAN, options: ['default' => false])]
     private bool $is_paid = false;
-    #[ORM\Column(name: 'comment', type: 'text', nullable: true)]
+    #[ORM\Column(name: 'comment', type: Types::TEXT, nullable: true)]
     private ?string $comment = null;
     /** @var string[] */
     private array $errors = [];

--- a/galette/lib/Galette/Entity/ScheduledPayment.php
+++ b/galette/lib/Galette/Entity/ScheduledPayment.php
@@ -55,7 +55,6 @@ class ScheduledPayment
     private int $id;
     #[ORM\ManyToOne(targetEntity: Contribution::class)]
     #[ORM\JoinColumn(onDelete: 'cascade')]
-    private int $id_contribution;
     private Contribution $contribution;
     #[ORM\ManyToOne(targetEntity: PaymentType::class)]
     #[ORM\JoinColumn(
@@ -67,7 +66,6 @@ class ScheduledPayment
             'unsigned' => true
         ]
     )]
-    private int $id_paymenttype;
     private PaymentType $payment_type;
     #[ORM\Column(name: 'creation_date', type: 'date')]
     private string $creation_date;
@@ -148,10 +146,8 @@ class ScheduledPayment
 
         $pk = self::PK;
         $this->id = (int)$rs->$pk;
-        $this->id_contribution = (int)$rs->{Contribution::PK};
-        $this->contribution = new Contribution($this->zdb, $login, $this->id_contribution);
-        $this->id_paymenttype = (int)$rs->id_paymenttype;
-        $this->payment_type = new PaymentType($this->zdb, $this->id_paymenttype);
+        $this->contribution = new Contribution($this->zdb, $login, (int)$rs->{Contribution::PK});
+        $this->payment_type = new PaymentType($this->zdb, (int)$rs->id_paymenttype);
         $this->creation_date = $rs->creation_date;
         $this->scheduled_date = $rs->scheduled_date;
         $this->amount = (float)$rs->amount;
@@ -348,7 +344,6 @@ class ScheduledPayment
         } else {
             $this->contribution = $contribution;
         }
-        $this->id_contribution = $this->contribution->id;
         return $this;
     }
 
@@ -391,7 +386,6 @@ class ScheduledPayment
         } else {
             $this->payment_type = $payment_type;
         }
-        $this->id_paymenttype = $this->payment_type->id;
         return $this;
     }
 

--- a/galette/lib/Galette/Entity/Social.php
+++ b/galette/lib/Galette/Entity/Social.php
@@ -65,8 +65,6 @@ class Social
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(name: 'id_social', type: 'integer')]
-    //FIXME: does not works :/
-    //#[ORM\SequenceGenerator(sequenceName: 'galette_socials_id_seq', initialValue: 1)]
     private int $id;
     #[ORM\Column(type: 'string', length: 250)]
     private string $type;

--- a/galette/lib/Galette/Entity/Social.php
+++ b/galette/lib/Galette/Entity/Social.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Galette\Entity;
 
 use ArrayObject;
+use Doctrine\ORM\Mapping as ORM;
 use Galette\Core\GaletteMail;
 use Galette\Features\I18n;
 use Laminas\Db\Sql\Expression;
@@ -40,7 +41,8 @@ use Analog\Analog;
  * @property string $type
  * @property int $id
  */
-
+#[ORM\Entity]
+#[ORM\Table(name: 'orm_socials')]
 class Social
 {
     use I18n;
@@ -60,9 +62,27 @@ class Social
     public const DISCORD = 'discord';
 
     private Db $zdb;
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(name: 'id_social', type: 'integer')]
+    //FIXME: does not works :/
+    //#[ORM\SequenceGenerator(sequenceName: 'galette_socials_id_seq', initialValue: 1)]
     private int $id;
+    #[ORM\Column(type: 'string', length: 250)]
     private string $type;
+    #[ORM\Column(type: 'string', length: 255)]
     private string $url;
+    #[ORM\ManyToOne(targetEntity: Adherent::class)]
+    #[ORM\JoinColumn(
+        name: 'id_adh',
+        referencedColumnName: 'id_adh',
+        nullable: true,
+        onDelete: 'restrict',
+        options: [
+            'default' => null,
+            'unsigned' => true
+        ]
+    )]
     private ?int $id_adh;
     private ?Adherent $member = null;
 

--- a/galette/lib/Galette/Entity/Social.php
+++ b/galette/lib/Galette/Entity/Social.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Galette\Entity;
 
 use ArrayObject;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Galette\Core\GaletteMail;
 use Galette\Features\I18n;
@@ -64,11 +65,11 @@ class Social
     private Db $zdb;
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(name: 'id_social', type: 'integer', options: ['unsigned' => true])]
+    #[ORM\Column(name: 'id_social', type: Types::INTEGER, options: ['unsigned' => true])]
     private int $id;
-    #[ORM\Column(type: 'string', length: 250)]
+    #[ORM\Column(type: Types::STRING, length: 250)]
     private string $type;
-    #[ORM\Column(type: 'string', length: 255)]
+    #[ORM\Column(type: Types::STRING, length: 255)]
     private string $url;
     #[ORM\ManyToOne(targetEntity: Adherent::class)]
     #[ORM\JoinColumn(

--- a/galette/lib/Galette/Entity/Social.php
+++ b/galette/lib/Galette/Entity/Social.php
@@ -64,7 +64,7 @@ class Social
     private Db $zdb;
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(name: 'id_social', type: 'integer')]
+    #[ORM\Column(name: 'id_social', type: 'integer', options: ['unsigned' => true])]
     private int $id;
     #[ORM\Column(type: 'string', length: 250)]
     private string $type;

--- a/galette/lib/Galette/Entity/Status.php
+++ b/galette/lib/Galette/Entity/Status.php
@@ -50,10 +50,14 @@ class Status
     private Db $zdb;
 
     #[ORM\Id]
-    #[ORM\Column(name: 'id_statut', type: 'integer')]
     #[ORM\GeneratedValue]
+    #[ORM\Column(name: 'id_statut', type: 'integer')]
+    //FIXME: does not works :/
+    //#[ORM\SequenceGenerator(sequenceName: 'galette_statuts_id_seq', initialValue: 1)]
     private int $id;
+    #[ORM\Column(name: 'libelle_statut', type: 'string')]
     private string $label;
+    #[ORM\Column(name: 'priorite_statut', type: 'smallint', options: ['default' => 0])]
     private int $priority;
 
     public const ID_NOT_EXISTS = -1;

--- a/galette/lib/Galette/Entity/Status.php
+++ b/galette/lib/Galette/Entity/Status.php
@@ -52,8 +52,6 @@ class Status
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(name: 'id_statut', type: 'integer')]
-    //FIXME: does not works :/
-    //#[ORM\SequenceGenerator(sequenceName: 'galette_statuts_id_seq', initialValue: 1)]
     private int $id;
     #[ORM\Column(name: 'libelle_statut', type: 'string')]
     private string $label;

--- a/galette/lib/Galette/Entity/Status.php
+++ b/galette/lib/Galette/Entity/Status.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Galette\Entity;
 
 use Analog\Analog;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Galette\Core\Db;
 use ArrayObject;
@@ -51,11 +52,11 @@ class Status
 
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(name: 'id_statut', type: 'integer', options: ['unsigned' => true])]
+    #[ORM\Column(name: 'id_statut', type: Types::INTEGER, options: ['unsigned' => true])]
     private int $id;
-    #[ORM\Column(name: 'libelle_statut', type: 'string')]
+    #[ORM\Column(name: 'libelle_statut', type: Types::STRING)]
     private string $label;
-    #[ORM\Column(name: 'priorite_statut', type: 'smallint', options: ['default' => 0])]
+    #[ORM\Column(name: 'priorite_statut', type: Types::SMALLINT, options: ['default' => 0])]
     private int $priority;
 
     public const ID_NOT_EXISTS = -1;

--- a/galette/lib/Galette/Entity/Status.php
+++ b/galette/lib/Galette/Entity/Status.php
@@ -51,7 +51,7 @@ class Status
 
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(name: 'id_statut', type: 'integer')]
+    #[ORM\Column(name: 'id_statut', type: 'integer', options: ['unsigned' => true])]
     private int $id;
     #[ORM\Column(name: 'libelle_statut', type: 'string')]
     private string $label;

--- a/galette/lib/Galette/Entity/Status.php
+++ b/galette/lib/Galette/Entity/Status.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Galette\Entity;
 
 use Analog\Analog;
+use Doctrine\ORM\Mapping as ORM;
 use Galette\Core\Db;
 use ArrayObject;
 use Galette\Features\I18n;
@@ -34,6 +35,8 @@ use Throwable;
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'orm_statuts')]
 class Status
 {
     use I18n;
@@ -46,6 +49,9 @@ class Status
 
     private Db $zdb;
 
+    #[ORM\Id]
+    #[ORM\Column(name: 'id_statut', type: 'integer')]
+    #[ORM\GeneratedValue]
     private int $id;
     private string $label;
     private int $priority;

--- a/galette/lib/Galette/Entity/Title.php
+++ b/galette/lib/Galette/Entity/Title.php
@@ -50,8 +50,6 @@ class Title
     #[ORM\Id]
     #[ORM\Column(name: 'id_title', type: 'integer', options: ['unsigned' => true])]
     #[ORM\GeneratedValue]
-    //FIXME: does not works :/
-    //#[ORM\SequenceGenerator(sequenceName: 'galette_titles_id_seq', initialValue: 1)]
     private int $id;
     #[ORM\Column(name: 'short_label', type: 'string', length: 10)]
     private string $short;

--- a/galette/lib/Galette/Entity/Title.php
+++ b/galette/lib/Galette/Entity/Title.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Galette\Entity;
 
 use ArrayObject;
+use Doctrine\ORM\Mapping as ORM;
 use Galette\Core\Db;
 use Throwable;
 use Analog\Analog;
@@ -39,12 +40,16 @@ use Analog\Analog;
  * @property-read string $tshort
  * @property-read string $tlong
  */
-
+#[ORM\Entity]
+#[ORM\Table(name: 'orm_titles')]
 class Title
 {
     public const TABLE = 'titles';
     public const PK = 'id_title';
 
+    #[ORM\Id]
+    #[ORM\Column(name: 'id_statut', type: 'integer')]
+    #[ORM\GeneratedValue]
     private int $id;
     private string $short;
     private ?string $long;

--- a/galette/lib/Galette/Entity/Title.php
+++ b/galette/lib/Galette/Entity/Title.php
@@ -48,10 +48,14 @@ class Title
     public const PK = 'id_title';
 
     #[ORM\Id]
-    #[ORM\Column(name: 'id_statut', type: 'integer')]
+    #[ORM\Column(name: 'id_title', type: 'integer', options: ['unsigned' => true])]
     #[ORM\GeneratedValue]
+    //FIXME: does not works :/
+    //#[ORM\SequenceGenerator(sequenceName: 'galette_titles_id_seq', initialValue: 1)]
     private int $id;
+    #[ORM\Column(name: 'short_label', type: 'string', length: 10)]
     private string $short;
+    #[ORM\Column(name: 'long_label', type: 'string', length: 100, nullable: true)]
     private ?string $long;
 
     public const MR = 1;

--- a/galette/lib/Galette/Entity/Title.php
+++ b/galette/lib/Galette/Entity/Title.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Galette\Entity;
 
 use ArrayObject;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Galette\Core\Db;
 use Throwable;
@@ -48,12 +49,12 @@ class Title
     public const PK = 'id_title';
 
     #[ORM\Id]
-    #[ORM\Column(name: 'id_title', type: 'integer', options: ['unsigned' => true])]
+    #[ORM\Column(name: 'id_title', type: Types::INTEGER, options: ['unsigned' => true])]
     #[ORM\GeneratedValue]
     private int $id;
-    #[ORM\Column(name: 'short_label', type: 'string', length: 10)]
+    #[ORM\Column(name: 'short_label', type: Types::STRING, length: 10)]
     private string $short;
-    #[ORM\Column(name: 'long_label', type: 'string', length: 100, nullable: true)]
+    #[ORM\Column(name: 'long_label', type: Types::STRING, length: 100, nullable: true)]
     private ?string $long;
 
     public const MR = 1;

--- a/galette/lib/Galette/Entity/Transaction.php
+++ b/galette/lib/Galette/Entity/Transaction.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Galette\Entity;
 
 use ArrayObject;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Galette\Events\GaletteEvent;
 use Galette\Repository\PaymentTypes;
@@ -60,14 +61,14 @@ class Transaction
     public const PK = 'trans_id';
 
     #[ORM\Id]
-    #[ORM\Column(name: 'trans_id', type: 'integer', options: ['unsigned' => true])]
+    #[ORM\Column(name: 'trans_id', type: Types::INTEGER, options: ['unsigned' => true])]
     #[ORM\GeneratedValue]
     private int $id;
-    #[ORM\Column(name: 'trans_date', type: 'date')]
+    #[ORM\Column(name: 'trans_date', type: Types::DATE_MUTABLE)]
     private string $date;
-    #[ORM\Column(name: 'trans_amount', type: 'decimal', precision: 15, scale: 2)]
+    #[ORM\Column(name: 'trans_amount', type: Types::DECIMAL, precision: 15, scale: 2)]
     private float $amount;
-    #[ORM\Column(name: 'trans_desc', type: 'string', length: 255, options: ['default' => ''])]
+    #[ORM\Column(name: 'trans_desc', type: Types::STRING, length: 255, options: ['default' => ''])]
     private ?string $description = null;
     #[ORM\ManyToOne(targetEntity: Adherent::class)]
     #[ORM\JoinColumn(

--- a/galette/lib/Galette/Entity/Transaction.php
+++ b/galette/lib/Galette/Entity/Transaction.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Galette\Entity;
 
 use ArrayObject;
+use Doctrine\ORM\Mapping as ORM;
 use Galette\Events\GaletteEvent;
 use Galette\Repository\PaymentTypes;
 use Throwable;
@@ -48,6 +49,8 @@ use Galette\Helpers\EntityHelper;
  * @property ?integer $member
  * @property ?integer $payment_type
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'orm_transactions')]
 class Transaction
 {
     use Dynamics;
@@ -56,11 +59,35 @@ class Transaction
     public const TABLE = 'transactions';
     public const PK = 'trans_id';
 
+    #[ORM\Id]
+    #[ORM\Column(name: 'trans_id', type: 'integer', options: ['unsigned' => true])]
+    #[ORM\GeneratedValue]
     private int $id;
+    #[ORM\Column(name: 'trans_date', type: 'date')]
     private string $date;
+    #[ORM\Column(name: 'trans_amount', type: 'decimal', precision: 15, scale: 2)]
     private float $amount;
+    #[ORM\Column(name: 'trans_desc', type: 'string', length: 255, options: ['default' => ''])]
     private ?string $description = null;
+    #[ORM\ManyToOne(targetEntity: Adherent::class)]
+    #[ORM\JoinColumn(
+        name: Adherent::PK,
+        referencedColumnName: Adherent::PK,
+        onDelete: 'restrict',
+        options: [
+            'unsigned' => true
+        ]
+    )]
     private ?int $member = null;
+    #[ORM\ManyToOne(targetEntity: PaymentType::class)]
+    #[ORM\JoinColumn(
+        name: 'type_paiement_trans',
+        referencedColumnName: PaymentType::PK,
+        onDelete: 'restrict',
+        options: [
+            'unsigned' => true
+        ]
+    )]
     private ?int $payment_type = null;
 
     private Db $zdb;

--- a/galette/lib/Galette/ORM/ForeignKeyManager.php
+++ b/galette/lib/Galette/ORM/ForeignKeyManager.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Galette\ORM;
 
+use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
@@ -37,9 +38,11 @@ class ForeignKeyManager
     /**
      * Post schema generation, to fix FK constraints names
      *
-     * @param GenerateSchemaEventArgs $args
+     * @param GenerateSchemaEventArgs $args Event arguments
+     *
      * @return void
-     * @throws \Doctrine\DBAL\Schema\SchemaException
+     *
+     * @throws SchemaException
      */
     public function postGenerateSchema(GenerateSchemaEventArgs $args): void
     {

--- a/galette/lib/Galette/ORM/ForeignKeyManager.php
+++ b/galette/lib/Galette/ORM/ForeignKeyManager.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Copyright © 2003-2024 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Galette\ORM;
+
+use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+
+/**
+ * ORM Foreign Key Manager
+ *
+ * @author Johan Cwiklinski <johan@x-tnd.be>
+ */
+class ForeignKeyManager
+{
+    /**
+     * Post schema generation, to fix FK constraints names
+     *
+     * @param GenerateSchemaEventArgs $args
+     * @return void
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     */
+    public function postGenerateSchema(GenerateSchemaEventArgs $args): void
+    {
+        $schema = $args->getSchema();
+
+        foreach ($schema->getTables() as $table) {
+            foreach ($table->getForeignKeys() as $fk) {
+                $table->removeForeignKey($fk->getName());
+                $table->addForeignKeyConstraint(
+                    $fk->getForeignTableName(),
+                    $fk->getLocalColumns(),
+                    $fk->getForeignColumns(),
+                    $fk->getOptions(),
+                    $fk->getLocalColumns()[0]
+                );
+            }
+        }
+    }
+}

--- a/galette/lib/Galette/ORM/TablePrefix.php
+++ b/galette/lib/Galette/ORM/TablePrefix.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Copyright © 2003-2024 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Galette\ORM;
+
+use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Mapping\ClassMetadata;
+
+/**
+ * ORM Table Prefix
+ *
+ * @author Johan Cwiklinski <johan@x-tnd.be>
+ */
+class TablePrefix
+{
+    protected string $prefix;
+
+    /**
+     * Constructor
+     *
+     * @param string $prefix Table prefix
+     */
+    public function __construct(string $prefix)
+    {
+        $this->prefix = $prefix;
+    }
+
+    /**
+     * Load class metadata
+     *
+     * @param LoadClassMetadataEventArgs $eventArgs Event arguments
+     */
+    public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs): void
+    {
+        $classMetadata = $eventArgs->getClassMetadata();
+
+        if (!$classMetadata->isInheritanceTypeSingleTable() || $classMetadata->getName() === $classMetadata->rootEntityName) {
+            $classMetadata->setPrimaryTable([
+                'name' => sprintf(
+                    '%s%s',
+                    $this->prefix,
+                    $classMetadata->getTableName()
+                )
+            ]);
+        }
+
+        foreach ($classMetadata->getAssociationMappings() as $fieldName => $mapping) {
+            if ($mapping['type'] == ClassMetadata::MANY_TO_MANY && $mapping['isOwningSide']) {
+                $mappedTableName = $mapping['joinTable']['name'];
+                $classMetadata->associationMappings[$fieldName]['joinTable']['name'] = sprintf(
+                    '%s%s',
+                    $this->prefix,
+                    $mappedTableName
+                );
+            }
+        }
+    }
+
+}

--- a/galette/lib/Galette/ORM/TablePrefix.php
+++ b/galette/lib/Galette/ORM/TablePrefix.php
@@ -49,6 +49,8 @@ class TablePrefix
      * Load class metadata
      *
      * @param LoadClassMetadataEventArgs $eventArgs Event arguments
+     *
+     * @return void
      */
     public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs): void
     {
@@ -75,5 +77,4 @@ class TablePrefix
             }
         }
     }
-
 }


### PR DESCRIPTION
Just to see if that can be a good idea, and what would be required.

Here is a list of problems I've identified so far:

- [x] there is no size on integers (to be changed in mysql schema)
- [ ] `ONUPDATE` does not exists database side (ids cannot be changed in Galette anyway)
- [x] `tinyint` is used only for booleans. Some fields must be changed to `smallint`:
   - [x] `adherents.sexe_adh`
   - [x] `statuts.priorite_statut`
- [x] Some default values must be removed database side (no really related to ORM)
   - [x] `adherents.sexe_adh`
   - [x] `adherents.pref_lang`
- [x] `reminders.reminder_id` is `smallint` instead of `int` MySQL side. It should also probably be set `unsigned` as all other primary keys.
- [x] ~~PostgreSQL sequence names are not customizable. It uses following `{table_name}_{id_field_name}_seq`~~ changed as of #544
- [ ] `searches.parameters` is `json` PostgreSQL side, but `text` MySQL side
- [x] `adherents.date_echeance`, `adherents.tel_adh`, `adherents.gsm_adh` and  `adherents.email_adh` has a default null value on MySQL but nothing on PostgreSQL
- [x] several date have a default value of `19010101` (PostgreSQL) ( `1901-01-01` for MySQL)
- [ ] `fields_categories`, `fields_config` (and also `preferences` - among other certainly) are not standard entities and does not have fields required for Doctrine mapping. How to work with those ones?
- [x] `pdfmodels.model_type` is an `integer` PostgreSQL side, a `tinyint(2)` MySQL side
- [x] `groups.id_group` (and related FKs) is not unsigned