### PR TITLE
fix(ScheduledPayment) fix error when posting scheduled payment

### DIFF
--- a/galette/lib/Galette/Entity/ScheduledPayment.php
+++ b/galette/lib/Galette/Entity/ScheduledPayment.php
@@ -197,7 +197,7 @@ class ScheduledPayment
             ->setPaymentType((int)$data['id_paymenttype'])
             ->setCreationDate($data['creation_date'] ?? date('Y-m-d'))
             ->setScheduledDate($data['scheduled_date'])
-            ->setAmount((float)$data['amount'] ?? $this->contribution->amount)
+            ->setAmount(isset($data['amount']) ? (float)$data['amount'] : $this->contribution->amount)
             ->setPaid($data['paid'] ? boolval($data['paid']) : false)
             ->setComment($data['comment'] ?? null);
 

--- a/galette/lib/Galette/Entity/ScheduledPayment.php
+++ b/galette/lib/Galette/Entity/ScheduledPayment.php
@@ -198,7 +198,7 @@ class ScheduledPayment
             ->setCreationDate($data['creation_date'] ?? date('Y-m-d'))
             ->setScheduledDate($data['scheduled_date'])
             ->setAmount(isset($data['amount']) ? (float)$data['amount'] : $this->contribution->amount)
-            ->setPaid($data['paid'] ? boolval($data['paid']) : false)
+            ->setPaid(isset($data['paid']) ? (bool)$data['paid'] : false)
             ->setComment($data['comment'] ?? null);
 
         return count($this->errors) === 0;

--- a/galette/lib/Galette/Entity/ScheduledPayment.php
+++ b/galette/lib/Galette/Entity/ScheduledPayment.php
@@ -150,7 +150,7 @@ class ScheduledPayment
         if (!isset($data[Contribution::PK]) || !is_numeric($data[Contribution::PK])) {
             $this->errors[] = _T('Contribution is required');
         } else {
-            if (!$this->contribution->load($data[Contribution::PK])) {
+            if (!$this->contribution->load((int)$data[Contribution::PK])) {
                 $this->errors[] = _T('Unable to load contribution');
             } else {
                 if (isset($data['amount'])) {
@@ -177,10 +177,10 @@ class ScheduledPayment
             $this->errors[] = _T('Payment type is required');
         } else {
             //no schedule inception allowed!
-            if ($data['id_paymenttype'] === PaymentType::SCHEDULED) {
+            if ((int)$data['id_paymenttype'] === PaymentType::SCHEDULED) {
                 $this->errors[] = _T('Cannot schedule a scheduled payment!');
             } else {
-                $this->payment_type = new PaymentType($this->zdb, $data['id_paymenttype']);
+                $this->payment_type = new PaymentType($this->zdb, (int)$data['id_paymenttype']);
             }
         }
 
@@ -193,12 +193,12 @@ class ScheduledPayment
         }
 
         $this
-            ->setContribution($data[Contribution::PK])
-            ->setPaymentType($data['id_paymenttype'])
+            ->setContribution((int)$data[Contribution::PK])
+            ->setPaymentType((int)$data['id_paymenttype'])
             ->setCreationDate($data['creation_date'] ?? date('Y-m-d'))
             ->setScheduledDate($data['scheduled_date'])
-            ->setAmount($data['amount'] ?? $this->contribution->amount)
-            ->setPaid($data['is_paid'] ?? false)
+            ->setAmount((float)$data['amount'] ?? $this->contribution->amount)
+            ->setPaid($data['paid'] ? boolval($data['paid']) : false)
             ->setComment($data['comment'] ?? null);
 
         return count($this->errors) === 0;


### PR DESCRIPTION
When saving a scheduled payment on a contribution, $data[Contribution::PK] is a string and we get an error as it should be casted as an int.
I also fixed the expected name for the `paid` parameter which is not `is_paid` but `paid` 