### PR TITLE
update links v1.1.5.2 Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ### English
 
-[![Download most recent Galette release (1.1.3)](https://img.shields.io/badge/1.1.3-Latest_Galette-ffb619.svg?logo=php&logoColor=white&style=for-the-badge)](https://galette.eu/download/galette-1.1.3.tar.bz2)
+[![Download most recent Galette release (1.1.5.2)](https://img.shields.io/badge/1.1.5.2-Latest_Galette-ffb619.svg?logo=php&logoColor=white&style=for-the-badge)](https://galette.eu/download/galette-1.1.5.2.tar.bz2)
 [![Download Galette development (nightly) build](https://img.shields.io/badge/nightly-Galette_development-ffb619.svg?logo=php&logoColor=white&style=for-the-badge)](https://galette.eu/download/galette-dev.tar.bz2)
 
 Galette is a membership management web application towards non profit organizations; released under GPLv3.
@@ -31,7 +31,7 @@ This project is tested with BrowserStack
 
 ### Français
 
-[![Télécharger la version de Galette la plus récente (1.1.3)](https://img.shields.io/badge/1.1.3-Dernière_Galette-ffb619.svg?logo=php&logoColor=white&style=for-the-badge)](https://galette.eu/download/galette-1.1.3.tar.bz2)
+[![Télécharger la version de Galette la plus récente (1.1.5.2)](https://img.shields.io/badge/1.1.5.2-Dernière_Galette-ffb619.svg?logo=php&logoColor=white&style=for-the-badge)](https://galette.eu/download/galette-1.1.5.2.tar.bz2)
 [![Télécharger la version de développement (nighly) de Galette](https://img.shields.io/badge/nightly-Galette_développement-ffb619.svg?logo=php&logoColor=white&style=for-the-badge)](https://galette.eu/download/galette-dev.tar.bz2)
 
 Galette est un outil de gestion d’adhérents et de cotisations en ligne à destination des associations, sous license GPLV3.


### PR DESCRIPTION
The links in the `README.md` to download the latest Galette point to version v1.1.3.
This is a simple update to point to v1.1.5.2.