### PR TITLE
Single line links in footer

### DIFF
--- a/galette/templates/default/elements/footer.html.twig
+++ b/galette/templates/default/elements/footer.html.twig
@@ -19,8 +19,8 @@
  */
 #}
 {% set new_release = callstatic('\\Galette\\Core\\Galette', 'getNewRelease') %}
-    <footer class="page-footer{% if login.getCompactMenu() %} extended"{% endif %}">
-        <div class="ui center aligned basic padded segment footer-wrapper">
+    <footer class="page-footer">
+        <div class="ui center aligned basic padded segment footer-wrapper{% if login.getCompactMenu() %} extended"{% endif %}">
             <div class="row">
                 <div class="ui horizontal bulleted link list">
                     <a id="copyright" href="https://galette.eu/" class="item{% if new_release.new and login.isLogged() and (login.isAdmin() or login.isStaff()) %} tooltip" data-title="{{ _T("A new Galette release is available.") }}" data-content="{{ _T("You currently use Galette %1$s, and %2$s is available.")|replace({"%1$s": constant('GALETTE_DISPLAY_VERSION'), "%2$s": new_release.version}) }}"{% else %}"{% endif %}>

--- a/galette/templates/default/elements/footer.html.twig
+++ b/galette/templates/default/elements/footer.html.twig
@@ -23,9 +23,16 @@
         <div class="ui center aligned basic padded segment footer-wrapper">
             <div class="row">
                 <div class="ui horizontal bulleted link list">
-                    <a href="https://galette.eu" class="item">
-                        <i class="icon globe europe" aria-hidden="true"></i>
-                        {{ _T("Website") }}
+                    <a id="copyright" href="https://galette.eu/" class="item{% if new_release.new and login.isLogged() and (login.isAdmin() or login.isStaff()) %} tooltip" data-title="{{ _T("A new Galette release is available.") }}" data-content="{{ _T("You currently use Galette %1$s, and %2$s is available.")|replace({"%1$s": constant('GALETTE_DISPLAY_VERSION'), "%2$s": new_release.version}) }}"{% else %}"{% endif %}>
+{% if new_release.new and login.isLogged() and (login.isAdmin() or login.isStaff()) %}
+                        <div class="ui transition looping pulsating blue circular horizontal icon label">
+                            <i class="arrow alternate circle up icon" aria-hidden="true"></i>
+                            <span class="visually-hidden">{{ _T("A new Galette release is available.") }}</span>
+                        </div>
+{% else %}
+                        <i class="icon cookie bite" aria-hidden="true"></i>
+{% endif %}
+                        Galette{% if login.isLogged() %} {{ constant('GALETTE_DISPLAY_VERSION') }}{% endif %}
                     </a>
                     <a href="https://doc.galette.eu" class="item">
                         <i class="icon book" aria-hidden="true"></i>
@@ -35,21 +42,6 @@
                         <i class="icon mastodon" aria-hidden="true"></i>
                         @galette
                     </a>
-                </div>
-            </div>
-            <div class="row">
-                <div class="ui horizontal bulleted link list">
-                    <a id="copyright" href="https://galette.eu/" class="item{% if new_release.new %} tooltip" data-title="{{ _T("A new Galette release is available.") }}" data-content="{{ _T("You currently use Galette %1$s, and %2$s is available.")|replace({"%1$s": constant('GALETTE_DISPLAY_VERSION'), "%2$s": new_release.version}) }}"{% else %}"{% endif %}>
-{% if new_release.new and login.isLogged() and (login.isAdmin() or login.isStaff()) %}
-                        <div class="ui transition looping pulsating blue circular horizontal icon label">
-                            <i class="arrow alternate circle up icon" aria-hidden="true"></i>
-                            <span class="visually-hidden">{{ _T("A new Galette release is available.") }}</span>
-                        </div>
-{% else %}
-                        <i class="icon cookie bite" aria-hidden="true"></i>
-{% endif %}
-                        Galette {{ constant('GALETTE_DISPLAY_VERSION') }}
-                    </a>
 {% if login.isLogged() and (login.isAdmin() or login.isStaff()) %}
                     <a id="sysinfos" href="{{ url_for('sysinfos') }}" class="item">
                         <i class="icon cogs" aria-hidden="true"></i>
@@ -57,14 +49,6 @@
                     </a>
 {% endif %}
                 </div>
-{% if login.isLogged() and cur_route == 'dashboard' %}
-                {# Comply with the Twemoji project's requirements about attribution #}
-                <!--
-                    Emojis used by Galette's core and its official plugins on the dashboard
-                    are licensed under CC-BY 4.0 <https://creativecommons.org/licenses/by/4.0/>
-                    by Twemoji <https://twemoji.twitter.com/>
-                -->
-{% endif %}
             </div>
 {# Display footer line, if it does exists #}
 {% if preferences.pref_footer != '' %}
@@ -77,4 +61,12 @@
             </div>
 {% endif %}
         </div>
+{# Comply with the Twemoji project's requirements about attribution #}
+{% if login.isLogged() and cur_route == 'dashboard' %}
+        <!--
+            Emojis used by Galette's core and its official plugins on the dashboard
+            are licensed under CC-BY 4.0 <https://creativecommons.org/licenses/by/4.0/>
+            by Twemoji <https://twemoji.twitter.com/>
+        -->
+{% endif %}
     </footer>

--- a/galette/templates/default/elements/header.html.twig
+++ b/galette/templates/default/elements/header.html.twig
@@ -19,7 +19,7 @@
  */
 #}
 {# This file contains common html headers to include for Galette Twig rendering. #}
-        <title>{% if preferences.pref_slogan != "" %}{{ __(preferences.pref_slogan) }} - {% endif %}{% if page_title != "" %}{{ page_title }} - {% endif %}Galette {{ constant('GALETTE_VERSION') }}</title>
+        <title>{% if preferences.pref_slogan != "" %}{{ __(preferences.pref_slogan) }} - {% endif %}{% if page_title != "" %}{{ page_title }} - {% endif %}Galette</title>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width" />
         <link rel="stylesheet" type="text/css" href="{{ base_path() }}/{{ constant('GALETTE_THEME') }}ui/semantic{% if i18n.isRtl() %}.rtl{% endif %}.min.css" />


### PR DESCRIPTION
I started this PR because the existing "Website" link in the footer is a bit confusing for users that can think it is a link to the association's website.

It ended this way :
* the website "link" was changed in a simple "Galette" link
* the version is only displayed when a user is logged-in, or also on public pages when in demo mode (I think it's better to hide the version on public pages in production mode to harden the discovery of obsolete instances with search engines if indexation prevention is not enabled in the preferences)
* all links are displayed on a single line