### PR TITLE
Improve groups selection tree UX

### DIFF
--- a/galette/templates/default/pages/groups_list.html.twig
+++ b/galette/templates/default/pages/groups_list.html.twig
@@ -24,10 +24,20 @@
 
 {% macro group_item(login, group, parents, selected) %}
     <div class="{% if group.getGroups()|length > 0 %}title{% if group.getName() in parents %} active{% endif %}{% else %}nochild{% endif %}">
-        <i class="{% if group.getGroups()|length > 0 %}dropdown{% else %}empty{% endif %} icon" aria-hidden="true"></i>
-        <a class="ui{% if group.getName() == selected %} primary{% endif %}{% if not login.isGroupManager(group.getId()) %} disabled{% endif %} label" href="{% if login.isGroupManager(group.getId()) %}{{ url_for("groups", {"id": group.getId()}) }}{% else %}#{% endif %}">
-            {{ group.getName() }}
+        {% if group.getGroups()|length > 0 %}
+        <i class="dropdown icon" aria-hidden="true"></i>
+        {% endif %}
+        {% if login.isGroupManager(group.getId()) and group.getName() != selected %}
+        <a class="icon" href="{% if login.isGroupManager(group.getId()) %}{{ url_for("groups", {"id": group.getId()}) }}{% else %}#{% endif %}">
+            <i class="edit icon" aria-hidden="true"></i>
+            <span class="visually-hidden">Edit</span>
         </a>
+        {% else %}
+        <i class="black folder open outline icon"></i>
+        {% endif %}
+        <span class="{% if group.getName() == selected %}active{% endif %}">
+            {{ group.getName() }}
+        </span>
     </div>
     {% if group.getGroups()|length > 0 %}
     <div class="content{% if group.getName() in parents %} active{% endif %}">

--- a/ui/semantic/galette/modules/accordion.overrides
+++ b/ui/semantic/galette/modules/accordion.overrides
@@ -37,8 +37,18 @@ details.ui.basic.styled.accordion .title {
 /*--------------------------------
      Tree accordion style
 ---------------------------------*/
-.ui.accordion.tree .nochild {
-   padding: .5em 0;
+.ui.accordion.tree {
+     .accordion > .title,
+     .nochild {
+        padding: .7em 0;
+     }
+     .nochild {
+       margin-left: 1.75em;
+     }
+     span.active {
+        font-weight: bold;
+        color: @black;
+     }
 }
 
 /*-------------


### PR DESCRIPTION
- browse groups by clicking on their name instead of clicking on their arrow
- add an icon to select and edit a group (replaced by an open folder when group is selected)
- fix alignements in case of very long names (by removing the use of labels on names)

Before :
![tree-before](https://github.com/user-attachments/assets/625d527d-4626-4f26-9c10-ed383b3b3a6e)

After :
![tree-after](https://github.com/user-attachments/assets/c6dcbf29-be45-4b64-b778-262ba70ded2a)

