### PR TITLE
Consistent naming on pages titles and menu links

### DIFF
--- a/galette/lib/Galette/Controllers/Crud/ContributionsController.php
+++ b/galette/lib/Galette/Controllers/Crud/ContributionsController.php
@@ -530,7 +530,7 @@ class ContributionsController extends CrudController
 
         $tpl_vars = [
             'page_title'        => $raw_type === 'contributions' ?
-                                    _T("Contributions management") : _T("Transactions management"),
+                                    _T("List of contributions") : _T("List of transactions"),
             'contribs'          => $contrib,
             'list'              => $contribs_list,
             'nb'                => $contrib->getCount(),

--- a/galette/lib/Galette/Controllers/Crud/DocumentsController.php
+++ b/galette/lib/Galette/Controllers/Crud/DocumentsController.php
@@ -195,7 +195,7 @@ class DocumentsController extends CrudController
         $filters->setViewPagination($this->routeparser, $this->view);
 
         $params = [
-            'page_title' => _T("Documents list"),
+            'page_title' => _T("Documents"),
             'nb' => count($documents),
             'documents' => $documents,
             'filters' => $filters,
@@ -231,7 +231,7 @@ class DocumentsController extends CrudController
         $documents = $document->getTypedList();
 
         $params = [
-            'page_title' => _T("Documents list"),
+            'page_title' => _T("Documents"),
             'typed_documents' => $documents,
             'documentation' => 'usermanual/documents.html#public-list'
         ];

--- a/galette/lib/Galette/Controllers/Crud/DynamicFieldsController.php
+++ b/galette/lib/Galette/Controllers/Crud/DynamicFieldsController.php
@@ -215,7 +215,7 @@ class DynamicFieldsController extends CrudController
             'fields_list'       => $fields_list,
             'form_name'         => $form_name,
             'form_title'        => DynamicField::getFormTitle($form_name),
-            'page_title'        => _T("Dynamic fields configuration"),
+            'page_title'        => _T("Dynamic fields"),
             'html_editor'       => true,
             'html_editor_active' => $this->preferences->pref_editor_enabled,
             'documentation'     => 'usermanual/configuration.html#dynamic-fields'

--- a/galette/lib/Galette/Controllers/Crud/MembersController.php
+++ b/galette/lib/Galette/Controllers/Crud/MembersController.php
@@ -321,7 +321,7 @@ class MembersController extends CrudController
             [
                 'filter_name' => $this->getFilterName($this->getDefaultFilterName(), ['prefix' => 'public', 'suffix' => 'list']),
                 'with_photos' => false,
-                'page_title' => _T("Members list"),
+                'page_title' => _T("Members"),
                 'template' => 'pages/members_public_list.html.twig',
                 'html_class' => '',
             ],
@@ -352,7 +352,7 @@ class MembersController extends CrudController
             [
                 'filter_name' => $this->getFilterName($this->getDefaultFilterName(), ['prefix' => 'public', 'suffix' => 'trombi']),
                 'with_photos' => true,
-                'page_title' => _T("Members list"),
+                'page_title' => _T("Gallery"),
                 'template' => 'pages/members_public_gallery.html.twig',
                 'html_class' => 'gallery',
             ],
@@ -538,7 +538,7 @@ class MembersController extends CrudController
             $response,
             'pages/members_list.html.twig',
             array(
-                'page_title'            => _T("Members management"),
+                'page_title'            => _T("List of members"),
                 'require_mass'          => true,
                 'members'               => $members_list,
                 'filter_groups_options' => $groups_list,

--- a/galette/lib/Galette/Controllers/Crud/PaymentTypeController.php
+++ b/galette/lib/Galette/Controllers/Crud/PaymentTypeController.php
@@ -94,7 +94,7 @@ class PaymentTypeController extends CrudController
             $response,
             'pages/configuration_payment_types.html.twig',
             [
-                'page_title'        => _T("Payment types management"),
+                'page_title'        => _T("Payment types"),
                 'list'              => $list
             ]
         );

--- a/galette/lib/Galette/Controllers/Crud/ScheduledPaymentController.php
+++ b/galette/lib/Galette/Controllers/Crud/ScheduledPaymentController.php
@@ -176,7 +176,7 @@ class ScheduledPaymentController extends CrudController
             $response,
             'pages/scheduledpayments_list.html.twig',
             [
-                'page_title'        => _T("Scheduled payments management"),
+                'page_title'        => _T("List of scheduled payments"),
                 'scheduled'         => $scheduled,
                 'list'              => $list,
                 'nb'                => $scheduled->getCount(),

--- a/galette/lib/Galette/Controllers/Crud/TitlesController.php
+++ b/galette/lib/Galette/Controllers/Crud/TitlesController.php
@@ -89,7 +89,7 @@ class TitlesController extends CrudController
             $response,
             'pages/configuration_titles.html.twig',
             [
-                'page_title'        => _T("Titles management"),
+                'page_title'        => _T("Titles"),
                 'titles_list'       => $titles->getList()
             ]
         );

--- a/galette/lib/Galette/Controllers/CsvController.php
+++ b/galette/lib/Galette/Controllers/CsvController.php
@@ -106,7 +106,7 @@ class CsvController extends AbstractController
             $response,
             'pages/export.html.twig',
             array(
-                'page_title'        => _T("CVS database Export"),
+                'page_title'        => _T("Exports"),
                 'tables_list'       => $tables_list,
                 'written'           => $this->flash->getMessage('written_exports'),
                 'existing'          => $existing,
@@ -246,7 +246,7 @@ class CsvController extends AbstractController
             $response,
             'pages/import.html.twig',
             array(
-                'page_title'        => _T("CSV members import"),
+                'page_title'        => _T("Imports"),
                 'existing'          => $existing,
                 'dryrun'            => true,
                 'import_file'       => $this->session->import_file,

--- a/galette/lib/Galette/Controllers/GaletteController.php
+++ b/galette/lib/Galette/Controllers/GaletteController.php
@@ -458,7 +458,7 @@ class GaletteController extends AbstractController
         $fc = $this->fields_config;
 
         $params = [
-            'page_title'            => _T("Fields configuration"),
+            'page_title'            => _T("Core fields"),
             'time'                  => time(),
             'categories'            => FieldsCategories::getList($this->zdb),
             'categorized_fields'    => $fc->getCategorizedFields(),
@@ -554,7 +554,7 @@ class GaletteController extends AbstractController
         $lc = $this->lists_config;
 
         $params = [
-            'page_title'    => _T("Lists configuration"),
+            'page_title'    => _T("Core lists"),
             'table'         => $table,
             'time'          => time(),
             'listed_fields' => $lc->getListedFields(),

--- a/galette/lib/Galette/Controllers/TextController.php
+++ b/galette/lib/Galette/Controllers/TextController.php
@@ -67,7 +67,7 @@ class TextController extends AbstractController
             $response,
             'pages/configuration_texts.html.twig',
             [
-                'page_title'        => _T("Automatic emails texts edition"),
+                'page_title'        => _T("Emails content"),
                 'texts'             => $texts,
                 'reflist'           => $texts->getRefs($lang),
                 'langlist'          => $this->i18n->getList(),

--- a/galette/lib/Galette/Core/Galette.php
+++ b/galette/lib/Galette/Core/Galette.php
@@ -317,7 +317,7 @@ class Galette
                     'icon' => 'dharmachakra',
                     'items' => [
                         [
-                            'label' => _T("Manage groups"),
+                            'label' => _T("Groups"),
                             'title' => _T("View and manage groups"),
                             'route' => [
                                 'name' => 'groups'
@@ -336,7 +336,7 @@ class Galette
                             ]
                         ],
                         [
-                            'label' => _T("Manage mailings"),
+                            'label' => _T("Mailings"),
                             'title' => _T("Manage mailings that has been sent"),
                             'route' => [
                                 'name' => 'mailings'
@@ -424,7 +424,7 @@ class Galette
                                 ]
                             ],
                             [
-                                'label' => _T("Manage statuses"),
+                                'label' => _T("User statuses"),
                                 'route' => [
                                     'name' => 'status',
                                     'aliases' => ['editStatus']
@@ -479,7 +479,7 @@ class Galette
 
                     if ($login->isSuperAdmin()) {
                         $menus['configuration']['items'][] = [
-                            'label' => _T("Admin tools"),
+                            'label' => _T("Administration tools"),
                             'title' => _T("Various administrative tools"),
                             'route' => [
                                 'name' => 'adminTools'
@@ -537,7 +537,7 @@ class Galette
                 'icon' => 'eye outline',
                 'items' => [
                     [
-                        'label' => _T("Members list"),
+                        'label' => _T("Members"),
                         'route' => [
                             'name' => 'publicMembersList'
                         ],


### PR DESCRIPTION
I didn't modify nor create new translatable strings. Only made replacements with existing ones with the intention to use the most simple/explicit ones by matching the pages titles and their links in the menu.