### PR TITLE
Feature/public pages dropdowns

### DIFF
--- a/galette/includes/routes/public_pages.routes.php
+++ b/galette/includes/routes/public_pages.routes.php
@@ -49,6 +49,16 @@ $app->group('/public', function (RouteCollectorProxy $app) use ($routeparser): v
         [Crud\MembersController::class, 'filterPublicMembersGallery']
     )->setName('filterPublicMembersGallery');
 
+    $app->get(
+        '/staff/list[/{option:page|order}/{value:\d+|\w+}]',
+        [Crud\MembersController::class, 'publicStaffList']
+    )->setName('publicStaffList');
+
+    //public staff members gallery
+    $app->get(
+        '/staff/gallery[/{option:page|order}/{value:\d+|\w+}]',
+        [Crud\MembersController::class, 'publicStaffGallery']
+    )->setName('publicStaffGallery');
 
     $app->get(
         '/documents[/{option:page|order}/{value:\d+|\w+}]',

--- a/galette/install/scripts/upgrade-to-1.20.php
+++ b/galette/install/scripts/upgrade-to-1.20.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace Galette\Updates;
 
 use Analog\Analog;
+use Galette\Core\Preferences;
 use Galette\DynamicFields\DynamicField;
 use Galette\Entity\ContributionsTypes;
 use Galette\Updater\AbstractUpdater;
@@ -143,6 +144,39 @@ class UpgradeTo120 extends AbstractUpdater
                 Adapter::QUERY_MODE_EXECUTE
             );
         }
+
+        //handle preferences
+        $preferences = new Preferences($this->zdb);
+
+        $delete_prefs = [];
+        if ($preferences->pref_log) { //@phpstan-ignore-line
+            $delete_prefs[] = 'pref_log';
+        }
+
+        if ($preferences->pref_publicpages_visibility) { //@phpstan-ignore-line
+            $pref_publicpages_visibility = $preferences->pref_publicpages_visibility;
+            $update = $this->zdb->update(Preferences::TABLE);
+            $update
+                ->set(['val_pref' => $pref_publicpages_visibility])
+                ->where->in(
+                    'nom_pref',
+                    [
+                        'pref_publicpages_visibility_generic',
+                        'pref_publicpages_visibility_memberslist',
+                        'pref_publicpages_visibility_membersgallery',
+                        'pref_publicpages_visibility_documents'
+                    ]
+                );
+            $this->zdb->execute($update);
+            $delete_prefs[] = 'pref_publicpages_visibility';
+        }
+
+        if ($delete_prefs) {
+            $delete = $this->zdb->delete(Preferences::TABLE);
+            $delete->where->in('nom_pref', $delete_prefs);
+            $this->zdb->execute($delete);
+        }
+
         return true;
     }
 }

--- a/galette/lib/Galette/Controllers/Crud/MembersController.php
+++ b/galette/lib/Galette/Controllers/Crud/MembersController.php
@@ -322,7 +322,7 @@ class MembersController extends CrudController
                 'filter_name' => $this->getFilterName($this->getDefaultFilterName(), ['prefix' => 'public', 'suffix' => 'list']),
                 'with_photos' => false,
                 'page_title' => _T("Members"),
-                'template' => 'pages/members_public_list.html.twig',
+                'template' => 'pages/public/members_list.html.twig',
                 'html_class' => '',
             ],
             $option,
@@ -353,8 +353,80 @@ class MembersController extends CrudController
                 'filter_name' => $this->getFilterName($this->getDefaultFilterName(), ['prefix' => 'public', 'suffix' => 'trombi']),
                 'with_photos' => true,
                 'page_title' => _T("Gallery"),
-                'template' => 'pages/members_public_gallery.html.twig',
+                'template' => 'pages/public/members_gallery.html.twig',
                 'html_class' => 'gallery',
+            ],
+            $option,
+            $value
+        );
+    }
+
+    /**
+     * Public members list
+     *
+     * @param Request             $request  PSR Request
+     * @param Response            $response PSR Response
+     * @param string|null         $option   One of 'page' or 'order'
+     * @param string|integer|null $value    Value of the option
+     *
+     * @return Response
+     */
+    public function publicStaffList(
+        Request $request,
+        Response $response,
+        ?string $option = null,
+        string|int|null $value = null,
+    ): Response {
+        $filter_name = $this->getFilterName($this->getDefaultFilterName(), ['prefix' => 'public', 'suffix' => 'stafflist']);
+        $filters = new MembersList();
+        $this->session->$filter_name = $filters;
+
+        return $this->publicList(
+            $request,
+            $response,
+            [
+                'filter_name' => $filter_name,
+                'with_photos' => false,
+                'page_title' => _T("Staff"),
+                'template' => 'pages/public/staff_list.html.twig',
+                'html_class' => '',
+                'staff' => true,
+            ],
+            $option,
+            $value
+        );
+    }
+
+    /**
+     * Public staff gallery
+     *
+     * @param Request             $request  PSR Request
+     * @param Response            $response PSR Response
+     * @param string|null         $option   One of 'page' or 'order'
+     * @param string|integer|null $value    Value of the option
+     *
+     * @return Response
+     */
+    public function publicStaffGallery(
+        Request $request,
+        Response $response,
+        ?string $option = null,
+        string|int|null $value = null,
+    ): Response {
+        $filter_name = $this->getFilterName($this->getDefaultFilterName(), ['prefix' => 'public', 'suffix' => 'stafftrombi']);
+        $filters = new MembersList();
+        $this->session->$filter_name = $filters;
+
+        return $this->publicList(
+            $request,
+            $response,
+            [
+                'filter_name' => $filter_name,
+                'with_photos' => true,
+                'page_title' => _T("Staff gallery"),
+                'template' => 'pages/public/staff_gallery.html.twig',
+                'html_class' => 'gallery',
+                'staff' => true,
             ],
             $option,
             $value
@@ -398,7 +470,11 @@ class MembersController extends CrudController
         }
 
         $m = new Members($filters);
-        $members = $m->getPublicList($args['with_photos'] ?? false);
+        if ($args['staff'] ?? false) {
+            $members = $m->getPublicStaffList($args['with_photos'] ?? false);
+        } else {
+            $members = $m->getPublicList($args['with_photos'] ?? false);
+        }
 
         $this->session->$varname = $filters;
 

--- a/galette/lib/Galette/Controllers/ImagesController.php
+++ b/galette/lib/Galette/Controllers/ImagesController.php
@@ -105,15 +105,14 @@ class ImagesController extends AbstractController
         }
         $adh->load($id);
 
-        $picture = null;
+        $picture = new Picture();
         if (
             $adh->canEdit($this->login)
-            || $this->preferences->showPublicPages($this->login)
+            || ($this->preferences->showPublicPage($this->login, 'pref_publicpages_visibility_membersgallery')
+                || $this->preferences->showPublicPage($this->login, 'pref_publicpages_visibility_staffgallery'))
             && $adh->appearsInMembersList()
         ) {
             $picture = $adh->picture;
-        } else {
-            $picture = new Picture();
         }
 
         return $this->sendResponse($response, $picture);

--- a/galette/lib/Galette/Core/Galette.php
+++ b/galette/lib/Galette/Core/Galette.php
@@ -530,87 +530,89 @@ class Galette
          */
         global $preferences, $login, $plugins, $zdb;
 
-        $menus = [];
         if ($preferences->arePublicPagesEnabled()) {
-            $items = [];
+            return [];
+        }
 
-            if ($preferences->showPublicPage($login, 'pref_publicpages_visibility_memberslist')) {
-                $items[] = [
-                    'label' => _T("Members"),
-                    'route' => [
-                        'name' => 'publicMembersList'
-                    ],
-                    'icon' => 'address book'
-                ];
-            }
+        $menus = [];
+        $items = [];
 
-            if ($preferences->showPublicPage($login, 'pref_publicpages_visibility_membersgallery')) {
-                $items[] = [
-                    'label' => _T('Gallery'),
-                    'route' => [
-                        'name' => 'publicMembersGallery'
-                    ],
-                    'icon' => 'user friends'
-                ];
-            }
+        if ($preferences->showPublicPage($login, 'pref_publicpages_visibility_memberslist')) {
+            $items[] = [
+                'label' => _T("Members"),
+                'route' => [
+                    'name' => 'publicMembersList'
+                ],
+                'icon' => 'address book'
+            ];
+        }
 
-            if ($preferences->showPublicPage($login, 'pref_publicpages_visibility_stafflist')) {
-                $items[] = [
-                    'label' => _T("Staff"),
-                    'route' => [
-                        'name' => 'publicStaffList'
-                    ],
-                    'icon' => 'address card'
-                ];
-            }
+        if ($preferences->showPublicPage($login, 'pref_publicpages_visibility_membersgallery')) {
+            $items[] = [
+                'label' => _T('Gallery'),
+                'route' => [
+                    'name' => 'publicMembersGallery'
+                ],
+                'icon' => 'user friends'
+            ];
+        }
 
-            if ($preferences->showPublicPage($login, 'pref_publicpages_visibility_staffgallery')) {
-                $items[] = [
-                    'label' => _T('Staff gallery'),
-                    'route' => [
-                        'name' => 'publicStaffGallery'
-                    ],
-                    'icon' => 'user cog'
-                ];
-            }
+        if ($preferences->showPublicPage($login, 'pref_publicpages_visibility_stafflist')) {
+            $items[] = [
+                'label' => _T("Staff"),
+                'route' => [
+                    'name' => 'publicStaffList'
+                ],
+                'icon' => 'address card'
+            ];
+        }
 
-            //display documents menu if at least one document is present with current ACLs
-            $document = new Document($zdb);
-            $documents = $document->getList();
-            if (
-                $login->isSuperAdmin()
-                || $preferences->showPublicPage($login, 'pref_publicpages_visibility_documents')
-                && count($documents)
-            ) {
-                $items[] = [
-                    'label' => _T("Documents"),
-                    'title' => _T("View documents related to your association"),
-                    'route' => [
-                        'name' => 'documentsPublicList'
-                    ],
-                    'icon' => 'file alternate'
-                ];
-            }
+        if ($preferences->showPublicPage($login, 'pref_publicpages_visibility_staffgallery')) {
+            $items[] = [
+                'label' => _T('Staff gallery'),
+                'route' => [
+                    'name' => 'publicStaffGallery'
+                ],
+                'icon' => 'user cog'
+            ];
+        }
 
-            foreach (array_keys($plugins->getModules()) as $module_id) {
-                //get plugins public menus entries
-                $plugin_class = $plugins->getClassName($module_id, true);
-                if (class_exists($plugin_class)) {
-                    $plugin = new $plugin_class();
-                    $items = array_merge(
-                        $items,
-                        $plugin->getPublicMenuItems()
-                    );
-                }
-            }
+        //display documents menu if at least one document is present with current ACLs
+        $document = new Document($zdb);
+        $documents = $document->getList();
+        if (
+            $login->isSuperAdmin()
+            || $preferences->showPublicPage($login, 'pref_publicpages_visibility_documents')
+            && count($documents)
+        ) {
+            $items[] = [
+                'label' => _T("Documents"),
+                'title' => _T("View documents related to your association"),
+                'route' => [
+                    'name' => 'documentsPublicList'
+                ],
+                'icon' => 'file alternate'
+            ];
+        }
 
-            if (count($items)) {
-                $menus['public'] = [
-                    'title' => _T("Public pages"),
-                    'icon' => 'eye outline',
-                    'items' => $items
-                ];
+        foreach (array_keys($plugins->getModules()) as $module_id) {
+            //get plugins public menus entries
+            $plugin_class = $plugins->getClassName($module_id, true);
+            if (class_exists($plugin_class)) {
+                $plugin = new $plugin_class();
+                $items = array_merge(
+                    $items,
+                    $plugin->getPublicMenuItems()
+                );
             }
+        }
+
+        if (count($items)) {
+            $menus['public'] = [
+                'title' => _T("Public pages"),
+                'icon' => 'eye outline',
+                'items' => $items
+            ];
         }
 
         return $menus;

--- a/galette/lib/Galette/Core/Galette.php
+++ b/galette/lib/Galette/Core/Galette.php
@@ -530,7 +530,7 @@ class Galette
          */
         global $preferences, $login, $plugins, $zdb;
 
-        if ($preferences->arePublicPagesEnabled()) {
+        if (!$preferences->arePublicPagesEnabled()) {
             return [];
         }
 
@@ -771,7 +771,7 @@ class Galette
         //display documents menu if at least one document is present with current ACLs
         $document = new Document($zdb);
         $documents = $document->getList();
-        if ($preferences->showPublicPage($login, 'pref_publicpages_visibility_documents') && ($login->isSuperAdmin() || count($documents))) {
+        if ($login->isSuperAdmin() || count($documents)) {
             $dashboards = array_merge(
                 $dashboards,
                 [

--- a/galette/lib/Galette/Core/Galette.php
+++ b/galette/lib/Galette/Core/Galette.php
@@ -537,43 +537,93 @@ class Galette
         $menus = [];
         $items = [];
 
-        if ($preferences->showPublicPage($login, 'pref_publicpages_visibility_memberslist')) {
+        $label_members = _T("Members");
+        $label_staff = _T("Staff");
+        $children = [];
+
+        if (
+            $preferences->showPublicPage($login, 'pref_publicpages_visibility_memberslist')
+            || $preferences->showPublicPage($login, 'pref_publicpages_visibility_stafflist')
+        ) {
+            $label = _T("Directories");
+            $route = ['name' => 'publicMembersList'];
+            $route_staff = ['name' => 'publicStaffList'];
+            $icon = 'address book';
+            if (
+                $preferences->showPublicPage($login, 'pref_publicpages_visibility_memberslist')
+                && $preferences->showPublicPage($login, 'pref_publicpages_visibility_stafflist')
+            ) {
+                $children = [
+                    [
+                        'label' => $label_members,
+                        'route' => $route,
+                        'alternative_menu_label' => $label_members,
+                        'alternative_menu_icon' => $icon
+                    ],
+                    [
+                        'label' => $label_staff,
+                        'route' => $route_staff,
+                        'alternative_menu_label' => $label_staff,
+                        'alternative_menu_icon' => $icon . ' outline'
+                    ]
+                ];
+            } elseif (!$preferences->showPublicPage($login, 'pref_publicpages_visibility_memberslist')) {
+                $label = $label_staff;
+                $route = $route_staff;
+                $icon = $icon . ' outline';
+            } elseif (!$preferences->showPublicPage($login, 'pref_publicpages_visibility_stafflist')) {
+                $label = $label_members;
+            }
+
             $items[] = [
-                'label' => _T("Members"),
-                'route' => [
-                    'name' => 'publicMembersList'
-                ],
-                'icon' => 'address book'
+                'label' => $label,
+                'route' => $route,
+                'icon' => $icon,
+                'children' => $children
             ];
         }
 
-        if ($preferences->showPublicPage($login, 'pref_publicpages_visibility_membersgallery')) {
-            $items[] = [
-                'label' => _T('Gallery'),
-                'route' => [
-                    'name' => 'publicMembersGallery'
-                ],
-                'icon' => 'user friends'
-            ];
-        }
+        if (
+            $preferences->showPublicPage($login, 'pref_publicpages_visibility_membersgallery')
+            || $preferences->showPublicPage($login, 'pref_publicpages_visibility_staffgallery')
+        ) {
+            $label = _T("Galleries");
+            $label_members_gallery = _T("Gallery");
+            $label_staff_gallery = _T("Staff gallery");
+            $route = ['name' => 'publicMembersGallery'];
+            $route_staff = ['name' => 'publicStaffGallery'];
+            $icon = 'user friends';
+            if (
+                $preferences->showPublicPage($login, 'pref_publicpages_visibility_membersgallery')
+                && $preferences->showPublicPage($login, 'pref_publicpages_visibility_staffgallery')
+            ) {
+                $children = [
+                    [
+                        'label' => $label_members,
+                        'route' => $route,
+                        'alternative_menu_label' => $label_members_gallery,
+                        'alternative_menu_icon' => $icon
+                    ],
+                    [
+                        'label' => $label_staff,
+                        'route' => $route_staff,
+                        'alternative_menu_label' => $label_staff_gallery,
+                        'alternative_menu_icon' => 'users cog'
+                    ]
+                ];
+            } elseif (!$preferences->showPublicPage($login, 'pref_publicpages_visibility_membersgallery')) {
+                $label = $label_staff_gallery;
+                $route = $route_staff;
+                $icon = 'users cog';
+            } elseif (!$preferences->showPublicPage($login, 'pref_publicpages_visibility_staffgallery')) {
+                $label = $label_members_gallery;
+            }
 
-        if ($preferences->showPublicPage($login, 'pref_publicpages_visibility_stafflist')) {
             $items[] = [
-                'label' => _T("Staff"),
-                'route' => [
-                    'name' => 'publicStaffList'
-                ],
-                'icon' => 'address card'
-            ];
-        }
-
-        if ($preferences->showPublicPage($login, 'pref_publicpages_visibility_staffgallery')) {
-            $items[] = [
-                'label' => _T('Staff gallery'),
-                'route' => [
-                    'name' => 'publicStaffGallery'
-                ],
-                'icon' => 'user cog'
+                'label' => $label,
+                'route' => $route,
+                'icon' => $icon,
+                'children' => $children
             ];
         }
 

--- a/galette/lib/Galette/Core/Galette.php
+++ b/galette/lib/Galette/Core/Galette.php
@@ -531,33 +531,58 @@ class Galette
         global $preferences, $login, $plugins, $zdb;
 
         $menus = [];
-        if ($preferences->showPublicPages($login)) {
-            $menus['public'] = [
-                'title' => _T("Public pages"),
-                'icon' => 'eye outline',
-                'items' => [
-                    [
-                        'label' => _T("Members"),
-                        'route' => [
-                            'name' => 'publicMembersList'
-                        ],
-                        'icon' => 'address book'
+        if ($preferences->arePublicPagesEnabled()) {
+            $items = [];
+
+            if ($preferences->showPublicPage($login, 'pref_publicpages_visibility_memberslist')) {
+                $items[] = [
+                    'label' => _T("Members"),
+                    'route' => [
+                        'name' => 'publicMembersList'
                     ],
-                    [
-                        'label' => _T("Gallery"),
-                        'route' => [
-                            'name' => 'publicMembersGallery'
-                        ],
-                        'icon' => 'user friends'
-                    ]
-                ]
-            ];
+                    'icon' => 'address book'
+                ];
+            }
+
+            if ($preferences->showPublicPage($login, 'pref_publicpages_visibility_membersgallery')) {
+                $items[] = [
+                    'label' => _T('Gallery'),
+                    'route' => [
+                        'name' => 'publicMembersGallery'
+                    ],
+                    'icon' => 'user friends'
+                ];
+            }
+
+            if ($preferences->showPublicPage($login, 'pref_publicpages_visibility_stafflist')) {
+                $items[] = [
+                    'label' => _T("Staff"),
+                    'route' => [
+                        'name' => 'publicStaffList'
+                    ],
+                    'icon' => 'address card'
+                ];
+            }
+
+            if ($preferences->showPublicPage($login, 'pref_publicpages_visibility_staffgallery')) {
+                $items[] = [
+                    'label' => _T('Staff gallery'),
+                    'route' => [
+                        'name' => 'publicStaffGallery'
+                    ],
+                    'icon' => 'user cog'
+                ];
+            }
 
             //display documents menu if at least one document is present with current ACLs
             $document = new Document($zdb);
             $documents = $document->getList();
-            if ($login->isSuperAdmin() || count($documents)) {
-                $menus['public']['items'][] = [
+            if (
+                $login->isSuperAdmin()
+                || $preferences->showPublicPage($login, 'pref_publicpages_visibility_documents')
+                && count($documents)
+            ) {
+                $items[] = [
                     'label' => _T("Documents"),
                     'title' => _T("View documents related to your association"),
                     'route' => [
@@ -572,11 +597,19 @@ class Galette
                 $plugin_class = $plugins->getClassName($module_id, true);
                 if (class_exists($plugin_class)) {
                     $plugin = new $plugin_class();
-                    $menus['public']['items'] = array_merge(
-                        $menus['public']['items'],
+                    $items = array_merge(
+                        $items,
                         $plugin->getPublicMenuItems()
                     );
                 }
+            }
+
+            if (count($items)) {
+                $menus['public'] = [
+                    'title' => _T("Public pages"),
+                    'icon' => 'eye outline',
+                    'items' => $items
+                ];
             }
         }
 
@@ -736,7 +769,7 @@ class Galette
         //display documents menu if at least one document is present with current ACLs
         $document = new Document($zdb);
         $documents = $document->getList();
-        if ($preferences->showPublicPages($login) && ($login->isSuperAdmin() || count($documents))) {
+        if ($preferences->showPublicPage($login, 'pref_publicpages_visibility_documents') && ($login->isSuperAdmin() || count($documents))) {
             $dashboards = array_merge(
                 $dashboards,
                 [

--- a/galette/lib/Galette/Core/GalettePlugin.php
+++ b/galette/lib/Galette/Core/GalettePlugin.php
@@ -65,7 +65,7 @@ abstract class GalettePlugin
         global $preferences, $login;
 
         $menus = [];
-        if ($preferences->showPublicPages($login)) {
+        if ($preferences->showPublicPage($login, 'pref_publicpages_visibility_plugins')) {
             $menus = static::getPublicMenusItemsList();
         }
 

--- a/galette/lib/Galette/Core/Preferences.php
+++ b/galette/lib/Galette/Core/Preferences.php
@@ -114,7 +114,13 @@ use Galette\Repository\Members;
  * @property string $pref_cc_secondary
  * @property string $pref_cc_secondary_text
  * @property boolean $pref_bool_publicpages
- * @property integer $pref_publicpages_visibility
+ * @property integer $pref_publicpages_visibility_generic
+ * @property integer $pref_publicpages_visibility_documents
+ * @property integer $pref_publicpages_visibility_memberslist
+ * @property integer $pref_publicpages_visibility_membersgallery
+ * @property integer $pref_publicpages_visibility_stafflist
+ * @property integer $pref_publicpages_visibility_staffgallery
+ * @property boolean $pref_bool_groupsmanagers_are_staff
  * @property boolean $pref_bool_selfsubscribe
  * @property string $pref_member_form_grid
  * @property string $pref_mail_sign
@@ -169,12 +175,15 @@ class Preferences
     public const POSTAL_ADDRESS_FROM_STAFF = 1;
 
     /** Public pages stuff */
-    /** Public pages are publically visibles */
+    /** Public pages are publicly visibles */
     public const PUBLIC_PAGES_VISIBILITY_PUBLIC = 0;
     /** Public pages are visibles for up-to-date members only */
     public const PUBLIC_PAGES_VISIBILITY_RESTRICTED = 1;
     /** Public pages are visibles for admin and staff members only */
     public const PUBLIC_PAGES_VISIBILITY_PRIVATE = 2;
+    /** Public pages are hidden */
+    public const PUBLIC_PAGES_VISIBILITY_HIDDEN = 3;
+    public const PUBLIC_PAGES_VISIBILITY_INHERIT = 4;
 
     /** No password strength */
     public const PWD_NONE = 0;
@@ -274,7 +283,13 @@ class Preferences
         'pref_card_self'    =>    1,
         'pref_theme'        =>    'default',
         'pref_bool_publicpages' => true,
-        'pref_publicpages_visibility' => self::PUBLIC_PAGES_VISIBILITY_RESTRICTED,
+        'pref_publicpages_visibility_generic' => self::PUBLIC_PAGES_VISIBILITY_RESTRICTED,
+        'pref_publicpages_visibility_documents' => self::PUBLIC_PAGES_VISIBILITY_RESTRICTED,
+        'pref_publicpages_visibility_memberslist' => self::PUBLIC_PAGES_VISIBILITY_RESTRICTED,
+        'pref_publicpages_visibility_membersgallery' => self::PUBLIC_PAGES_VISIBILITY_RESTRICTED,
+        'pref_publicpages_visibility_stafflist' => self::PUBLIC_PAGES_VISIBILITY_RESTRICTED,
+        'pref_publicpages_visibility_staffgallery' => self::PUBLIC_PAGES_VISIBILITY_RESTRICTED,
+        'pref_bool_groupsmanagers_are_staff' => false,
         'pref_mail_sign' => "{ASSO_NAME}\r\n\r\n{ASSO_WEBSITE}",
         /* Preferences for member/subscribe form */
         'pref_bool_selfsubscribe' => true,
@@ -972,16 +987,53 @@ class Preferences
     /**
      * Are public pages visible?
      *
+     * @return boolean
+     */
+    public function arePublicPagesEnabled(): bool
+    {
+        return (bool)$this->prefs['pref_bool_publicpages'];
+    }
+
+    /**
+     * Are public pages visible?
+     *
      * @param Authentication $login Authentication instance
      *
      * @return boolean
+     *
+     * @deprecated 1.2.0
      */
     public function showPublicPages(Authentication $login): bool
     {
-        if ($this->prefs['pref_bool_publicpages']) {
+        Analog::log(
+            'Preferences::showPublicPages() is deprecated, use Preferences::showPublicPage() instead.',
+            Analog::WARNING
+        );
+        return $this->showPublicPage($login, 'pref_publicpages_visibility_memberslist')
+            || $this->showPublicPage($login, 'pref_publicpages_visibility_membersgallery');
+    }
+
+    /**
+     * Are public pages visible?
+     *
+     * @param Authentication $login Authentication instance
+     * @param string         $right Right to check
+     *
+     * @return boolean
+     */
+    public function showPublicPage(Authentication $login, string $right): bool
+    {
+        if ($this->arePublicPagesEnabled()) {
             //if public pages are actives, let's check if we
             //display them for curent call
-            switch ($this->prefs['pref_publicpages_visibility']) {
+            if (!isset($this->prefs[$right])) {
+                //Core does not handle plugins permission, just a global right.
+                $right = 'pref_publicpages_visibility_generic';
+            }
+            switch ($this->prefs[$right]) {
+                case self::PUBLIC_PAGES_VISIBILITY_INHERIT:
+                    //inherit from generic right
+                    return $this->showPublicPage($login, 'pref_publicpages_visibility_generic');
                 case self::PUBLIC_PAGES_VISIBILITY_PUBLIC:
                     //pages are publicly visibles
                     return true;
@@ -1004,8 +1056,7 @@ class Preferences
                         return false;
                     }
                 default:
-                    //should never be there
-                    return false;
+                    throw new \RuntimeException('Unknown public pages right: ' . $this->prefs[$right]);
             }
         } else {
             return false;
@@ -1050,7 +1101,12 @@ class Preferences
                 'pref_postal_staff_member',
                 'pref_password_length',
                 'pref_password_strength',
-                'pref_publicpages_visibility',
+                'pref_publicpages_visibility_generic',
+                'pref_publicpages_visibility_documents',
+                'pref_publicpages_visibility_memberslist',
+                'pref_publicpages_visibility_membersgallery',
+                'pref_publicpages_visibility_stafflist',
+                'pref_publicpages_visibility_staffgallery',
                 'pref_redirect_on_create',
                 'pref_statut'
             ],

--- a/galette/lib/Galette/Core/Preferences.php
+++ b/galette/lib/Galette/Core/Preferences.php
@@ -1026,42 +1026,34 @@ class Preferences
     public function showPublicPage(Authentication $login, string $right): bool
     {
         if ($this->arePublicPagesEnabled()) {
-            //if public pages are actives, let's check if we
-            //display them for curent call
-            if (!isset($this->prefs[$right])) {
-                //Core does not handle plugins permission, just a global right.
-                $right = 'pref_publicpages_visibility_generic';
-            }
-            switch ($this->prefs[$right]) {
-                case self::PUBLIC_PAGES_VISIBILITY_INHERIT:
-                    //inherit from generic right
-                    return $this->showPublicPage($login, 'pref_publicpages_visibility_generic');
-                case self::PUBLIC_PAGES_VISIBILITY_PUBLIC:
-                    //pages are publicly visibles
-                    return true;
-                case self::PUBLIC_PAGES_VISIBILITY_RESTRICTED:
-                    //pages should be displayed only for up-to-date members
-                    if (
-                        $login->isUp2Date()
-                        || $login->isAdmin()
-                        || $login->isStaff()
-                    ) {
-                        return true;
-                    } else {
-                        return false;
-                    }
-                case self::PUBLIC_PAGES_VISIBILITY_PRIVATE:
-                    //pages should be displayed only for staff and admins
-                    if ($login->isAdmin() || $login->isStaff()) {
-                        return true;
-                    } else {
-                        return false;
-                    }
-                default:
-                    throw new \RuntimeException('Unknown public pages right: ' . $this->prefs[$right]);
-            }
-        } else {
             return false;
+        }
+
+        //if public pages are actives, let's check if we
+        //display them for curent call
+        if (!isset($this->prefs[$right])) {
+            //Core does not handle plugins permission, just a global right.
+            $right = 'pref_publicpages_visibility_generic';
+        }
+        switch ($this->prefs[$right]) {
+            case self::PUBLIC_PAGES_VISIBILITY_INHERIT:
+                //inherit from generic right
+                return $this->showPublicPage($login, 'pref_publicpages_visibility_generic');
+            case self::PUBLIC_PAGES_VISIBILITY_PUBLIC:
+                //pages are publicly visibles
+                return true;
+            case self::PUBLIC_PAGES_VISIBILITY_RESTRICTED:
+                //pages should be displayed only for up-to-date members
+                return
+                    $login->isUp2Date()
+                    || $login->isAdmin()
+                    || $login->isStaff()
+                ;
+            case self::PUBLIC_PAGES_VISIBILITY_PRIVATE:
+                //pages should be displayed only for staff and admins
+                return $login->isAdmin() || $login->isStaff();
+            default:
+                throw new \RuntimeException('Unknown public pages right: ' . $this->prefs[$right]);
         }
     }
 

--- a/galette/lib/Galette/Core/Preferences.php
+++ b/galette/lib/Galette/Core/Preferences.php
@@ -1025,7 +1025,7 @@ class Preferences
      */
     public function showPublicPage(Authentication $login, string $right): bool
     {
-        if ($this->arePublicPagesEnabled()) {
+        if (!$this->arePublicPagesEnabled()) {
             return false;
         }
 

--- a/galette/lib/Galette/Core/Preferences.php
+++ b/galette/lib/Galette/Core/Preferences.php
@@ -122,6 +122,7 @@ use Galette\Repository\Members;
  * @property integer $pref_publicpages_visibility_staffgallery
  * @property boolean $pref_bool_groupsmanagers_are_staff
  * @property boolean $pref_bool_selfsubscribe
+ * @property boolean $pref_bool_empty_form_link
  * @property string $pref_member_form_grid
  * @property string $pref_mail_sign
  * @property string $pref_new_contrib_script
@@ -294,6 +295,7 @@ class Preferences
         /* Preferences for member/subscribe form */
         'pref_bool_selfsubscribe' => true,
         'pref_member_form_grid' => 'one',
+        'pref_bool_empty_form_link' => false,
         /* New contribution script */
         'pref_new_contrib_script' => '',
         'pref_bool_wrap_mails' => true,
@@ -1125,6 +1127,7 @@ class Preferences
                 'pref_bool_mailowner',
                 'pref_bool_publicpages',
                 'pref_bool_selfsubscribe',
+                'pref_bool_empty_form_link',
                 'pref_bool_wrap_mails',
                 'pref_disable_members_socials',
                 'pref_editor_enabled',

--- a/galette/lib/Galette/Middleware/PublicPages.php
+++ b/galette/lib/Galette/Middleware/PublicPages.php
@@ -72,7 +72,26 @@ class PublicPages
     {
         $response = new \Slim\Psr7\Response();
 
-        if (!$this->preferences->showPublicPages($this->login)) {
+        $right_pattern = 'pref_publicpages_visibility_%s%s';
+        $current_path = trim($request->getUri()->getPath(), '/');
+        $page = explode('/', $current_path);
+        if ($page[0] === 'plugins') {
+            $right_pattern .= '_%s';
+            $right = sprintf(
+                $right_pattern,
+                'plugin',
+                $page[1] ?? '',
+                $page[3] ?? ''
+            );
+        } else {
+            $right = sprintf(
+                $right_pattern,
+                $page[1] ?? '',
+                $page[2] ?? ''
+            );
+        }
+
+        if (!$this->preferences->showPublicPage($this->login, $right)) {
             $this->flash->addMessage('error_detected', _T("Unauthorized"));
             return $response
                 ->withHeader(

--- a/galette/templates/default/elements/inline_styles.html.twig
+++ b/galette/templates/default/elements/inline_styles.html.twig
@@ -87,6 +87,7 @@
         .custom-colors .ui.menu .active.item,
         .custom-colors .ui.fixed.menu .item.active,
         .custom-colors .ui.fixed.menu .item:active:not(.right):not(:hover),
+        .custom-colors .ui.fixed.menu .active-menu.dropdown.item:not(:hover),
         .custom-colors .ui.inverted.menu .active.item,
         .custom-colors .ui.vertical.menu .active.item,
         .custom-colors .ui.vertical.menu .content.active .item:active:not(:hover),

--- a/galette/templates/default/elements/language.html.twig
+++ b/galette/templates/default/elements/language.html.twig
@@ -20,11 +20,11 @@
 #}
 {% if ui is defined %}
     {% if ui == 'item'%}
-        {% set component_classes = "tooltip language item" %}
+        {% set component_classes = "tooltip focus-visible language item" %}
         {% set content_classes = "content" %}
         {% set header = true %}
     {% elseif ui == 'dropdown' %}
-        {% set component_classes = "tooltip language ui dropdown navigation right-aligned item" %}
+        {% set component_classes = "tooltip focus-visible language ui dropdown navigation right-aligned item" %}
         {% set content_classes = "menu" %}
         {% set header = false %}
     {% endif %}

--- a/galette/templates/default/elements/navigation/navigation_sidebar.html.twig
+++ b/galette/templates/default/elements/navigation/navigation_sidebar.html.twig
@@ -34,7 +34,7 @@
     {% include "elements/navigation/public_pages.html.twig" with {
             tips_position: "right center",
             sign_in: true,
-            mode: "default"
+            mode: "sidebar"
     } %}
 {% else %}
     {% include "elements/navigation/navigation_items.html.twig" with {

--- a/galette/templates/default/elements/navigation/navigation_topbar.html.twig
+++ b/galette/templates/default/elements/navigation/navigation_topbar.html.twig
@@ -32,7 +32,7 @@
                 tips_position: "bottom center",
                 sign_in: true,
                 sign_in_side: 'right',
-                mode: "default"
+                mode: "topbar"
         } %}
 
         {% include "elements/language.html.twig" with {

--- a/galette/templates/default/elements/navigation/public_pages.html.twig
+++ b/galette/templates/default/elements/navigation/public_pages.html.twig
@@ -39,6 +39,14 @@
             'icon': 'add user',
             'class': 'ui basic button'
         }]) %}
+    {% elseif (not is_current_url("subscribe") and ext_auth is not defined) and preferences.pref_bool_empty_form_link %}
+        {% set public_items = public_items|merge([{
+            'label': _T("Empty adhesion form"),
+            'title': _T("Download empty adhesion form"),
+            'route': {'name': 'emptyAdhesionForm'},
+            'icon': 'red file pdf outline',
+            'class': 'ui basic button'
+        }]) %}
     {% endif %}
     {% if not is_current_url("login") and ext_auth is not defined %}
         {% set public_items = public_items|merge([{

--- a/galette/templates/default/elements/navigation/public_pages.html.twig
+++ b/galette/templates/default/elements/navigation/public_pages.html.twig
@@ -25,7 +25,7 @@
         {% set public_menus = callstatic('\\Galette\\Core\\Galette', 'getPublicMenus') %}
         {% for public_menu in public_menus %}
             {% for public_item in public_menu.items %}
-                {{ menus_macros.renderMenuItem(public_item.label, public_item.title ?? null, public_item.route, public_item.icon ?? null, null, tips_position, mode) }}
+                {{ menus_macros.renderMenuItem(public_item.label, public_item.title ?? null, public_item.route, public_item.icon ?? null, null, tips_position, mode, public_item.children ?? null) }}
             {% endfor %}
         {% endfor %}
     {% endif %}

--- a/galette/templates/default/macros.twig
+++ b/galette/templates/default/macros.twig
@@ -22,6 +22,11 @@
     {% set my_routes = [] %}
     {% for item in items %}
         {% set my_routes = my_routes|merge([item.route.name])|merge(item.route.aliases ?? []) %}
+        {% if item.children is defined %}
+            {% for child in item.children %}
+                {% set my_routes = my_routes|merge([child.route.name])|merge(child.route.aliases ?? []) %}
+            {% endfor %}
+        {% endif %}
     {% endfor %}
     {% if mode == "compact" %}
         <div class="ui{% if cur_route in my_routes %} active-menu{% endif %} dropdown navigation item tooltip" data-html="{{ title }}" data-position="right center">
@@ -30,7 +35,7 @@
             <i class="dropdown icon" aria-hidden="true"></i>
             <div class="menu">
                 {% for item in items %}
-                    {{ _self.renderMenuItem(item.label, item.title ?? null, item.route, item.icon ?? null, null, 'right center') }}
+                    {{ _self.renderMenuItem(item.label, item.title ?? null, item.route, null, null, 'right center', mode, item.children ?? null) }}
                 {% endfor %}
             </div>
         </div>
@@ -43,14 +48,14 @@
             </div>
             <div class="content{% if cur_route in my_routes %} active{% endif %}">
                 {% for item in items %}
-                    {{ _self.renderMenuItem(item.label, item.title ?? null, item.route, item.icon ?? null, null, null, mode) }}
+                    {{ _self.renderMenuItem(item.label, item.title ?? null, item.route, item.icon ?? null, null, null, mode, item.children ?? null) }}
                 {% endfor %}
             </div>
         </div>
     {% endif %}
 {% endmacro %}
 
-{% macro renderMenuItem(label, title, route, icon, class, tips_position, mode) %}
+{% macro renderMenuItem(label, title, route, icon, class, tips_position, mode, children) %}
     {% if class is empty %}
         {% set my_routes = [route.name]|merge(route.aliases ?? []) %}
         {% if is_current_url(route.name, route.args ?? [] + cur_route_args ?? []) %}
@@ -59,18 +64,50 @@
             {% set class = "item" %}
         {% endif %}
     {% endif %}
-    <a
-            href="{{ url_for(route.name, route.args|default([])) }}"
-            class="{{ class }}"
-            {% if title %}title="{{ title }}"{% endif %}
-            {% if tips_position %}data-position="{{ tips_position }}"{% endif %}
-            {% if mode != "default" %}tabindex="-1"{% endif %}
-    >
-        {% if icon %}
+    {% if children is empty %}
+        <a
+                href="{{ url_for(route.name, route.args|default([])) }}"
+                class="{{ class }}"
+                {% if title %}title="{{ title }}"{% endif %}
+                {% if tips_position %}data-position="{{ tips_position }}"{% endif %}
+                {% if mode == "compact" %}tabindex="-1"{% endif %}
+        >
+        {% if icon and mode != 'compact' %}
             <i class="{{ icon }} icon" aria-hidden="true"></i>
         {% endif %}
-        {{ label }}
-    </a>
+            {{ label }}
+        </a>
+    {% elseif (mode != 'topbar') and login.isLogged() %}
+        {% for item in children %}
+            {% set icon = mode == "compact" ? null : item.alternative_menu_icon %}
+            {{ _self.renderMenuItem(item.alternative_menu_label, item.title ?? null, item.route, icon, null, item.tips_position ?? null) }}
+        {% endfor %}
+    {% else %}
+        {{ _self.renderMenuDropdown(label, title ?? null, icon ?? null, tips_position ?? null, mode, children) }}
+    {% endif %}
+{% endmacro %}
+
+{% macro renderMenuDropdown(label, title, icon, tips_position, mode, children) %}
+    {% set my_routes = [] %}
+    {% for item in children %}
+        {% set my_routes = my_routes|merge([item.route.name])|merge(item.route.aliases ?? []) %}
+    {% endfor %}
+    <div class="{{ mode != 'sidebar' ? 'focus-visible ui dropdown navigation ' }}{% if cur_route in my_routes %} active-menu {% endif %}item">
+    {% if mode == 'sidebar' %}
+        <div class="image header title" data-fold="fold-{{ icon|replace({' ': '-'}) }}" tabindex="0">
+    {% endif %}
+            <i class="{{ icon }} icon" aria-hidden="true"></i>
+            <span>{{ label }}</span>
+            <i class="dropdown icon" aria-hidden="true"></i>
+    {% if mode == 'sidebar' %}
+        </div>
+    {% endif %}
+        <div class="{{ mode != 'sidebar' ? 'menu' : 'content' }}{{ mode == 'sidebar' and cur_route in my_routes ?? ' active' }}" tabindex="-1">
+            {% for item in children %}
+                {{ _self.renderMenuItem(item.label, item.title ?? null, item.route, null, null, null, mode) }}
+            {% endfor %}
+        </div>
+    </div>
 {% endmacro %}
 
 {% macro dashboardCard(label, title, route, icon) %}

--- a/galette/templates/default/pages/member_form.html.twig
+++ b/galette/templates/default/pages/member_form.html.twig
@@ -120,6 +120,24 @@
         </div>
         <div class="sixteen wide tablet ten wide computer eleven wide widescreen column">
     {% endif %}
+
+    {% if (member.id is empty or self_adh and members.list is not defined) and preferences.pref_bool_empty_form_link %}
+            <div class="ui icon info visible message">
+                <i class="info circle blue icon" aria-hidden="true"></i>
+                <div class="content">
+                    {{ _T("If you'd rather not subscribe online, you can download an empty adhesion form") }}
+                    <a
+                        href="{{ url_for("emptyAdhesionForm") }}"
+                        class="ui right floated labeled icon button"
+                        title="{{ _T("Download empty adhesion form") }}"
+                    >
+                        <i class="red file pdf outline icon" aria-hidden="true"></i>
+                        <span>{{ _T("Empty adhesion form") }}</span>
+                    </a>
+                </div>
+            </div>
+    {% endif %}
+
             {# Main form entries #}
             {% include "components/form.html.twig" %}
 

--- a/galette/templates/default/pages/plugins.html.twig
+++ b/galette/templates/default/pages/plugins.html.twig
@@ -34,7 +34,7 @@
             </tr>
         </thead>
         <tbody>
-            <tr class="plugins">
+            <tr class="with-headers plugins">
                 <th colspan="6" class="center aligned"><strong>{{ _T('Active plugins') }}</strong></th>
             </tr>
 {% for name, plugin in plugins_list %}
@@ -71,7 +71,7 @@
                 <td colspan="6">{{ _T('No active plugin.') }}</td>
             </tr>
 {% endfor %}
-            <tr class="inactives plugins">
+            <tr class="with-headers inactives plugins">
                 <th colspan="6" class="center aligned"><strong>{{ _T('Inactive plugins') }}</strong></th>
             </tr>
             <thead>

--- a/galette/templates/default/pages/preferences.html.twig
+++ b/galette/templates/default/pages/preferences.html.twig
@@ -327,12 +327,37 @@
                             <label for="pref_bool_publicpages">{{ _T("Public pages enabled?") }}</label>
                         </div>
                     </div>
-                    <div id="publicpages_visibility" class="field{% if not pref.pref_bool_publicpages %} displaynone{% endif %}">
-                        <label for="pref_publicpages_visibility">{{ _T("Show public pages for") }}</label>
-                        <select name="pref_publicpages_visibility" id="pref_publicpages_visibility" class="ui search dropdown">
-                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PUBLIC') }}"{% if pref.pref_publicpages_visibility == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PUBLIC') %} selected="selected"{% endif %}>{{ _T("Everyone") }}</option>
-                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_RESTRICTED') }}"{% if pref.pref_publicpages_visibility == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_RESTRICTED') %} selected="selected"{% endif %}>{{ _T("Up to date members") }}</option>
-                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') }}"{% if pref.pref_publicpages_visibility == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') %} selected="selected"{% endif %}>{{ _T("Admin and staff only") }}</option>
+                    <div class="publicpages_visibility field{% if not pref.pref_bool_publicpages %} displaynone{% endif %}">
+                        <label for="pref_publicpages_visibility_generic">
+                            {{ _T("Default") }}
+                            <i class="circular small inverted primary icon info tooltip" title="{{ _T("Will apply for all public pages that are not listed here, including plugin ones.") }}" aria-hidden="true"></i>
+                        </label>
+                        <select name="pref_publicpages_visibility_generic" id="pref_publicpages_visibility_generic" class="ui search dropdown">
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_HIDDEN') }}"{% if pref.pref_publicpages_visibility_generic == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_HIDDEN') %} selected="selected"{% endif %}>{{ _T("Hidden") }}</option>
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PUBLIC') }}"{% if pref.pref_publicpages_visibility_generic == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PUBLIC') %} selected="selected"{% endif %}>{{ _T("Everyone") }}</option>
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_RESTRICTED') }}"{% if pref.pref_publicpages_visibility_generic == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_RESTRICTED') %} selected="selected"{% endif %}>{{ _T("Up to date members") }}</option>
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') }}"{% if pref.pref_publicpages_visibility_generic == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') %} selected="selected"{% endif %}>{{ _T("Admin and staff only") }}</option>
+                        </select>
+                    </div>
+
+                    <div class="publicpages_visibility field{% if not pref.pref_bool_publicpages %} displaynone{% endif %}">
+                        <label for="pref_publicpages_visibility_memberslist">{{ _T("Members list") }}</label>
+                        <select name="pref_publicpages_visibility_memberslist" id="pref_publicpages_visibility_memberslist" class="ui search dropdown">
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_HIDDEN') }}"{% if pref.pref_publicpages_visibility_memberslist == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_INHERIT') %} selected="selected"{% endif %}>{{ _T("Inherit") }}</option>
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_HIDDEN') }}"{% if pref.pref_publicpages_visibility_memberslist == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_HIDDEN') %} selected="selected"{% endif %}>{{ _T("Hidden") }}</option>
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PUBLIC') }}"{% if pref.pref_publicpages_visibility_memberslist == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PUBLIC') %} selected="selected"{% endif %}>{{ _T("Everyone") }}</option>
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_RESTRICTED') }}"{% if pref.pref_publicpages_visibility_memberslist == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_RESTRICTED') %} selected="selected"{% endif %}>{{ _T("Up to date members") }}</option>
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') }}"{% if pref.pref_publicpages_visibility_memberslist == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') %} selected="selected"{% endif %}>{{ _T("Admin and staff only") }}</option>
+                        </select>
+                    </div>
+                    <div class="publicpages_visibility field{% if not pref.pref_bool_publicpages %} displaynone{% endif %}">
+                        <label for="pref_publicpages_visibility_membersgallery">{{ _T("Members gallery") }}</label>
+                        <select name="pref_publicpages_visibility_membersgallery" id="pref_publicpages_visibility_membersgallery" class="ui search dropdown">
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_HIDDEN') }}"{% if pref.pref_publicpages_visibility_membersgallery == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_INHERIT') %} selected="selected"{% endif %}>{{ _T("Inherit") }}</option>
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_HIDDEN') }}"{% if pref.pref_publicpages_visibility_membersgallery == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_HIDDEN') %} selected="selected"{% endif %}>{{ _T("Hidden") }}</option>
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PUBLIC') }}"{% if pref.pref_publicpages_visibility_membersgallery == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PUBLIC') %} selected="selected"{% endif %}>{{ _T("Everyone") }}</option>
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_RESTRICTED') }}"{% if pref.pref_publicpages_visibility_membersgallery == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_RESTRICTED') %} selected="selected"{% endif %}>{{ _T("Up to date members") }}</option>
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') }}"{% if pref.pref_publicpages_visibility_membersgallery == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') %} selected="selected"{% endif %}>{{ _T("Admin and staff only") }}</option>
                         </select>
                     </div>
                 </div>{# /column #}
@@ -341,6 +366,42 @@
                         <div class="ui right aligned toggle checkbox">
                             <input type="checkbox" name="pref_bool_selfsubscribe" id="pref_bool_selfsubscribe" value="1"{% if pref.pref_bool_selfsubscribe %} checked="checked"{% endif %}/>
                             <label for="pref_bool_selfsubscribe">{{ _T("Self subscription enabled?") }}</label>
+                        </div>
+                    </div>
+                    <div class="publicpages_visibility field{% if not pref.pref_bool_publicpages %} displaynone{% endif %}">
+                        <label for="pref_publicpages_visibility_documents">{{ _T("Documents") }}</label>
+                        <select name="pref_publicpages_visibility_documents" id="pref_publicpages_visibility_documents" class="ui search dropdown">
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_HIDDEN') }}"{% if pref.pref_publicpages_visibility_documents == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_INHERIT') %} selected="selected"{% endif %}>{{ _T("Inherit") }}</option>
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_HIDDEN') }}"{% if pref.pref_publicpages_visibility_documents == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_HIDDEN') %} selected="selected"{% endif %}>{{ _T("Hidden") }}</option>
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PUBLIC') }}"{% if pref.pref_publicpages_visibility_documents == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PUBLIC') %} selected="selected"{% endif %}>{{ _T("Everyone") }}</option>
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_RESTRICTED') }}"{% if pref.pref_publicpages_visibility_documents == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_RESTRICTED') %} selected="selected"{% endif %}>{{ _T("Up to date members") }}</option>
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') }}"{% if pref.pref_publicpages_visibility_documents == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') %} selected="selected"{% endif %}>{{ _T("Admin and staff only") }}</option>
+                        </select>
+                    </div>
+                    <div class="publicpages_visibility field{% if not pref.pref_bool_publicpages %} displaynone{% endif %}">
+                        <label for="pref_publicpages_visibility_stafflist">{{ _T("Staff list") }}</label>
+                        <select name="pref_publicpages_visibility_stafflist" id="pref_publicpages_visibility_stafflist" class="ui search dropdown">
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_HIDDEN') }}"{% if pref.pref_publicpages_visibility_stafflist == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_INHERIT') %} selected="selected"{% endif %}>{{ _T("Inherit") }}</option>
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_HIDDEN') }}"{% if pref.pref_publicpages_visibility_stafflist == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_HIDDEN') %} selected="selected"{% endif %}>{{ _T("Hidden") }}</option>
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PUBLIC') }}"{% if pref.pref_publicpages_visibility_stafflist == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PUBLIC') %} selected="selected"{% endif %}>{{ _T("Everyone") }}</option>
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_RESTRICTED') }}"{% if pref.pref_publicpages_visibility_stafflist == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_RESTRICTED') %} selected="selected"{% endif %}>{{ _T("Up to date members") }}</option>
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') }}"{% if pref.pref_publicpages_visibility_stafflist == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') %} selected="selected"{% endif %}>{{ _T("Admin and staff only") }}</option>
+                        </select>
+                    </div>
+                    <div class="publicpages_visibility field{% if not pref.pref_bool_publicpages %} displaynone{% endif %}">
+                        <label for="pref_publicpages_visibility_staffgallery">{{ _T("Staff gallery") }}</label>
+                        <select name="pref_publicpages_visibility_staffgallery" id="pref_publicpages_visibility_staffgallery" class="ui search dropdown">
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_HIDDEN') }}"{% if pref.pref_publicpages_visibility_staffgallery == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_INHERIT') %} selected="selected"{% endif %}>{{ _T("Inherit") }}</option>
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_HIDDEN') }}"{% if pref.pref_publicpages_visibility_staffgallery == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_HIDDEN') %} selected="selected"{% endif %}>{{ _T("Hidden") }}</option>
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PUBLIC') }}"{% if pref.pref_publicpages_visibility_staffgallery == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PUBLIC') %} selected="selected"{% endif %}>{{ _T("Everyone") }}</option>
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_RESTRICTED') }}"{% if pref.pref_publicpages_visibility_staffgallery == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_RESTRICTED') %} selected="selected"{% endif %}>{{ _T("Up to date members") }}</option>
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') }}"{% if pref.pref_publicpages_visibility_staffgallery == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') %} selected="selected"{% endif %}>{{ _T("Admin and staff only") }}</option>
+                        </select>
+                    </div>
+                    <div class="publicpages_visibility field inline"{% if not pref.pref_bool_publicpages %} displaynone{% endif %}>
+                        <div class="ui right aligned toggle checkbox">
+                            <input type="checkbox" name="pref_bool_groupsmanagers_are_staff" id="pref_bool_groupsmanagers_are_staff" value="1" {% if pref.pref_bool_groupsmanagers_are_staff %} checked="checked"{% endif %}/>
+                            <label for="pref_bool_groupsmanagers_are_staff">{{ _T("Include groups managers with staff?") }}</label>
                         </div>
                     </div>
                 </div>{# /column #}
@@ -1042,9 +1103,11 @@
                 });
 
                 let _publicpages_status = document.getElementById('pref_bool_publicpages');
-                let _publicpages_visibility = document.getElementById('publicpages_visibility');
+                let _publicpages_visibility = document.getElementsByClassName('publicpages_visibility');
                 _publicpages_status.addEventListener('change', function () {
-                    _publicpages_visibility.classList.toggle('displaynone');
+                    for (let i = 0; i < _publicpages_visibility.length; i++) {
+                        _publicpages_visibility[i].classList.toggle('displaynone');
+                    }
                     return;
                 });
 

--- a/galette/templates/default/pages/preferences.html.twig
+++ b/galette/templates/default/pages/preferences.html.twig
@@ -319,7 +319,23 @@
                 <i class="eye outline icon"></i>
                 {{ __('Public pages') }}
             </div>
-            <div class="ui stackable two column grid">
+            <div class="ui stackable three column grid">
+                <div class="column">
+                    <div class="field inline">
+                        <div class="ui right aligned toggle checkbox">
+                            <input type="checkbox" name="pref_bool_selfsubscribe" id="pref_bool_selfsubscribe" value="1"{% if pref.pref_bool_selfsubscribe %} checked="checked"{% endif %}/>
+                            <label for="pref_bool_selfsubscribe">{{ _T("Self subscription enabled?") }}</label>
+                        </div>
+                    </div>
+                </div>{# /column #}
+                <div class="column">
+                    <div class="field inline">
+                        <div class="ui right aligned toggle checkbox">
+                            <input type="checkbox" name="pref_bool_empty_form_link" id="pref_bool_empty_form_link" value="1"{% if pref.pref_bool_empty_form_link %} checked="checked"{% endif %}/>
+                            <label for="pref_bool_empty_form_link">{{ _T("Display the link to download the empty adhesion form") }}</label>
+                        </div>
+                    </div>
+                </div>{# /column #}
                 <div class="column">
                     <div class="field inline">
                         <div class="ui right aligned toggle checkbox">
@@ -327,7 +343,11 @@
                             <label for="pref_bool_publicpages">{{ _T("Public pages enabled?") }}</label>
                         </div>
                     </div>
-                    <div class="publicpages_visibility field{% if not pref.pref_bool_publicpages %} displaynone{% endif %}">
+                </div>{# /column #}
+            </div>
+            <div id="publicpages_visibility" class="ui stackable two column grid{% if not pref.pref_bool_publicpages %} displaynone{% endif %}">
+                <div class="column">
+                    <div class="field">
                         <label for="pref_publicpages_visibility_generic">
                             {{ _T("Default") }}
                             <i class="circular small inverted primary icon info tooltip" title="{{ _T("Will apply for all public pages that are not listed here, including plugin ones.") }}" aria-hidden="true"></i>
@@ -339,8 +359,7 @@
                             <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') }}"{% if pref.pref_publicpages_visibility_generic == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') %} selected="selected"{% endif %}>{{ _T("Admin and staff only") }}</option>
                         </select>
                     </div>
-
-                    <div class="publicpages_visibility field{% if not pref.pref_bool_publicpages %} displaynone{% endif %}">
+                    <div class="field">
                         <label for="pref_publicpages_visibility_memberslist">{{ _T("Members list") }}</label>
                         <select name="pref_publicpages_visibility_memberslist" id="pref_publicpages_visibility_memberslist" class="ui search dropdown">
                             <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_HIDDEN') }}"{% if pref.pref_publicpages_visibility_memberslist == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_INHERIT') %} selected="selected"{% endif %}>{{ _T("Inherit") }}</option>
@@ -350,7 +369,7 @@
                             <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') }}"{% if pref.pref_publicpages_visibility_memberslist == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') %} selected="selected"{% endif %}>{{ _T("Admin and staff only") }}</option>
                         </select>
                     </div>
-                    <div class="publicpages_visibility field{% if not pref.pref_bool_publicpages %} displaynone{% endif %}">
+                    <div class="field">
                         <label for="pref_publicpages_visibility_membersgallery">{{ _T("Members gallery") }}</label>
                         <select name="pref_publicpages_visibility_membersgallery" id="pref_publicpages_visibility_membersgallery" class="ui search dropdown">
                             <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_HIDDEN') }}"{% if pref.pref_publicpages_visibility_membersgallery == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_INHERIT') %} selected="selected"{% endif %}>{{ _T("Inherit") }}</option>
@@ -362,13 +381,7 @@
                     </div>
                 </div>{# /column #}
                 <div class="column">
-                    <div class="field inline">
-                        <div class="ui right aligned toggle checkbox">
-                            <input type="checkbox" name="pref_bool_selfsubscribe" id="pref_bool_selfsubscribe" value="1"{% if pref.pref_bool_selfsubscribe %} checked="checked"{% endif %}/>
-                            <label for="pref_bool_selfsubscribe">{{ _T("Self subscription enabled?") }}</label>
-                        </div>
-                    </div>
-                    <div class="publicpages_visibility field{% if not pref.pref_bool_publicpages %} displaynone{% endif %}">
+                    <div class="field">
                         <label for="pref_publicpages_visibility_documents">{{ _T("Documents") }}</label>
                         <select name="pref_publicpages_visibility_documents" id="pref_publicpages_visibility_documents" class="ui search dropdown">
                             <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_HIDDEN') }}"{% if pref.pref_publicpages_visibility_documents == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_INHERIT') %} selected="selected"{% endif %}>{{ _T("Inherit") }}</option>
@@ -378,7 +391,7 @@
                             <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') }}"{% if pref.pref_publicpages_visibility_documents == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') %} selected="selected"{% endif %}>{{ _T("Admin and staff only") }}</option>
                         </select>
                     </div>
-                    <div class="publicpages_visibility field{% if not pref.pref_bool_publicpages %} displaynone{% endif %}">
+                    <div class="field">
                         <label for="pref_publicpages_visibility_stafflist">{{ _T("Staff list") }}</label>
                         <select name="pref_publicpages_visibility_stafflist" id="pref_publicpages_visibility_stafflist" class="ui search dropdown">
                             <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_HIDDEN') }}"{% if pref.pref_publicpages_visibility_stafflist == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_INHERIT') %} selected="selected"{% endif %}>{{ _T("Inherit") }}</option>
@@ -388,7 +401,7 @@
                             <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') }}"{% if pref.pref_publicpages_visibility_stafflist == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') %} selected="selected"{% endif %}>{{ _T("Admin and staff only") }}</option>
                         </select>
                     </div>
-                    <div class="publicpages_visibility field{% if not pref.pref_bool_publicpages %} displaynone{% endif %}">
+                    <div class="field">
                         <label for="pref_publicpages_visibility_staffgallery">{{ _T("Staff gallery") }}</label>
                         <select name="pref_publicpages_visibility_staffgallery" id="pref_publicpages_visibility_staffgallery" class="ui search dropdown">
                             <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_HIDDEN') }}"{% if pref.pref_publicpages_visibility_staffgallery == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_INHERIT') %} selected="selected"{% endif %}>{{ _T("Inherit") }}</option>
@@ -398,7 +411,7 @@
                             <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') }}"{% if pref.pref_publicpages_visibility_staffgallery == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') %} selected="selected"{% endif %}>{{ _T("Admin and staff only") }}</option>
                         </select>
                     </div>
-                    <div class="publicpages_visibility field inline"{% if not pref.pref_bool_publicpages %} displaynone{% endif %}>
+                    <div class="field inline">
                         <div class="ui right aligned toggle checkbox">
                             <input type="checkbox" name="pref_bool_groupsmanagers_are_staff" id="pref_bool_groupsmanagers_are_staff" value="1" {% if pref.pref_bool_groupsmanagers_are_staff %} checked="checked"{% endif %}/>
                             <label for="pref_bool_groupsmanagers_are_staff">{{ _T("Include groups managers with staff?") }}</label>
@@ -1103,11 +1116,9 @@
                 });
 
                 let _publicpages_status = document.getElementById('pref_bool_publicpages');
-                let _publicpages_visibility = document.getElementsByClassName('publicpages_visibility');
+                let _publicpages_visibility = document.getElementById('publicpages_visibility');
                 _publicpages_status.addEventListener('change', function () {
-                    for (let i = 0; i < _publicpages_visibility.length; i++) {
-                        _publicpages_visibility[i].classList.toggle('displaynone');
-                    }
+                    _publicpages_visibility.classList.toggle('displaynone');
                     return;
                 });
 

--- a/galette/templates/default/pages/public/gallery.html.twig
+++ b/galette/templates/default/pages/public/gallery.html.twig
@@ -1,0 +1,69 @@
+{#
+/**
+ * Copyright © 2003-2024 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ */
+#}
+{% extends 'elements/list.html.twig' %}
+
+{% set nb = nb_members %}
+{% set is_public = not login.isLogged() %}
+{% set list_type = nb_members > 0 ? 'cards' : 'empty' %}
+
+{% macro drawEntry(member, staff, time) %}
+    <div class="ui fluid card">
+        {% set mid = member.id %}
+        <div class="image">
+            <img
+                src="{{ url_for("photo", {"id": member.id, "rand": time}) }}"
+                width="{{ member.picture.getOptimalWidth() }}"
+                height="{{ member.picture.getOptimalHeight() }}"
+                alt="{{ member.sfullname }}{% if member.nickname != '' %} ({{ member.nickname|escape }}){% endif %}"
+            />
+        </div>
+        <div class="center aligned content">
+            <div class="header">{{ member.sfullname }}</div>
+    {% if member.nickname != '' %}
+            <div class="meta">
+                {{ member.nickname|escape }}
+            </div>
+    {% endif %}
+        </div>
+
+    {% set mgroups = member.getManagedGroups() %}
+    {% if staff or mgroups|length %}
+        <div class="extra content">
+            <span class="right floated">
+        {% if staff %}
+                <i class="ui user tie orange icon" aria-hidden="true"></i>
+                {{ member.sstatus }}
+        {% endif %}
+        {% if mgroups|length %}
+            {% if staff %}
+                <br />
+            {% endif %}
+            <i class="ui users cog orange icon" aria-hidden="true"></i>
+            {{ __('Manages:') }}
+            {% for group in mgroups %}
+                {{ group.getName() }}
+            {% endfor %}
+        {% endif %}
+            </span>
+        </div>
+    {% endif %}
+    </div>
+{% endmacro %}

--- a/galette/templates/default/pages/public/list.html.twig
+++ b/galette/templates/default/pages/public/list.html.twig
@@ -20,7 +20,7 @@
 #}
 {% extends 'elements/list.html.twig' %}
 
-{% set nb = members|length %}
+{% set nb = nb_members %}
 {% set no_action = true %}
 {% set is_public = not login.isLogged() %}
 
@@ -66,22 +66,6 @@
     </tr>
 {% endmacro %}
 
-{% set form = {
-    'order': {
-        'name': 'publicMembersList'
-    }
-} %}
-
-{% block infoline %}
-    {% set infoline = {
-        'label': _Tn("%count member", "%count members", nb_members)|replace({'%count': nb_members}),
-        'route': {
-            'name': 'filterPublicMembersList'
-        }
-    } %}
-    {{ parent() }}
-{% endblock %}
-
 {% block header %}
     {% set columns = [
         {'label': _T('Name'), order: constant("Galette\\Repository\\Members::ORDERBY_NAME")},
@@ -99,31 +83,4 @@
     ]) %}
 
     {{ parent() }}
-{% endblock %}
-
-{% block search %}
-    <div class="ui icon info visible message">
-        <i class="info circle blue icon" aria-hidden="true"></i>
-        <div class="content">
-            {{ _T("This page shows only members who have choosen to be visible on the public lists and are up-to-date within their contributions. If you want your account to be visible here, edit your profile and check 'Be visible in the members list'") }}
-        </div>
-    </div>
-{% endblock %}
-
-{% block body %}
-    {% if nb_members > 0 %}
-        {% for member in members.staff %}
-            {{ _self.drawEntry(member, true) }}
-        {% endfor %}
-
-        {% for member in members.members %}
-            {{ _self.drawEntry(member, false) }}
-        {% endfor %}
-    {% else %}
-        <tr>
-            <td class="emptylist" colspan="4">
-                {{ _T('No member') }}
-            </td>
-        </tr>
-    {% endif %}
 {% endblock %}

--- a/galette/templates/default/pages/public/members_gallery.html.twig
+++ b/galette/templates/default/pages/public/members_gallery.html.twig
@@ -1,0 +1,57 @@
+{#
+/**
+ * Copyright © 2003-2024 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ */
+#}
+{% extends 'pages/public/gallery.html.twig' %}
+
+{% block infoline %}
+    {% set infoline = {
+        'label': _Tn("%count member", "%count members", nb_members)|replace({'%count': nb_members}),
+        'route': {
+            'name': 'filterPublicMembersGallery'
+        }
+    } %}
+    {{ parent() }}
+{% endblock %}
+
+{% block search %}
+    <div class="ui icon info visible message">
+        <i class="info circle blue icon" aria-hidden="true"></i>
+        <div class="content">
+            {{ _T("This page shows only members who have choosen to be visible on the public lists and are up-to-date within their contributions. If you want your account to be visible here, edit your profile and check 'Be visible in the members list'") }}
+        </div>
+    </div>
+{% endblock %}
+
+{% block body %}
+    {% if nb_members > 0 %}
+        {% for member in members.staff %}
+            {{ _self.drawEntry(member, true, time) }}
+        {% endfor %}
+        {% for member in members.members %}
+            {{ _self.drawEntry(member, false, time) }}
+        {% endfor %}
+    {% else %}
+        <div class="ui small message">
+            <div class="content">
+                <em>{{ _T('No member') }}</em>
+            </div>
+        </div>
+    {% endif %}
+{% endblock %}

--- a/galette/templates/default/pages/public/members_list.html.twig
+++ b/galette/templates/default/pages/public/members_list.html.twig
@@ -18,49 +18,40 @@
  * along with Galette. If not, see <http://www.gnu.org/licenses/>.
  */
 #}
-{% extends 'elements/list.html.twig' %}
+{% extends 'pages/public/list.html.twig' %}
 
-{% set nb = members|length %}
-{% set is_public = not login.isLogged() %}
-{% set list_type = nb_members > 0 ? 'cards' : 'empty' %}
-
-{% macro drawEntry(member, staff, time) %}
-    <div class="ui fluid card">
-        {% set mid = member.id %}
-        <div class="image">
-            <img
-                    src="{{ url_for("photo", {"id": member.id, "rand": time}) }}"
-                    width="{{ member.picture.getOptimalWidth() }}"
-                    height="{{ member.picture.getOptimalHeight() }}"
-                    alt="{{ member.sfullname }}{% if member.nickname != '' %} ({{ member.nickname|escape }}){% endif %}"
-            />
-        </div>
-        <div class="center aligned content">
-            <div class="header">{{ member.sfullname }}</div>
-    {% if member.nickname != '' %}
-            <div class="meta">
-                {{ member.nickname|escape }}
-            </div>
-    {% endif %}
-        </div>
-    {% if staff %}
-        <div class="extra content">
-            <span class="right floated">
-                <i class="ui user tie orange icon" aria-hidden="true"></i>
-                {{ member.sstatus }}
-            </span>
-        </div>
-    {% endif %}
-    </div>
-{% endmacro %}
+{% set form = {
+    'order': {
+        'name': 'publicMembersList'
+    }
+} %}
 
 {% block infoline %}
     {% set infoline = {
         'label': _Tn("%count member", "%count members", nb_members)|replace({'%count': nb_members}),
         'route': {
-            'name': 'filterPublicMembersGallery'
+            'name': 'filterPublicMembersList'
         }
     } %}
+    {{ parent() }}
+{% endblock %}
+
+{% block header %}
+    {% set columns = [
+        {'label': _T('Name'), order: constant("Galette\\Repository\\Members::ORDERBY_NAME")},
+        {'label': _T("Nickname"), order: constant("Galette\\Repository\\Members::ORDERBY_NICKNAME")},
+    ] %}
+
+    {% if login.isLogged() %}
+        {% set columns = columns|merge([
+            {'label': _T("Email")}
+        ]) %}
+    {% endif %}
+
+    {% set columns = columns|merge([
+        {'label': _T("Information")}
+    ]) %}
+
     {{ parent() }}
 {% endblock %}
 
@@ -76,16 +67,17 @@
 {% block body %}
     {% if nb_members > 0 %}
         {% for member in members.staff %}
-            {{ _self.drawEntry(member, true, time) }}
+            {{ _self.drawEntry(member, true) }}
         {% endfor %}
+
         {% for member in members.members %}
-            {{ _self.drawEntry(member, false, time) }}
+            {{ _self.drawEntry(member, false) }}
         {% endfor %}
     {% else %}
-        <div class="ui small message">
-            <div class="content">
-                <em>{{ _T('No member') }}</em>
-            </div>
-        </div>
+        <tr>
+            <td class="emptylist" colspan="4">
+                {{ _T('No member') }}
+            </td>
+        </tr>
     {% endif %}
 {% endblock %}

--- a/galette/templates/default/pages/public/staff_gallery.html.twig
+++ b/galette/templates/default/pages/public/staff_gallery.html.twig
@@ -1,0 +1,46 @@
+{#
+/**
+ * Copyright © 2003-2024 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ */
+#}
+{% extends 'pages/public/gallery.html.twig' %}
+
+{% block infoline %}
+    {# Empty this block #}
+{% endblock %}
+
+{% block body %}
+    {% if nb_members > 0 %}
+        {% for member in members.staff %}
+            {{ _self.drawEntry(member, true, time) }}
+        {% endfor %}
+        {% for group_managers in members.groups %}
+            {% for manager in group_managers %}
+                {% if members.staff[manager.id] is not defined %}
+                    {{ _self.drawEntry(manager, false, time) }}
+                {% endif %}
+            {% endfor %}
+        {% endfor %}
+    {% else %}
+        <div class="ui small message">
+            <div class="content">
+                <em>{{ _T('No member') }}</em>
+            </div>
+        </div>
+    {% endif %}
+{% endblock %}

--- a/galette/templates/default/pages/public/staff_list.html.twig
+++ b/galette/templates/default/pages/public/staff_list.html.twig
@@ -1,0 +1,77 @@
+{#
+/**
+ * Copyright © 2003-2024 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ */
+#}
+{% extends 'pages/public/list.html.twig' %}
+
+{% set is_paginated = false %}
+
+{% block infoline %}
+    {% set infoline = {
+        'label': _Tn("%count member", "%count members", nb_members)|replace({'%count': nb_members})
+    } %}
+    {{ parent() }}
+{% endblock %}
+
+{% block header %}
+    {% set columns = [
+        {'label': _T('Name'), order: constant("Galette\\Repository\\Members::ORDERBY_NAME")},
+        {'label': _T("Nickname"), order: constant("Galette\\Repository\\Members::ORDERBY_NICKNAME")},
+    ] %}
+
+    {% if login.isLogged() %}
+        {% set columns = columns|merge([
+            {'label': _T("Email")}
+        ]) %}
+    {% endif %}
+
+    {% set columns = columns|merge([
+        {'label': _T("Information")}
+    ]) %}
+
+    {{ parent() }}
+{% endblock %}
+
+{% block body %}
+    {% if nb_members > 0 %}
+        {% if members.groups|length > 0 %}
+        <tr class="with-headers">
+            <th scope="colgroup" colspan="4">{{ _T('Staff members') }}</th>
+        </tr>
+        {% endif %}
+        {% for member in members.staff %}
+            {{ _self.drawEntry(member, true) }}
+        {% endfor %}
+
+        {% for group, group_managers in members.groups %}
+            <tr class="with-headers">
+                <th scope="colgroup" colspan="4">{{ _T('"%1$s" group managers')|format(group) }}</th>
+            </tr>
+            {% for manager in group_managers %}
+                {{ _self.drawEntry(manager, false) }}
+            {% endfor %}
+        {% endfor %}
+    {% else %}
+        <tr>
+            <td class="emptylist" colspan="4">
+                {{ _T('No member') }}
+            </td>
+        </tr>
+    {% endif %}
+{% endblock %}

--- a/tests/Galette/Core/tests/units/Galette.php
+++ b/tests/Galette/Core/tests/units/Galette.php
@@ -139,10 +139,10 @@ class Galette extends GaletteTestCase
         $plugins = new \Galette\Core\Plugins($db);
         $preferences = $this->getMockBuilder(\Galette\Core\Preferences::class)
             ->setConstructorArgs(array($db))
-            ->onlyMethods(array('showPublicPages'))
+            ->onlyMethods(array('showPublicPage'))
             ->getMock();
 
-        $preferences->method('showPublicPages')->willReturn(true);
+        $preferences->method('showPublicPage')->willReturn(true);
 
         $menus = \Galette\Core\Galette::getMenus();
         $this->assertIsArray($menus);
@@ -229,19 +229,19 @@ class Galette extends GaletteTestCase
         $db = new \Galette\Core\Db();
         $preferences = $this->getMockBuilder(\Galette\Core\Preferences::class)
             ->setConstructorArgs(array($db))
-            ->onlyMethods(array('showPublicPages'))
+            ->onlyMethods(array('showPublicPage'))
             ->getMock();
-        $preferences->method('showPublicPages')->willReturn(false);
+        $preferences->method('showPublicPage')->willReturn(false);
 
         $menus = \Galette\Core\Galette::getPublicMenus();
         $this->assertIsArray($menus);
-        $this->assertCount(0, $menus);
+        $this->assertCount(0, $menus, print_r($menus, true));
 
         $preferences = $this->getMockBuilder(\Galette\Core\Preferences::class)
             ->setConstructorArgs(array($db))
-            ->onlyMethods(array('showPublicPages'))
+            ->onlyMethods(array('showPublicPage'))
             ->getMock();
-        $preferences->method('showPublicPages')->willReturn(true);
+        $preferences->method('showPublicPage')->willReturn(true);
 
         $menus = \Galette\Core\Galette::getPublicMenus();
         $this->assertIsArray($menus);

--- a/tests/Galette/Core/tests/units/Galette.php
+++ b/tests/Galette/Core/tests/units/Galette.php
@@ -228,6 +228,20 @@ class Galette extends GaletteTestCase
         global $preferences;
 
         $db = new \Galette\Core\Db();
+
+        //public pages are disabled
+        $preferences = $this->getMockBuilder(\Galette\Core\Preferences::class)
+            ->setConstructorArgs(array($db))
+            ->onlyMethods(array('arePublicPagesEnabled', 'showPublicPage'))
+            ->getMock();
+        $preferences->method('arePublicPagesEnabled')->willReturn(false);
+        $preferences->method('showPublicPage')->willReturn(true); //should not matter.
+
+        $menus = \Galette\Core\Galette::getPublicMenus();
+        $this->assertIsArray($menus);
+        $this->assertCount(0, $menus, print_r($menus, true));
+
+        //public pages are enabled but not shown
         $preferences = $this->getMockBuilder(\Galette\Core\Preferences::class)
             ->setConstructorArgs(array($db))
             ->onlyMethods(array('arePublicPagesEnabled', 'showPublicPage'))
@@ -235,6 +249,7 @@ class Galette extends GaletteTestCase
         $preferences->method('arePublicPagesEnabled')->willReturn(true);
         $preferences->method('showPublicPage')->willReturn(false);
 
+        //public pages are enabled and shown
         $menus = \Galette\Core\Galette::getPublicMenus();
         $this->assertIsArray($menus);
         $this->assertCount(0, $menus, print_r($menus, true));

--- a/tests/Galette/Core/tests/units/Galette.php
+++ b/tests/Galette/Core/tests/units/Galette.php
@@ -139,9 +139,10 @@ class Galette extends GaletteTestCase
         $plugins = new \Galette\Core\Plugins($db);
         $preferences = $this->getMockBuilder(\Galette\Core\Preferences::class)
             ->setConstructorArgs(array($db))
-            ->onlyMethods(array('showPublicPage'))
+            ->onlyMethods(array('arePublicPagesEnabled', 'showPublicPage'))
             ->getMock();
 
+        $preferences->method('arePublicPagesEnabled')->willReturn(true);
         $preferences->method('showPublicPage')->willReturn(true);
 
         $menus = \Galette\Core\Galette::getMenus();
@@ -229,8 +230,9 @@ class Galette extends GaletteTestCase
         $db = new \Galette\Core\Db();
         $preferences = $this->getMockBuilder(\Galette\Core\Preferences::class)
             ->setConstructorArgs(array($db))
-            ->onlyMethods(array('showPublicPage'))
+            ->onlyMethods(array('arePublicPagesEnabled', 'showPublicPage'))
             ->getMock();
+        $preferences->method('arePublicPagesEnabled')->willReturn(true);
         $preferences->method('showPublicPage')->willReturn(false);
 
         $menus = \Galette\Core\Galette::getPublicMenus();
@@ -239,8 +241,9 @@ class Galette extends GaletteTestCase
 
         $preferences = $this->getMockBuilder(\Galette\Core\Preferences::class)
             ->setConstructorArgs(array($db))
-            ->onlyMethods(array('showPublicPage'))
+            ->onlyMethods(array('arePublicPagesEnabled', 'showPublicPage'))
             ->getMock();
+        $preferences->method('arePublicPagesEnabled')->willReturn(true);
         $preferences->method('showPublicPage')->willReturn(true);
 
         $menus = \Galette\Core\Galette::getPublicMenus();

--- a/tests/Galette/Core/tests/units/Preferences.php
+++ b/tests/Galette/Core/tests/units/Preferences.php
@@ -188,16 +188,23 @@ class Preferences extends GaletteTestCase
     {
         $this->preferences->load();
 
-        $visibility = $this->preferences->pref_publicpages_visibility;
-        $this->assertEquals(
-            \Galette\Core\Preferences::PUBLIC_PAGES_VISIBILITY_RESTRICTED,
-            $visibility
-        );
+        $visibilities = [
+            'pref_publicpages_visibility_memberslist',
+            'pref_publicpages_visibility_membersgallery',
+            'pref_publicpages_visibility_stafflist',
+            'pref_publicpages_visibility_staffgallery'
+        ];
+
+        foreach ($visibilities as $visibility) {
+            $this->preferences->$visibility = \Galette\Core\Preferences::PUBLIC_PAGES_VISIBILITY_RESTRICTED;
+        }
 
         $anon_login = new \Galette\Core\Login(
             $this->zdb,
             new \Galette\Core\I18n()
         );
+
+        $this->preferences->pref_bool_publicpages = true;
 
         $admin_login = $this->getMockBuilder(\Galette\Core\Login::class)
             ->setConstructorArgs(array($this->zdb, new \Galette\Core\I18n()))
@@ -211,38 +218,42 @@ class Preferences extends GaletteTestCase
             ->getMock();
         $user_login->method('isUp2Date')->willReturn(true);
 
-        $visible = $this->preferences->showPublicPages($anon_login);
-        $this->assertFalse($visible);
+        foreach ($visibilities as $visibility) {
+            $visible = $this->preferences->showPublicPage($anon_login, $visibility);
+            $this->assertFalse($visible);
 
-        $visible = $this->preferences->showPublicPages($admin_login);
-        $this->assertTrue($visible);
+            $visible = $this->preferences->showPublicPage($admin_login, $visibility);
+            $this->assertTrue($visible);
 
-        $visible = $this->preferences->showPublicPages($user_login);
-        $this->assertTrue($visible);
+            $visible = $this->preferences->showPublicPage($user_login, $visibility);
+            $this->assertTrue($visible);
+        }
 
-        $this->preferences->pref_publicpages_visibility
-            = \Galette\Core\Preferences::PUBLIC_PAGES_VISIBILITY_PUBLIC;
+        foreach ($visibilities as $visibility) {
+            $this->preferences->$visibility = \Galette\Core\Preferences::PUBLIC_PAGES_VISIBILITY_PUBLIC;
 
-        $visible = $this->preferences->showPublicPages($anon_login);
-        $this->assertTrue($visible);
+            $visible = $this->preferences->showPublicPage($anon_login, $visibility);
+            $this->assertTrue($visible);
 
-        $visible = $this->preferences->showPublicPages($admin_login);
-        $this->assertTrue($visible);
+            $visible = $this->preferences->showPublicPage($admin_login, $visibility);
+            $this->assertTrue($visible);
 
-        $visible = $this->preferences->showPublicPages($user_login);
-        $this->assertTrue($visible);
+            $visible = $this->preferences->showPublicPage($user_login, $visibility);
+            $this->assertTrue($visible);
+        }
 
-        $this->preferences->pref_publicpages_visibility
-            = \Galette\Core\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE;
+        foreach ($visibilities as $visibility) {
+            $this->preferences->$visibility = \Galette\Core\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE;
 
-        $visible = $this->preferences->showPublicPages($anon_login);
-        $this->assertFalse($visible);
+            $visible = $this->preferences->showPublicPage($anon_login, $visibility);
+            $this->assertFalse($visible);
 
-        $visible = $this->preferences->showPublicPages($admin_login);
-        $this->assertTrue($visible);
+            $visible = $this->preferences->showPublicPage($admin_login, $visibility);
+            $this->assertTrue($visible);
 
-        $visible = $this->preferences->showPublicPages($user_login);
-        $this->assertFalse($visible);
+            $visible = $this->preferences->showPublicPage($user_login, $visibility);
+            $this->assertFalse($visible);
+        }
     }
 
     /**

--- a/ui/semantic/galette/collections/menu.overrides
+++ b/ui/semantic/galette/collections/menu.overrides
@@ -22,6 +22,12 @@
   .ui.fixed.menu .item.active {
     background: @activeItemBackground;
   }
+  .ui.fixed.menu .active.dropdown.item {
+    font-weight: normal;
+  }
+  .ui.fixed.menu .active-menu.dropdown.item:not(:hover) {
+    background: @lightGaletteColor;
+  }
 }
 
 & when (@variationMenuVertical) {
@@ -60,6 +66,13 @@
       .small.disabled.text {
         color: @midWhite;
       }
+    }
+  }
+  .ui.vertical.sidebar.menu > .item {
+    font-weight: bold;
+    & > i.icon {
+      float: left;
+      margin: 0 .5em 0 0;
     }
   }
 }

--- a/ui/semantic/galette/collections/table.overrides
+++ b/ui/semantic/galette/collections/table.overrides
@@ -159,6 +159,14 @@ td.emptylist {
     }
 }
 
+/*-----------------------------
+     <th> outside <thead>
+------------------------------*/
+tr.with-headers th {
+    padding: @cellVerticalPadding @cellHorizontalPadding;
+    background: @lightSecondaryColor;
+}
+
 /*------------------
      Plugins list
 -------------------*/
@@ -174,12 +182,19 @@ tr.inactives.plugins th {
     border-bottom: @rowBorder;
 }
 @media only screen and (max-width: @largestMobileScreen) {
+    .ui.ui.ui.ui.table:not(.unstackable) > tbody > tr.with-headers,
+    .ui.ui.ui.ui.table:not(.unstackable) > tbody > tr.with-headers:hover,
+    .ui.ui.ui.ui.table:not(.unstackable) > tbody > tr.with-headers > th {
+        background: @lightSecondaryColor !important;
+    }
     .ui.ui.ui.ui.table:not(.unstackable) > tbody > tr.plugins,
+    .ui.ui.ui.ui.table:not(.unstackable) > tbody > tr.plugins:hover,
     .ui.ui.ui.ui.table:not(.unstackable) > tbody > tr.plugins > th {
-        background: @pluginsActiveBackground;
+        background: @pluginsActiveBackground !important;
     }
     .ui.ui.ui.ui.table:not(.unstackable) > tbody > tr.inactives.plugins,
+    .ui.ui.ui.ui.table:not(.unstackable) > tbody > tr.inactives.plugins:hover,
     .ui.ui.ui.ui.table:not(.unstackable) > tbody > tr.inactives.plugins > th {
-        background: @pluginsInactiveBackground;
+        background: @pluginsInactiveBackground !important;
     }
 }

--- a/ui/semantic/galette/globals/site.overrides
+++ b/ui/semantic/galette/globals/site.overrides
@@ -58,7 +58,7 @@
 a,
 .ui.button:not(.tertiary),
 .compact_menu .ui.dropdown.item,
-.ui.dropdown.language,
+.ui.dropdown.focus-visible,
 .infoline .ui.dropdown:not(.tertiary) {
     &:focus-visible {
         outline: 3px solid @blueFocus;


### PR DESCRIPTION
Group public pages in dropdowns when logged out to give space in the navigation top bar.
![public-pages-dropdowns](https://github.com/user-attachments/assets/87a17e96-d117-4510-8ef9-498fd4f5569c)

If all public pages are not accessible, simple items are used as usual.
![public-pages-staff-only](https://github.com/user-attachments/assets/1d7ef508-3952-46c2-b8db-f2aa4ba57086)

