### PR TITLE
Public pages dropdowns

### DIFF
--- a/galette/lib/Galette/Core/Galette.php
+++ b/galette/lib/Galette/Core/Galette.php
@@ -537,8 +537,11 @@ class Galette
         $menus = [];
         $items = [];
 
+        $galleries = [];
+        $lists = [];
+
         if ($preferences->showPublicPage($login, 'pref_publicpages_visibility_memberslist')) {
-            $items[] = [
+            $lists[] = [
                 'label' => _T("Members"),
                 'route' => [
                     'name' => 'publicMembersList'
@@ -548,33 +551,55 @@ class Galette
         }
 
         if ($preferences->showPublicPage($login, 'pref_publicpages_visibility_membersgallery')) {
-            $items[] = [
+            $galleries[] = [
                 'label' => _T('Gallery'),
                 'route' => [
                     'name' => 'publicMembersGallery'
                 ],
-                'icon' => 'user friends'
+                'icon' => 'images'
             ];
         }
 
         if ($preferences->showPublicPage($login, 'pref_publicpages_visibility_stafflist')) {
-            $items[] = [
+            $lists[] = [
                 'label' => _T("Staff"),
                 'route' => [
                     'name' => 'publicStaffList'
                 ],
-                'icon' => 'address card'
+                'icon' => 'address book outline'
             ];
         }
 
         if ($preferences->showPublicPage($login, 'pref_publicpages_visibility_staffgallery')) {
-            $items[] = [
+            $galleries[] = [
                 'label' => _T('Staff gallery'),
                 'route' => [
                     'name' => 'publicStaffGallery'
                 ],
-                'icon' => 'user cog'
+                'icon' => 'images outline'
             ];
+        }
+
+        if (count($lists) > 1) {
+            //handle multiple lists
+            $items[] = [
+                'label' => _T("Directories"),
+                'icon' => 'address book',
+                'children' => $lists
+            ];
+        } else {
+            $items = array_merge($items, $lists);
+        }
+
+        if (count($galleries) > 1) {
+            //handle multiple galleries
+            $items[] = [
+                'label' => _T("Galleries"),
+                'icon' => 'images',
+                'children' => $galleries
+            ];
+        } else {
+            $items = array_merge($items, $galleries);
         }
 
         if ($preferences->showPublicPage($login, 'pref_publicpages_visibility_documents')) {

--- a/galette/templates/default/elements/inline_styles.html.twig
+++ b/galette/templates/default/elements/inline_styles.html.twig
@@ -87,6 +87,7 @@
         .custom-colors .ui.menu .active.item,
         .custom-colors .ui.fixed.menu .item.active,
         .custom-colors .ui.fixed.menu .item:active:not(.right):not(:hover),
+        .custom-colors .ui.fixed.menu .active-menu.dropdown.item:not(:hover),
         .custom-colors .ui.inverted.menu .active.item,
         .custom-colors .ui.vertical.menu .active.item,
         .custom-colors .ui.vertical.menu .content.active .item:active:not(:hover),

--- a/galette/templates/default/elements/language.html.twig
+++ b/galette/templates/default/elements/language.html.twig
@@ -20,11 +20,11 @@
 #}
 {% if ui is defined %}
     {% if ui == 'item'%}
-        {% set component_classes = "tooltip language item" %}
+        {% set component_classes = "tooltip focus-visible language item" %}
         {% set content_classes = "content" %}
         {% set header = true %}
     {% elseif ui == 'dropdown' %}
-        {% set component_classes = "tooltip language ui dropdown navigation right-aligned item" %}
+        {% set component_classes = "tooltip focus-visible language ui dropdown navigation right-aligned item" %}
         {% set content_classes = "menu" %}
         {% set header = false %}
     {% endif %}

--- a/galette/templates/default/elements/navigation/navigation_sidebar.html.twig
+++ b/galette/templates/default/elements/navigation/navigation_sidebar.html.twig
@@ -34,7 +34,7 @@
     {% include "elements/navigation/public_pages.html.twig" with {
             tips_position: "right center",
             sign_in: true,
-            mode: "default"
+            mode: "sidebar"
     } %}
 {% else %}
     {% include "elements/navigation/navigation_items.html.twig" with {

--- a/galette/templates/default/elements/navigation/navigation_topbar.html.twig
+++ b/galette/templates/default/elements/navigation/navigation_topbar.html.twig
@@ -32,7 +32,7 @@
                 tips_position: "bottom center",
                 sign_in: true,
                 sign_in_side: 'right',
-                mode: "default"
+                mode: "topbar"
         } %}
 
         {% include "elements/language.html.twig" with {

--- a/galette/templates/default/elements/navigation/public_pages.html.twig
+++ b/galette/templates/default/elements/navigation/public_pages.html.twig
@@ -25,7 +25,7 @@
         {% set public_menus = callstatic('\\Galette\\Core\\Galette', 'getPublicMenus') %}
         {% for public_menu in public_menus %}
             {% for public_item in public_menu.items %}
-                {{ menus_macros.renderMenuItem(public_item.label, public_item.title ?? null, public_item.route, public_item.icon ?? null, null, tips_position, mode) }}
+                {{ menus_macros.renderMenuItem(public_item.label, public_item.title ?? null, public_item.route ?? null, public_item.icon ?? null, null, tips_position, mode, public_item.children ?? null) }}
             {% endfor %}
         {% endfor %}
     {% endif %}

--- a/galette/templates/default/macros.twig
+++ b/galette/templates/default/macros.twig
@@ -21,7 +21,14 @@
 {% macro renderMenu(title, icon, items, mode) %}
     {% set my_routes = [] %}
     {% for item in items %}
-        {% set my_routes = my_routes|merge([item.route.name])|merge(item.route.aliases ?? []) %}
+        {% if item.route is defined %}
+            {% set my_routes = my_routes|merge([item.route.name])|merge(item.route.aliases ?? []) %}
+            {% if item.children is defined %}
+                {% for child in item.children %}
+                    {% set my_routes = my_routes|merge([child.route.name])|merge(child.route.aliases ?? []) %}
+                {% endfor %}
+            {% endif %}
+        {% endif %}
     {% endfor %}
     {% if mode == "compact" %}
         <div class="ui{% if cur_route in my_routes %} active-menu{% endif %} dropdown navigation item tooltip" data-html="{{ title }}" data-position="right center">
@@ -30,7 +37,7 @@
             <i class="dropdown icon" aria-hidden="true"></i>
             <div class="menu">
                 {% for item in items %}
-                    {{ _self.renderMenuItem(item.label, item.title ?? null, item.route, item.icon ?? null, null, 'right center') }}
+                    {{ _self.renderMenuItem(item.label, item.title ?? null, item.route ?? null, null, null, 'right center', mode, item.children ?? null) }}
                 {% endfor %}
             </div>
         </div>
@@ -43,34 +50,70 @@
             </div>
             <div class="content{% if cur_route in my_routes %} active{% endif %}">
                 {% for item in items %}
-                    {{ _self.renderMenuItem(item.label, item.title ?? null, item.route, item.icon ?? null, null, null, mode) }}
+                    {{ _self.renderMenuItem(item.label, item.title ?? null, item.route ?? null, item.icon ?? null, null, null, mode, item.children ?? null) }}
                 {% endfor %}
             </div>
         </div>
     {% endif %}
 {% endmacro %}
 
-{% macro renderMenuItem(label, title, route, icon, class, tips_position, mode) %}
+{% macro renderMenuItem(label, title, route, icon, class, tips_position, mode, children) %}
     {% if class is empty %}
-        {% set my_routes = [route.name]|merge(route.aliases ?? []) %}
-        {% if is_current_url(route.name, route.args ?? [] + cur_route_args ?? []) %}
-            {% set class = "active item" %}
+        {% if route is not null %}
+            {% set my_routes = [route.name]|merge(route.aliases ?? []) %}
+            {% if is_current_url(route.name, route.args ?? [] + cur_route_args ?? []) %}
+                {% set class = "active item" %}
+            {% else %}
+                {% set class = "item" %}
+            {% endif %}
         {% else %}
             {% set class = "item" %}
         {% endif %}
     {% endif %}
-    <a
-            href="{{ url_for(route.name, route.args|default([])) }}"
-            class="{{ class }}"
-            {% if title %}title="{{ title }}"{% endif %}
-            {% if tips_position %}data-position="{{ tips_position }}"{% endif %}
-            {% if mode != "default" %}tabindex="-1"{% endif %}
-    >
-        {% if icon %}
+    {% if children is empty %}
+        <a
+                href="{{ url_for(route.name, route.args|default([])) }}"
+                class="{{ class }}"
+                {% if title %}title="{{ title }}"{% endif %}
+                {% if tips_position %}data-position="{{ tips_position }}"{% endif %}
+                {% if mode == "compact" %}tabindex="-1"{% endif %}
+        >
+        {% if icon and mode != 'compact' %}
             <i class="{{ icon }} icon" aria-hidden="true"></i>
         {% endif %}
-        {{ label }}
-    </a>
+            {{ label }}
+        </a>
+    {% elseif (mode != 'topbar') and login.isLogged() %}
+        {% for item in children %}
+            {% set icon = mode == "compact" ? null : item.icon %}
+            {{ _self.renderMenuItem(item.label, item.title ?? null, item.route, icon, null, item.tips_position ?? null) }}
+        {% endfor %}
+    {% else %}
+        {{ _self.renderMenuDropdown(label, title ?? null, icon ?? null, tips_position ?? null, mode, children) }}
+    {% endif %}
+{% endmacro %}
+
+{% macro renderMenuDropdown(label, title, icon, tips_position, mode, children) %}
+    {% set my_routes = [] %}
+    {% for item in children %}
+        {% set my_routes = my_routes|merge([item.route.name])|merge(item.route.aliases ?? []) %}
+    {% endfor %}
+    <div class="{{ mode != 'sidebar' ? 'focus-visible ui dropdown navigation ' }}{% if cur_route in my_routes %} active-menu {% endif %}item">
+    {% if mode == 'sidebar' %}
+        <div class="image header title" data-fold="fold-{{ icon|replace({' ': '-'}) }}">
+    {% endif %}
+            <i class="{{ icon }} icon" aria-hidden="true"></i>
+            <span>{{ label }}</span>
+            <i class="dropdown icon" aria-hidden="true"></i>
+    {% if mode == 'sidebar' %}
+        </div>
+    {% endif %}
+        <div class="{{ mode != 'sidebar' ? 'menu' : 'content' }}{{ mode == 'sidebar' and cur_route in my_routes ?? ' active' }}">
+            {% for item in children %}
+                {{ _self.renderMenuItem(item.label, item.title ?? null, item.route, null, null, null, mode) }}
+            {% endfor %}
+        </div>
+    </div>
 {% endmacro %}
 
 {% macro dashboardCard(label, title, route, icon) %}

--- a/ui/semantic/galette/collections/menu.overrides
+++ b/ui/semantic/galette/collections/menu.overrides
@@ -22,6 +22,12 @@
   .ui.fixed.menu .item.active {
     background: @activeItemBackground;
   }
+  .ui.fixed.menu .active.dropdown.item {
+    font-weight: normal;
+  }
+  .ui.fixed.menu .active-menu.dropdown.item:not(:hover) {
+    background: @lightGaletteColor;
+  }
 }
 
 & when (@variationMenuVertical) {
@@ -60,6 +66,13 @@
       .small.disabled.text {
         color: @midWhite;
       }
+    }
+  }
+  .ui.vertical.sidebar.menu > .item {
+    font-weight: bold;
+    & > i.icon {
+      float: left;
+      margin: 0 .5em 0 0;
     }
   }
 }

--- a/ui/semantic/galette/globals/site.overrides
+++ b/ui/semantic/galette/globals/site.overrides
@@ -58,7 +58,7 @@
 a,
 .ui.button:not(.tertiary),
 .compact_menu .ui.dropdown.item,
-.ui.dropdown.language,
+.ui.dropdown.focus-visible,
 .infoline .ui.dropdown:not(.tertiary) {
     &:focus-visible {
         outline: 3px solid @blueFocus;


### PR DESCRIPTION
Group public pages in dropdowns when logged out to give space in the navigation top bar.
![public-pages-dropdowns](https://github.com/user-attachments/assets/87a17e96-d117-4510-8ef9-498fd4f5569c)

If all public pages are not accessible, simple items are used as usual.
![public-pages-staff-only](https://github.com/user-attachments/assets/1d7ef508-3952-46c2-b8db-f2aa4ba57086)

Replaces https://github.com/galette/galette/pull/608