### PR TITLE
Feature/additions for plugins

### DIFF
--- a/galette/includes/dependencies.php
+++ b/galette/includes/dependencies.php
@@ -144,6 +144,7 @@ $container->set('Slim\Views\Twig', function (ContainerInterface $c) {
     $view->getEnvironment()->addGlobal('logo', $c->get('logo'));
 
     $view->getEnvironment()->addGlobal('plugin_headers', $c->get('plugins')->getTplHeaders());
+    $view->getEnvironment()->addGlobal('plugin_scripts', $c->get('plugins')->getTplScripts());
 
     // galette_lang should be removed and languages used instead
     $view->getEnvironment()->addGlobal('galette_lang', $c->get('i18n')->getAbbrev());

--- a/galette/lib/Galette/Core/Plugins.php
+++ b/galette/lib/Galette/Core/Plugins.php
@@ -487,6 +487,23 @@ class Plugins
     }
 
     /**
+     * For each module, returns the scripts template file namespaced path, if present.
+     *
+     * @return array<string> of scripts to include for all modules
+     */
+    public function getTplScripts(): array
+    {
+        $_scripts = array();
+        foreach ($this->modules as $key => $module) {
+            $scripts_path = $this->getTemplatesPath($key) . '/scripts.html.twig';
+            if (file_exists($scripts_path)) {
+                $_scripts[$key] = sprintf('@%s/%s.html.twig', $this->getClassName($key), 'scripts');
+            }
+        }
+        return $_scripts;
+    }
+
+    /**
      * Does module need a database?
      *
      * @param string $id Module's ID

--- a/galette/templates/default/elements/scripts.html.twig
+++ b/galette/templates/default/elements/scripts.html.twig
@@ -229,7 +229,9 @@
         <script type="text/javascript" src="{{ base_path() }}/assets/js/summernote.min.js"></script>
         <script type="text/javascript" src="{{ base_path() }}/assets/js/lang/summernote-{{ i18n.getID()|replace({'_': '-'}) }}.min.js"></script>
         <script type="text/javascript">
-            function activateHtmlEditor(elt, basic) {
+            function activateHtmlEditor(elt, basic, styletags, insert) {
+                var _styletags = ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
+                var _insert = ['link', 'picture'];
                 if (basic === true) {
                     var _toolbar = [
                         ['font', ['bold', 'italic', 'underline', 'strikethrough', 'clear']],
@@ -238,11 +240,17 @@
                         ['view', ['codeview']]
                     ];
                 } else {
+                    if (typeof styletags !== 'undefined') {
+                        var _styletags = styletags;
+                    }
+                    if (typeof insert !== 'undefined') {
+                        var _insert = insert;
+                    }
                     var _toolbar = [
                         ['style', ['style']],
                         ['font', ['bold', 'italic', 'underline', 'strikethrough', 'clear']],
                         ['para', ['ul', 'ol', 'paragraph']],
-                        ['insert', ['link', 'picture']],
+                        ['insert', _insert],
                         ['view', ['codeview']]
                     ];
                 }
@@ -251,9 +259,7 @@
                     disableDragAndDrop: true,
                     height: 240,
                     toolbar: _toolbar,
-                    styleTags: [
-                        'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'
-                    ],
+                    styleTags: _styletags,
                     allowClipboardImagePasting: false,
                 });
                 elt.summernote('focus');

--- a/galette/templates/default/page.html.twig
+++ b/galette/templates/default/page.html.twig
@@ -95,5 +95,12 @@
         </a>
         {% include "elements/scripts.html.twig" %}
         {% block javascripts %}{% endblock %}
+        {# If some additional scripts should be added from plugins, we load the relevant template file
+           We have to use a template file, so Twig will do its work (like replacing variables). #}
+        {% if plugin_scripts|length != 0 %}
+            {% for mid, script in plugin_scripts %}
+                {% include script with {'module_id': mid} %}
+            {% endfor %}
+        {% endif %}
     </body>
 </html>

--- a/galette/templates/default/public_page.html.twig
+++ b/galette/templates/default/public_page.html.twig
@@ -77,5 +77,12 @@
         </a>
         {% include "elements/scripts.html.twig" %}
         {% block javascripts %}{% endblock %}
+        {# If some additional scripts should be added from plugins, we load the relevant template file
+           We have to use a template file, so Twig will do its work (like replacing variables). #}
+        {% if plugin_scripts|length != 0 %}
+            {% for mid, script in plugin_scripts %}
+                {% include script with {'module_id': mid} %}
+            {% endfor %}
+        {% endif %}
 </body>
 </html>


### PR DESCRIPTION
At the moment, plugins cannot add javascript code on every page. 
And the default configuration of summernote editor may not be suited to a plugin's needs.

These commits intend to change that.