### PR TITLE
Add complementary replacement values from the preferences

### DIFF
--- a/galette/lib/Galette/Features/Replacements.php
+++ b/galette/lib/Galette/Features/Replacements.php
@@ -187,6 +187,14 @@ trait Replacements
                 'title'     => sprintf('%s (%s)', _T('Your organisation address'), _T('with break lines')),
                 'pattern'   => '/{ASSO_ADDRESS_MULTI}/',
             ],
+            'asso_phone_number' => [
+                'title'     => _T('Your organisation phone number'),
+                'pattern'   => '/{ASSO_PHONE}/'
+            ],
+            'asso_email' => [
+                'title'     => _T('Your organisation email address'),
+                'pattern'   => '/{ASSO_EMAIL}/'
+            ],
             'asso_website'          => [
                 'title'     => _T('Your organisation website'),
                 'pattern'   => '/{ASSO_WEBSITE}/',
@@ -505,6 +513,8 @@ trait Replacements
                 'asso_slogan'        => $this->preferences->pref_slogan,
                 'asso_address'       => $address,
                 'asso_address_multi' => $address_multi,
+                'asso_phone_number'  => $this->preferences->getPhoneNumber(),
+                'asso_email'         => $this->preferences->pref_org_email,
                 'asso_website'       => $website,
                 'asso_logo'          => $logo_elt,
                 'asso_print_logo'    => $print_logo_elt,

--- a/galette/templates/default/pages/preferences.html.twig
+++ b/galette/templates/default/pages/preferences.html.twig
@@ -103,51 +103,105 @@
                         <label for="pref_adresse2" class="libelle">{{ _T("Address:") }} {{ _T(" (continuation)") }}</label>
                         <input type="text" name="pref_adresse2" id="pref_adresse2" value="{{ pref.pref_adresse2 }}" maxlength="190"/>
                     </div>
-                    <div class="field">
-                        <label for="pref_cp">{{ _T("Zip Code:") }}</label>
-                        <input type="text" name="pref_cp" id="pref_cp" value="{{ pref.pref_cp }}" maxlength="10"/>
+                    <div class="two fields">
+                        <div class="field">
+                            <label for="pref_cp">{{ _T("Zip Code:") }}</label>
+                            <input type="text" name="pref_cp" id="pref_cp" value="{{ pref.pref_cp }}" maxlength="10"/>
+                        </div>
+                        <div class="field">
+                            <label for="pref_ville">{{ _T("City:") }}</label>
+                            <input type="text" name="pref_ville" id="pref_ville" value="{{ pref.pref_ville }}" maxlength="100"/>
+                        </div>
+                    </div>
+                    <div class="two fields">
+                        <div class="field">
+                            <label for="pref_region">{{ _T("Region:") }}</label>
+                            <input type="text" name="pref_region" id="pref_region" value="{{ pref.pref_region }}" maxlength="100"/>
+                        </div>
+                        <div class="field">
+                            <label for="pref_pays">{{ _T("Country:") }}</label>
+                            <input type="text" name="pref_pays" id="pref_pays" value="{{ pref.pref_pays }}" maxlength="50"/>
+                        </div>
                     </div>
                     <div class="field">
-                        <label for="pref_ville">{{ _T("City:") }}</label>
-                        <input type="text" name="pref_ville" id="pref_ville" value="{{ pref.pref_ville }}" maxlength="100"/>
+                        <label>
+                            {{ _T("Postal address:") }}
+                            <i class="circular small basic question icon tooltip" title="{{ _T("Use either the address set above or select a staff member to retrieve its address.") }}" aria-hidden="true"></i>
+                        </label>
+                        <div id="postal_reference" class="inline fields">
+                            <div class="field">
+                                <div class="ui radio checkbox">
+                                    <label for="pref_postal_address_0">{{ _T("from preferences") }}</label>
+                                    <input type="radio" name="pref_postal_address" id="pref_postal_address_0" value="{{ constant('Galette\\Core\\Preferences::POSTAL_ADDRESS_FROM_PREFS') }}" {% if pref.pref_postal_address == constant('Galette\\Core\\Preferences::POSTAL_ADDRESS_FROM_PREFS') %}checked="checked"{% endif %}/>
+                                </div>
+                            </div>
+                            <div class="field">
+                                <div class="ui radio checkbox">
+                                    <label for="pref_postal_address_1">{{ _T("from a staff user") }}</label>
+                                    <input type="radio" name="pref_postal_address" id="pref_postal_address_1" value="{{ constant('Galette\\Core\\Preferences::POSTAL_ADDRESS_FROM_STAFF') }}" {% if pref.pref_postal_address == constant('Galette\\Core\\Preferences::POSTAL_ADDRESS_FROM_STAFF') %}checked="checked"{% endif %}/>
+                                </div>
+                            </div>
+                        </div>
+                        <div id="postal_staff_member" class="field">
+                            <label for="pref_postal_staff_member">{{ _T("Staff member whose address needs to be retrieved") }}</label>
+                            <select name="pref_postal_staff_member" id="pref_postal_staff_member" class="ui search dropdown">
+                                <option value="-1">{{ _T("-- Choose a staff member --") }}</option>
+                            {% for staff in staff_members %}
+                                <option value="{{ staff.id }}"{% if staff.id == pref.pref_postal_staff_member %} selected="selected"{% endif %}>{{ staff.name }} ({{ staff.sstatus }})</option>
+                            {% endfor %}
+                            </select>
+                        </div>
+                    </div>
+                </div>{# /column #}
+                <div class="column">
+                    <div class="field">
+                        <label for="pref_org_phone_number">
+                            {{ _T("Phone:") }}
+                            <i class="circular small basic question icon tooltip" title="{{ _T("Either use the phone number set below or select a staff member to retrieve its phone number.") }}" aria-hidden="true"></i>
+                        </label>
+                        <input type="text" name="pref_org_phone_number" id="pref_org_phone_number" value="{{ pref.pref_org_phone_number }}" maxlength="100"/>
+                        <div id="phone_reference" class="inline fields">
+                            <div class="field">
+                                <div class="ui radio checkbox">
+                                    <label for="pref_org_phone_0">{{ _T("from preferences") }}</label>
+                                    <input type="radio" name="pref_org_phone" id="pref_org_phone_0" value="{{ constant('Galette\\Core\\Preferences::PHONE_NUMBER_FROM_PREFS') }}" {% if pref.pref_org_phone == constant('Galette\\Core\\Preferences::PHONE_NUMBER_FROM_PREFS') %}checked="checked"{% endif %}/>
+                                </div>
+                            </div>
+                            <div class="field">
+                                <div class="ui radio checkbox">
+                                    <label for="pref_org_phone_1">{{ _T("phone from a staff user") }}</label>
+                                    <input type="radio" name="pref_org_phone" id="pref_org_phone_1" value="{{ constant('Galette\\Core\\Preferences::PHONE_NUMBER_FROM_STAFF') }}" {% if pref.pref_org_phone == constant('Galette\\Core\\Preferences::PHONE_NUMBER_FROM_STAFF') %}checked="checked"{% endif %}/>
+                                </div>
+                            </div>
+                            <div class="field">
+                                <div class="ui radio checkbox">
+                                    <label for="pref_org_phone_2">{{ _T("mobile phone from a staff user") }}</label>
+                                    <input type="radio" name="pref_org_phone" id="pref_org_phone_2" value="{{ constant('Galette\\Core\\Preferences::PHONE_NUMBER_MOBILE_FROM_STAFF') }}" {% if pref.pref_org_phone == constant('Galette\\Core\\Preferences::PHONE_NUMBER_MOBILE_FROM_STAFF') %}checked="checked"{% endif %}/>
+                                </div>
+                            </div>
+                        </div>
+                        <div id="phone_staff_member" class="field">
+                            <label for="pref_org_phone_staff_member">{{ _T("Staff member whose phone number needs to be retrieved") }}</label>
+                            <select name="pref_org_phone_staff_member" id="pref_org_phone_staff_member" class="ui search dropdown">
+                                <option value="-1">{{ _T("-- Choose a staff member --") }}</option>
+                            {% for staff in staff_members %}
+                                <option value="{{ staff.id }}"{% if staff.id == pref.pref_org_phone_staff_member %} selected="selected"{% endif %}>{{ staff.name }} ({{ staff.sstatus }})</option>
+                            {% endfor %}
+                            </select>
+                        </div>
                     </div>
                     <div class="field">
-                        <label for="pref_region">{{ _T("Region:") }}</label>
-                        <input type="text" name="pref_region" id=pref_region" value="{{ pref.pref_region }}" maxlength="100"/>
-                    </div>
-                    <div class="field">
-                        <label for="pref_pays">{{ _T("Country:") }}</label>
-                        <input type="text" name="pref_pays" id="pref_pays" value="{{ pref.pref_pays }}" maxlength="50"/>
+                        <label for="pref_org_email">{{ _T("E-Mail:") }}</label>
+                        <input type="text" name="pref_org_email" id="pref_org_email" value="{{ pref.pref_org_email }}" maxlength="100"/>
                     </div>
                     <div class="field">
                         <label for="pref_website">{{ _T("Website:") }}</label>
                         <input type="text" name="pref_website" id="pref_website" value="{{ pref.pref_website }}" maxlength="100"/>
                     </div>
                 </div>{# /column #}
+            </div>
+            <div class="ui stackable two column grid">
                 <div class="column">
-                    <div class="field">
-                        <label>
-                            {{ _T("Postal address:") }}
-                            <i class="circular small basic question icon tooltip" title="{{ _T("Use either the address setted below or select a staff member to retrieve he's address.") }}" aria-hidden="true"></i>
-                        </label>
-                        <div class="inline fields">
-                            <div class="field">
-                                <label for="pref_postal_address_0">{{ _T("from preferences") }}</label>
-                                <input type="radio" name="pref_postal_address" id="pref_postal_address_0" value="{{ constant('Galette\\Core\\Preferences::POSTAL_ADDRESS_FROM_PREFS') }}" {% if pref.pref_postal_address == constant('Galette\\Core\\Preferences::POSTAL_ADDRESS_FROM_PREFS') %}checked="checked"{% endif %}/>
-                            </div>
-                            <div class="field">
-                                <label for="pref_postal_address_1">{{ _T("from a staff user") }}</label>
-                                <input type="radio" name="pref_postal_address" id="pref_postal_address_1" value="{{ constant('Galette\\Core\\Preferences::POSTAL_ADDRESS_FROM_STAFF') }}" {% if pref.pref_postal_address == constant('Galette\\Core\\Preferences::POSTAL_ADDRESS_FROM_STAFF') %}checked="checked"{% endif %}/>
-                            </div>
-                        </div>
-                        <label for="pref_postal_staff_member">{{ _T("Staff member") }}</label>
-                        <select name="pref_postal_staff_member" id="pref_postal_staff_member" class="ui search dropdown">
-                            <option value="-1">{{ _T("-- Choose a staff member --") }}</option>
-                        {% for staff in staff_members %}
-                            <option value="{{ staff.id }}"{% if staff.id == pref.pref_postal_staff_member %} selected="selected"{% endif %}>{{ staff.name }} ({{ staff.sstatus }})</option>
-                        {% endfor %}
-                        </select>
-                    </div>
                     <div class="field">
                         <label for="pref_footer">{{ _T("Footer text:") }}</label>
                         <div class="ui right corner labeled input">
@@ -157,6 +211,14 @@
                             <textarea name="pref_footer" id="pref_footer" rows="2">{{ pref.pref_footer }}</textarea>
                         </div>
                     </div>
+                    <div class="field inline">
+                        <div class="ui right aligned toggle checkbox">
+                            <input type="checkbox" name="pref_noindex" id="pref_noindex" value="1"{% if pref.pref_noindex %} checked="checked"{% endif %}/>
+                            <label for="pref_noindex">{{ _T("Prevent search engines indexation") }}</label>
+                        </div>
+                    </div>
+                </div>{# /column #}
+                <div class="column">
                     <div class="field">
                         <label>
                             {{ _T("Telemetry date:") }}
@@ -182,12 +244,6 @@
                             {% endif %}
                             - <a href="{{ constant('GALETTE_TELEMETRY_URI') }}reference?showmodal&uuid={{ pref.pref_registration_uuid }}" id="register" target="_blank" class="ui labeled icon button"><i class="pen alternate icon" aria-hidden="true"></i>{{ regtxt }}</a>
                         </span>
-                    </div>
-                    <div class="field inline">
-                        <div class="ui right aligned toggle checkbox">
-                            <input type="checkbox" name="pref_noindex" id="pref_noindex" value="1"{% if pref.pref_noindex %} checked="checked"{% endif %}/>
-                            <label for="pref_noindex">{{ _T("Prevent search engines indexation") }}</label>
-                        </div>
                     </div>
                 </div>{# /column #}
             </div>{# /column grid #}
@@ -645,7 +701,7 @@
                     </div>
                 </div>{# /column #}
                 <div class="column">
-                    <div class="grouped fields">
+                    <div id="emailing_method" class="grouped fields">
                         <label>{{ _T("Emailing method:") }}</label>
                         <div class="field">
                             <div class="ui radio checkbox">
@@ -1091,11 +1147,11 @@
     {% if pref.pref_mail_method != constant('Galette\\Core\\GaletteMail::METHOD_SMTP') and pref.pref_mail_method != constant('Galette\\Core\\GaletteMail::METHOD_GMAIL') %}
                 $('#smtp_auth').addClass('displaynone');
     {% endif %}
-                $('.ui.radio.checkbox').checkbox({
+                $('#emailing_method .ui.radio.checkbox').checkbox({
                     onChange: function() {
                         var _checked = $(this).closest('input').attr('id');
-                        var _smtp_parameters = $(this).closest('.checkbox').parent().parent().siblings('#smtp_parameters');
-                        var _smtp_auth = $(this).closest('.checkbox').parent().parent().siblings('#smtp_auth');
+                        var _smtp_parameters = $('#smtp_parameters');
+                        var _smtp_auth = $('#smtp_auth');
                         if ( _checked == 'smtp' ) {
                             _smtp_parameters.removeClass('displaynone');
                             _smtp_auth.removeClass('displaynone');
@@ -1105,6 +1161,36 @@
                         } else {
                             _smtp_parameters.addClass('displaynone');
                             _smtp_auth.addClass('displaynone');
+                        }
+                    }
+                });
+
+    {% if pref.pref_postal_address == constant('Galette\\Core\\Preferences::POSTAL_ADDRESS_FROM_PREFS') %}
+                $('#postal_staff_member').addClass('displaynone');
+    {% endif %}
+                $('#postal_reference .ui.radio.checkbox').checkbox({
+                    onChange: function() {
+                        var _checked = $(this).closest('input').attr('id');
+                        var _postal_staff = $('#postal_staff_member');
+                        if ( _checked == 'pref_postal_address_1' ) {
+                            _postal_staff.removeClass('displaynone');
+                        } else {
+                            _postal_staff.addClass('displaynone');
+                        }
+                    }
+                });
+
+    {% if pref.pref_org_phone == constant('Galette\\Core\\Preferences::PHONE_NUMBER_FROM_PREFS') %}
+                $('#phone_staff_member').addClass('displaynone');
+    {% endif %}
+                $('#phone_reference .ui.radio.checkbox').checkbox({
+                    onChange: function() {
+                        var _checked = $(this).closest('input').attr('id');
+                        var _phone_staff = $('#phone_staff_member');
+                        if ( _checked == 'pref_org_phone_1' || _checked == 'pref_org_phone_2' ) {
+                            _phone_staff.removeClass('displaynone');
+                        } else {
+                            _phone_staff.addClass('displaynone');
                         }
                     }
                 });

--- a/tests/Galette/Core/tests/units/Preferences.php
+++ b/tests/Galette/Core/tests/units/Preferences.php
@@ -649,7 +649,7 @@ class Preferences extends GaletteTestCase
     {
         $legend = $this->preferences->getLegend();
         $this->assertCount(2, $legend);
-        $this->assertCount(10, $legend['main']['patterns']);
+        $this->assertCount(12, $legend['main']['patterns']);
         $this->assertCount(10, $legend['socials']['patterns']);
         $this->assertSame(
             [
@@ -1066,7 +1066,7 @@ class Preferences extends GaletteTestCase
 
         $post = array_merge($preferences, ['pref_postal_address' => \Galette\Core\Preferences::POSTAL_ADDRESS_FROM_STAFF]);
         $this->assertFalse($this->preferences->check($post, $this->login));
-        $this->assertSame(['You have to select a staff member'], $this->preferences->getErrors());
+        $this->assertSame(['You have to select a staff member to retrieve its address'], $this->preferences->getErrors());
 
         $memberOne = $this->getMemberOne();
         $post = array_merge(
@@ -1082,6 +1082,48 @@ class Preferences extends GaletteTestCase
         );
         $expected = "DURAND René\nGalette association's Non-member\n66, boulevard De Oliveira\n39 069 Martel - Antarctique";
         $this->assertSame($expected, $this->preferences->getPostalAddress());
+    }
+
+    /**
+     * Test phone number
+     *
+     * @return void
+     */
+    public function testOrgPhone(): void
+    {
+        $preferences = [];
+        foreach ($this->preferences->getDefaults() as $key => $value) {
+            $preferences[$key] = $value;
+        }
+
+        $post = array_merge($preferences, ['pref_org_phone' => \Galette\Core\Preferences::PHONE_NUMBER_FROM_PREFS]);
+        $this->assertTrue(
+            $this->preferences->check($post, $this->login),
+            print_r($this->preferences->getErrors(), true)
+        );
+
+        $post = array_merge($preferences, ['pref_org_phone' => \Galette\Core\Preferences::PHONE_NUMBER_FROM_STAFF]);
+        $this->assertFalse($this->preferences->check($post, $this->login));
+        $this->assertSame(['You have to select a staff member to retrieve its phone number'], $this->preferences->getErrors());
+
+        $post = array_merge($preferences, ['pref_org_phone' => \Galette\Core\Preferences::PHONE_NUMBER_MOBILE_FROM_STAFF]);
+        $this->assertFalse($this->preferences->check($post, $this->login));
+        $this->assertSame(['You have to select a staff member to retrieve its phone number'], $this->preferences->getErrors());
+
+        $memberOne = $this->getMemberOne();
+        $post = array_merge(
+            $preferences,
+            [
+                'pref_org_phone' => \Galette\Core\Preferences::PHONE_NUMBER_FROM_STAFF,
+                'pref_org_phone_staff_member' => $memberOne->id
+            ]
+        );
+        $this->assertTrue(
+            $this->preferences->check($post, $this->login),
+            print_r($this->preferences->getErrors(), true)
+        );
+        $expected = '0439153432';
+        $this->assertSame($expected, $this->preferences->getPhoneNumber());
     }
 
     /**

--- a/tests/Galette/Entity/tests/units/PdfModel.php
+++ b/tests/Galette/Entity/tests/units/PdfModel.php
@@ -104,6 +104,8 @@ class PdfModel extends GaletteTestCase
             'asso_slogan'        => '/{ASSO_SLOGAN}/',
             'asso_address'       => '/{ASSO_ADDRESS}/',
             'asso_address_multi' => '/{ASSO_ADDRESS_MULTI}/',
+            'asso_phone_number'  => '/{ASSO_PHONE}/',
+            'asso_email'         => '/{ASSO_EMAIL}/',
             'asso_website'       => '/{ASSO_WEBSITE}/',
             'asso_logo'          => '/{ASSO_LOGO}/',
             'asso_print_logo'    => '/{ASSO_PRINT_LOGO}/',
@@ -345,7 +347,7 @@ Au milieu
         $this->assertArrayHasKey('member', $legend);
         $this->assertArrayHasKey('contribution', $legend);
 
-        $this->assertCount(10, $legend['main']['patterns']);
+        $this->assertCount(12, $legend['main']['patterns']);
         $this->assertCount(28, $legend['member']['patterns']);
         $this->assertTrue(isset($legend['member']['patterns']['label_dynfield_' . $adf->getId() . '_adh']));
         $this->assertCount(14, $legend['contribution']['patterns']);


### PR DESCRIPTION
At first, I had the intention to add some of these values in the plugin I'm working on. But I realized that emails and pdf models would not be able to use them :confused: 

Then I tought I would open a request to add a feature to allow plugins to create replacement values available to the Core :thinking: 

But I found the following existing (old) requests on the tracker :
- [#201](https://bugs.galette.eu/issues/201) : Téléphone siège social de l'association
- [#204](https://bugs.galette.eu/issues/204) : siren, siret, N° greffe association

So, I hope it will be OK to add them in Core. This PR adds the following fields in the "General" tab of the Preferences :
- telephone number (with the possibility to select a staff member's one)
- email address (different from the sender email address)
- registration number
- registration office
- business identification number

I also add JS code to show/hide the staff member select when relevant.

![settings](https://github.com/user-attachments/assets/8d452e58-b8b3-4011-a45c-232619fc4bc2)

I chose not to add dedicated fields for the french SIREN *and* SIRET numbers, because unless I'm wrong, other countries don't make this distinction. In France, and because Galette doesn't deal with multiple addresses ; only the SIREN *or* a SIRET is necessary (not both). Moreover, nothing prevents the users from setting both number in the corresponding field (a.k.a "business identification number").

I didn't deal with the other requests of the issues above : 

- "heures de permanence" (201 & 204) : I don't see a convenient way to implement that. Maybe a simple textarea for "Additionnal contact details" could be enough? Let me know if you want me to add this textarea ; 201 could then be closed after that.

- "carte d'identité administrative de l'association" (204) : it can already exist on the website of the association, or could be implemented in a plugin. Moreover, the same thing is asked in another related issue but as a homepage ([#494](https://bugs.galette.eu/issues/494)).

- "adresse siège social" / "adresse de gestion" (204) : that would mean multiple addresses, and possibly each with it's own phone number, email (and SIRET for france). I don't think it is the purpose of Galette to list all the existing addresses of an association.

- "références Journal Officiel déclaration" (204) : this one is totally useless in my opinion

- "page statuts" (204) : statuses can be published as a document ; or I could add it in my plugin if requested

- "références bancaires BIC et IBAN..." (204) : they could be easily be added. Let me know if you want me to add them.