### PR TITLE
Change pages visibility settings order on mobile

### DIFF
--- a/galette/templates/default/pages/preferences.html.twig
+++ b/galette/templates/default/pages/preferences.html.twig
@@ -406,7 +406,7 @@
                     <div class="field">
                         <label for="pref_publicpages_visibility_generic">
                             {{ _T("Default") }}
-                            <i class="circular small inverted primary icon info tooltip" title="{{ _T("Will apply for all public pages that are not listed here, including plugin ones.") }}" aria-hidden="true"></i>
+                            <i class="circular small basic question icon tooltip" title="{{ _T("Will apply for all public pages that are not listed here, including plugin ones.") }}" aria-hidden="true"></i>
                         </label>
                         <select name="pref_publicpages_visibility_generic" id="pref_publicpages_visibility_generic" class="ui search dropdown">
                             <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_HIDDEN') }}"{% if pref.pref_publicpages_visibility_generic == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_HIDDEN') %} selected="selected"{% endif %}>{{ _T("Hidden") }}</option>
@@ -415,6 +415,20 @@
                             <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') }}"{% if pref.pref_publicpages_visibility_generic == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') %} selected="selected"{% endif %}>{{ _T("Admin and staff only") }}</option>
                         </select>
                     </div>
+                </div>{# /column #}
+                <div class="column">
+                    <div class="field">
+                        <label for="pref_publicpages_visibility_documents">{{ _T("Documents") }}</label>
+                        <select name="pref_publicpages_visibility_documents" id="pref_publicpages_visibility_documents" class="ui search dropdown">
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_INHERIT') }}"{% if pref.pref_publicpages_visibility_documents == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_INHERIT') %} selected="selected"{% endif %}>{{ _T("Inherit") }}</option>
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_HIDDEN') }}"{% if pref.pref_publicpages_visibility_documents == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_HIDDEN') %} selected="selected"{% endif %}>{{ _T("Hidden") }}</option>
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PUBLIC') }}"{% if pref.pref_publicpages_visibility_documents == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PUBLIC') %} selected="selected"{% endif %}>{{ _T("Everyone") }}</option>
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_RESTRICTED') }}"{% if pref.pref_publicpages_visibility_documents == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_RESTRICTED') %} selected="selected"{% endif %}>{{ _T("Up to date members") }}</option>
+                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') }}"{% if pref.pref_publicpages_visibility_documents == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') %} selected="selected"{% endif %}>{{ _T("Admin and staff only") }}</option>
+                        </select>
+                    </div>
+                </div>{# /column #}
+                <div class="column">
                     <div class="field">
                         <label for="pref_publicpages_visibility_memberslist">{{ _T("Members list") }}</label>
                         <select name="pref_publicpages_visibility_memberslist" id="pref_publicpages_visibility_memberslist" class="ui search dropdown">
@@ -437,16 +451,6 @@
                     </div>
                 </div>{# /column #}
                 <div class="column">
-                    <div class="field">
-                        <label for="pref_publicpages_visibility_documents">{{ _T("Documents") }}</label>
-                        <select name="pref_publicpages_visibility_documents" id="pref_publicpages_visibility_documents" class="ui search dropdown">
-                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_INHERIT') }}"{% if pref.pref_publicpages_visibility_documents == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_INHERIT') %} selected="selected"{% endif %}>{{ _T("Inherit") }}</option>
-                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_HIDDEN') }}"{% if pref.pref_publicpages_visibility_documents == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_HIDDEN') %} selected="selected"{% endif %}>{{ _T("Hidden") }}</option>
-                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PUBLIC') }}"{% if pref.pref_publicpages_visibility_documents == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PUBLIC') %} selected="selected"{% endif %}>{{ _T("Everyone") }}</option>
-                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_RESTRICTED') }}"{% if pref.pref_publicpages_visibility_documents == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_RESTRICTED') %} selected="selected"{% endif %}>{{ _T("Up to date members") }}</option>
-                            <option value="{{ constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') }}"{% if pref.pref_publicpages_visibility_documents == constant('Galette\\Core\\Preferences::PUBLIC_PAGES_VISIBILITY_PRIVATE') %} selected="selected"{% endif %}>{{ _T("Admin and staff only") }}</option>
-                        </select>
-                    </div>
                     <div class="field">
                         <label for="pref_publicpages_visibility_stafflist">{{ _T("Staff list") }}</label>
                         <select name="pref_publicpages_visibility_stafflist" id="pref_publicpages_visibility_stafflist" class="ui search dropdown">


### PR DESCRIPTION
On mobile, the documents visibility setting is displayed between members and staff pages :
![before](https://github.com/user-attachments/assets/02376e45-2cc0-4284-98ee-3970a5594157)

This PR reorders the fields so that the order is more logical on mobile. 
It also replaces the old inline help icon with the new one :
![after](https://github.com/user-attachments/assets/e755e786-740d-47cd-8cc0-420fa7c420c2)