### PR TITLE
More improvements on dynamic translations page

### DIFF
--- a/galette/includes/routes/management.routes.php
+++ b/galette/includes/routes/management.routes.php
@@ -340,6 +340,11 @@ $app->post(
 )->setName('editDynamicTranslation')->add($authenticate);
 
 $app->get(
+    '/dynamic-translation/remove/{text_orig}',
+    [DynamicTranslationsController::class, 'undoDynamicTranslation']
+)->setName('removeDynamicTranslation')->add($authenticate);
+
+$app->get(
     '/lists/{table}/configure',
     [GaletteController::class, 'configureListFields']
 )->setName('configureListFields')->add($authenticate);

--- a/galette/install/scripts/mysql.sql
+++ b/galette/install/scripts/mysql.sql
@@ -176,6 +176,7 @@ CREATE TABLE galette_l10n (
     text_locale varchar(15) NOT NULL,
     text_nref int NOT NULL default 1,
     text_trans varchar(255) NOT NULL default '',
+    text_is_source int NOT NULL,
     PRIMARY KEY (text_orig_sum, text_locale)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_520_ci;
 

--- a/galette/install/scripts/pgsql.sql
+++ b/galette/install/scripts/pgsql.sql
@@ -173,6 +173,7 @@ CREATE TABLE galette_l10n (
   text_locale character varying(15) NOT NULL,
   text_nref integer DEFAULT 1 NOT NULL,
   text_trans character varying(255) DEFAULT '' NOT NULL,
+  text_is_source integer NOT NULL,
   PRIMARY KEY (text_orig_sum, text_locale)
 );
 

--- a/galette/install/scripts/sql/upgrade-to-1.20-mysql.sql
+++ b/galette/install/scripts/sql/upgrade-to-1.20-mysql.sql
@@ -66,6 +66,8 @@ ALTER TABLE galette_l10n CHANGE text_trans text_trans varchar(255) NOT NULL DEFA
 ALTER TABLE galette_l10n ADD text_orig_sum varchar(40) NOT NULL;
 UPDATE galette_l10n SET text_orig_sum = MD5(text_orig);
 ALTER TABLE galette_l10n DROP PRIMARY KEY, ADD PRIMARY KEY (text_orig_sum, text_locale);
+ALTER TABLE galette_l10n ADD text_is_source INT NOT NULL;
+UPDATE galette_l10n SET text_is_source = CASE WHEN text_locale LIKE CONCAT((SELECT val_pref FROM galette_preferences WHERE nom_pref = 'pref_lang'), '%') THEN 1 ELSE 0 END;
 
 ALTER TABLE galette_tmppasswds CHANGE id_adh id_adh INT UNSIGNED NOT NULL;
 

--- a/galette/install/scripts/sql/upgrade-to-1.20-pgsql.sql
+++ b/galette/install/scripts/sql/upgrade-to-1.20-pgsql.sql
@@ -183,3 +183,6 @@ UPDATE galette_l10n SET text_orig_sum = MD5(text_orig);
 ALTER TABLE galette_l10n ALTER COLUMN text_orig_sum SET NOT NULL;
 ALTER TABLE galette_l10n DROP CONSTRAINT galette_l10n_pkey;
 ALTER TABLE galette_l10n ADD CONSTRAINT galette_l10n_pkey PRIMARY KEY (text_orig_sum, text_locale);
+ALTER TABLE galette_l10n ADD COLUMN text_is_source integer;
+UPDATE galette_l10n SET text_is_source = CASE WHEN galette_l10n.text_locale LIKE CONCAT(galette_preferences.val_pref, '%') AND galette_preferences.nom_pref = 'pref_lang' THEN 1 ELSE 0 END FROM galette_preferences WHERE galette_preferences.nom_pref = 'pref_lang';
+ALTER TABLE galette_l10n ALTER COLUMN text_is_source SET NOT NULL;

--- a/galette/lib/Galette/Core/L10n.php
+++ b/galette/lib/Galette/Core/L10n.php
@@ -102,14 +102,18 @@ class L10n
                     //add new entry
                     // User is supposed to use current language as original text.
                     $text_trans = $text_orig;
+                    $text_is_source = 0;
                     if ($lang->getLongID() != $this->i18n->getLongID()) {
                         $text_trans = '';
+                    } else {
+                        $text_is_source = 1;
                     }
                     $values = array(
                         'text_orig' => $text_orig,
                         'text_orig_sum' => md5($text_orig),
                         'text_locale' => $lang->getLongID(),
-                        'text_trans' => $text_trans
+                        'text_trans' => $text_trans,
+                        'text_is_source' => $text_is_source
                     );
 
                     $insert = $this->zdb->insert(self::TABLE);
@@ -274,11 +278,17 @@ class L10n
             $results = $this->zdb->execute($select);
             $existing_translations = array();
             foreach ($results as $row) {
-                $existing_translations[$row->text_locale] = $row->text_trans;
+                $existing_translations[$row->text_locale] = [
+                    'text_trans' => $row->text_trans,
+                    'text_is_source' => $row->text_is_source,
+                ];
             }
 
             if (!count($existing_translations)) {
-                $existing_translations[$this->i18n->getLongID()] = $text_orig_sum;
+                $existing_translations[$this->i18n->getLongID()] = [
+                    'text_trans' => $text_orig_sum,
+                    'text_is_source' => 1
+                ];
             }
 
             $results = array();

--- a/galette/templates/default/pages/configuration_dynamic_translations.html.twig
+++ b/galette/templates/default/pages/configuration_dynamic_translations.html.twig
@@ -32,45 +32,52 @@
                 <input type="hidden" name="new" value="true"/>
             </div>
     {% endif %}
-
-            <div class="ui top attached accordion-styled header">
     {% if exists and mode != 'ajax' %}
-                {{ _T("Original text:") }}
-                <div id="label-selection" class="ui basic labeled icon dropdown button tooltip" title="{{ _T("Choose label to translate") }}">
-                    <input type="hidden" name="filters">
-                    <i class="language icon"></i>
-                    <span class="text">{{ text_orig }}</span>
-                    <div class="menu">
-                        <div class="ui icon search input">
-                            <i class="search icon"></i>
-                            <input type="text"/>
-                        </div>
-                        <div class="scrolling menu">
-                            {% for sum, value in orig %}
-                                <a class="item" href="{{ url_for('dynamicTranslation', {"text_orig_sum": sum}) }}">{{ value }}</a>
-                            {% endfor %}
+            <div class="ui basic fitted segment">
+                <strong>{{ _T("Choose label to translate") }} : </strong>
+                <div class="ui buttons">
+                    <div id="label-selection" class="ui left labeled basic icon dropdown button">
+                        <input type="hidden" name="filters">
+                        <i class="dropdown icon"></i>
+                        <span class="text">{{ text_orig }}</span>
+                        <div class="menu">
+                            <div class="ui icon search input">
+                                <i class="search icon"></i>
+                                <input type="text"/>
+                            </div>
+                            <div class="scrolling menu">
+                                {% for sum, value in orig %}
+                                    <a class="item" href="{{ url_for('dynamicTranslation', {"text_orig_sum": sum}) }}">{{ value }}</a>
+                                {% endfor %}
+                            </div>
                         </div>
                     </div>
+                    <div class="or" data-text="{{ _T("or") }}"></div>
+                    <a class="ui right labeled icon button delete" href="{{ url_for('removeDynamicTranslation', {"text_orig": text_orig}) }}">
+                        <i class="trash red icon"></i>
+                        {{ _T("Delete") }}
+                    </a>
                 </div>
-    {% else %}
-                {{ _T("Original text:") }} {{ text_orig }}
+            </div>
     {% endif %}
-            </div>
-            <div class="ui bottom attached accordion-styled segment">
-                <div class="active content field">
-                    <table class="ui striped table">
+            <table class="ui striped definition table">
     {% for k, text in trans %}
-                        <tr>
-                            <td class="three wide"><label for="text_trans_{{ text.key }}">{{ text.name }}</label></td>
-                            <td class="thirteen wide">
-                                <input type="text" name="text_trans_{{ text.key }}" id="text_trans_{{ text.key }}" value="{% if text.text %}{{ text.text|escape }}{% endif %}"/>
-                            </td>
-                        </tr>
+                <tr>
+                    <th class="collapsing"><label for="text_trans_{{ text.key }}">{{ text.name }}</label></th>
+                    <td>
+        {% if not text.text is empty and text.text.text_is_source == 1 %}
+                        <div class="ui fluid left labeled disabled input">
+        {% endif %}
+                            <input type="text" name="text_trans_{{ text.key }}" id="text_trans_{{ text.key }}" value="{% if text.text %}{{ text.text.text_trans|escape }}{% endif %}"/>
+        {% if not text.text is empty and text.text.text_is_source == 1 %}
+                            <div class="ui tag black label">{{ _T("Original text") }}</div>
+                        </div>
+        {% endif %}
+                    </td>
+                </tr>
     {% endfor %}
-                    </table>
-                    <input type=hidden name="text_orig" value="{{ text_orig|escape }}"/>
-                </div>
-            </div>
+            </table>
+            <input type=hidden name="text_orig" value="{{ text_orig|escape }}"/>
     {% if mode != 'ajax' %}
             <div class="ui basic center aligned segment">
                 <button type="submit" name="trans" class="ui labeled icon primary button action">
@@ -86,4 +93,29 @@
 {% else %}
         <p>{{ _T("No fields to translate.") }}</p>
 {% endif %}
+{% endblock %}
+
+{% block javascripts %}
+    {% if text_orig|default %}
+        <script type="text/javascript">
+            $(function(){
+                $('.delete').click(function(event){
+                    event.preventDefault();
+                    var _href = this.getAttribute('href');
+                    {% set modal_content = _T("Are you sure you want to remove translations of «%t»?")|replace({"%t": text_orig}) ~ '<br/>' ~ _T("This can't be undone.") %}
+                    {% include "elements/js/modal.js.twig" with {
+                        modal_title_twig: _T("Remove translations")|e("js"),
+                        modal_content_twig: modal_content|e("js"),
+                        modal_class: "tiny",
+                        modal_onapprove: "window.location.href = _href;",
+                        modal_approve_text: _T("Remove")|e('js'),
+                        modal_approve_icon: "trash",
+                        modal_approve_color: "red",
+                        modal_cancel_text: _T("Cancel")|e("js"),
+                        modal_classname: "redalert",
+                    } %}
+                });
+            });
+        </script>
+    {% endif %}
 {% endblock %}

--- a/galette/templates/default/pages/configuration_payment_types.html.twig
+++ b/galette/templates/default/pages/configuration_payment_types.html.twig
@@ -73,7 +73,7 @@
                                     <span class="ui special popup">{{ _T("Edit '%s' payment type")|replace({'%s': ptype.getName()}) }}</span>
                                 </a>
                                 <a
-                                    href="{{ url_for('dynamicTranslations', {'text_orig': ptype.getName(false)|escape}) }}"
+                                    href="{{ url_for('dynamicTranslations', {'text_orig': ptype.getName(false)}) }}"
                                     class="action single-translate"
                                 >
                                     <i class="ui language grey icon tooltip" aria-hidden="true"></i>

--- a/galette/templates/default/pages/contributions_types_list.html.twig
+++ b/galette/templates/default/pages/contributions_types_list.html.twig
@@ -107,6 +107,13 @@
                             <span class="ui special popup">{{ _T("Edit '%s' field")|replace({'%s': entry.name|escape}) }}</span>
                         </a>
                         <a
+                            href="{{ url_for('dynamicTranslations', {'text_orig': entry.name}) }}"
+                            class="action single-translate"
+                        >
+                            <i class="ui language grey icon tooltip" aria-hidden="true"></i>
+                            <span class="ui special popup">{{ _T("Translate '%s'")|replace({'%s': entry.name|escape}) }}</span>
+                        </a>
+                        <a
                             href="{{ url_for('removeContributionType', {'id': eid}) }}"
                             class="delete"
                         >
@@ -134,6 +141,44 @@
                 selector: ".single-edit",
                 modal_title_twig: _T("Edit contribution type")|e("js"),
                 modal_class: "mini",
+                modal_onapprove: modal_onapprove
+            } %}
+
+            {% set extra_success = "
+                $('.modal-form form').on('submit', function(event) {
+                    event.preventDefault();
+                    var _form = $(this);
+                    var _data = _form.serialize();
+                    $.ajax({
+                        url: _form.attr('action'),
+                        type: 'POST',
+                        datatype: 'json',
+                        data: _data,
+                        error: function() {
+                            $.modal({
+                                title: '%error%',
+                                class: 'mini',
+                                actions: [{
+                                    text: '%close%',
+                                    icon: 'times',
+                                    class: 'icon labeled cancel'
+                                }],
+                                className: {
+                                    modal: 'ui redalert modal',
+                                    title: 'center aligned header',
+                                    content: 'center aligned content',
+                                    actions: 'center aligned actions'
+                                }
+                            }).modal('show');
+                        }
+                    });
+                });
+            " %}
+            {% include "elements/js/modal_action.js.twig" with {
+                selector: ".single-translate",
+                extra_success: extra_success|replace({'%error%': _T("An error occurred :(")|e("js"), '%close%': _T("Close")|e("js")}),
+                modal_title_twig: _T("Translate labels")|e("js"),
+                modal_content_class: "scrolling",
                 modal_onapprove: modal_onapprove
             } %}
 

--- a/galette/templates/default/pages/preferences.html.twig
+++ b/galette/templates/default/pages/preferences.html.twig
@@ -51,8 +51,8 @@
                         <div class="ui action input">
                             <input type="text" name="pref_slogan" id="pref_slogan" value="{{ pref.pref_slogan }}"/>
                             <a
-                                href="{{ url_for("dynamicTranslations", {"text_orig": pref.pref_slogan|escape}) }}"
-                                class="tooltip ui icon button"
+                                href="{{ url_for("dynamicTranslations", {"text_orig": pref.pref_slogan}) }}"
+                                class="single-translate tooltip ui icon button{% if pref.pref_slogan is empty %} disabled{% endif %}"
                                 title="{{ _T("Translate '%s'")|replace({'%s': pref.pref_slogan}) }}"
                             >
                                 <i class="language icon" aria-hidden="true"></i>
@@ -881,8 +881,8 @@
                         <div class="ui action input">
                             <input type="text" name="pref_card_abrev" id="pref_card_abrev" value="{{ pref.pref_card_abrev }}" maxlength="10"/>
                             <a
-                                href="{{ url_for("dynamicTranslations", {"text_orig": pref.pref_card_abrev|escape}) }}"
-                                class="tooltip ui icon button{% if pref.pref_card_abrev is empty %} disabled{% endif %}"
+                                href="{{ url_for("dynamicTranslations", {"text_orig": pref.pref_card_abrev}) }}"
+                                class="single-translate tooltip ui icon button{% if pref.pref_card_abrev is empty %} disabled{% endif %}"
                                 title="{{ _T("Translate '%s'")|replace({"%s": pref.pref_card_abrev}) }}"
                             >
                                 <i class="language icon" aria-hidden="true"></i>
@@ -896,8 +896,8 @@
                         <div class="ui action input">
                             <input type="text" name="pref_card_strip" id="pref_card_strip" value="{{ pref.pref_card_strip }}" maxlength="65"/>
                             <a
-                                href="{{ url_for("dynamicTranslations", {"text_orig": pref.pref_card_strip|escape}) }}"
-                                class="tooltip ui icon button{% if pref.pref_card_strip is empty %} disabled{% endif %}"
+                                href="{{ url_for("dynamicTranslations", {"text_orig": pref.pref_card_strip}) }}"
+                                class="single-translate tooltip ui icon button{% if pref.pref_card_strip is empty %} disabled{% endif %}"
                                 title="{{ _T("Translate '%s'")|replace({"%s": pref.pref_card_strip}) }}"
                             >
                                 <i class="language icon" aria-hidden="true"></i>
@@ -1306,6 +1306,51 @@
 
                 {% include "modals/telemetry.html.twig" with {part: "jsdialog"} %}
                 {% include "modals/telemetry.html.twig" with {part: "jsregister"} %}
+
+                {% set modal_onapprove = "
+                    $('.modal-form form #redirect_uri').val(window.location.href);
+                    $('.modal-form form').submit();
+                " %}
+                {% set extra_success = "
+                    $('.modal-form form').on('submit', function(event) {
+                        event.preventDefault();
+                        var _form = $(this);
+                        var _data = _form.serialize();
+                        $.ajax({
+                            url: _form.attr('action'),
+                            type: 'POST',
+                            datatype: 'json',
+                            data: _data,
+                            error: function() {
+                                $.modal({
+                                    title: '%error%',
+                                    class: 'mini',
+                                    actions: [{
+                                        text: '%close%',
+                                        icon: 'times',
+                                        class: 'icon labeled cancel'
+                                    }],
+                                    className: {
+                                        modal: 'ui redalert modal',
+                                        title: 'center aligned header',
+                                        content: 'center aligned content',
+                                        actions: 'center aligned actions'
+                                    }
+                                }).modal('show');
+                            }
+                        });
+                    });
+                " %}
+                var _transDynField = function() {
+                    {% include "elements/js/modal_action.js.twig" with {
+                        selector: ".single-translate",
+                        extra_success: extra_success|replace({'%error%': _T("An error occurred :(")|e("js"), '%close%': _T("Close")|e("js")}),
+                        modal_title_twig: _T("Translate labels")|e("js"),
+                        modal_content_class: "scrolling",
+                        modal_onapprove: modal_onapprove
+                    } %}
+                }
+                _transDynField();
             });
         </script>
 {% endblock %}

--- a/galette/templates/default/pages/status_list.html.twig
+++ b/galette/templates/default/pages/status_list.html.twig
@@ -92,6 +92,13 @@
                                 <span class="ui special popup">{{ _T("Edit '%s' field")|replace({'%s': entry.name|escape}) }}</span>
                             </a>
                             <a
+                                href="{{ url_for('dynamicTranslations', {'text_orig': entry.name}) }}"
+                                class="action single-translate"
+                            >
+                                <i class="ui language grey icon tooltip" aria-hidden="true"></i>
+                                <span class="ui special popup">{{ _T("Translate '%s'")|replace({'%s': entry.name|escape}) }}</span>
+                            </a>
+                            <a
                                     href="{{ url_for('removeStatus', {'id': eid}) }}"
                                     class="delete"
                             >
@@ -121,6 +128,44 @@
                 selector: ".single-edit",
                 modal_title_twig: modal_title_twig,
                 modal_class: "mini",
+                modal_onapprove: modal_onapprove
+            } %}
+
+            {% set extra_success = "
+                $('.modal-form form').on('submit', function(event) {
+                    event.preventDefault();
+                    var _form = $(this);
+                    var _data = _form.serialize();
+                    $.ajax({
+                        url: _form.attr('action'),
+                        type: 'POST',
+                        datatype: 'json',
+                        data: _data,
+                        error: function() {
+                            $.modal({
+                                title: '%error%',
+                                class: 'mini',
+                                actions: [{
+                                    text: '%close%',
+                                    icon: 'times',
+                                    class: 'icon labeled cancel'
+                                }],
+                                className: {
+                                    modal: 'ui redalert modal',
+                                    title: 'center aligned header',
+                                    content: 'center aligned content',
+                                    actions: 'center aligned actions'
+                                }
+                            }).modal('show');
+                        }
+                    });
+                });
+            " %}
+            {% include "elements/js/modal_action.js.twig" with {
+                selector: ".single-translate",
+                extra_success: extra_success|replace({'%error%': _T("An error occurred :(")|e("js"), '%close%': _T("Close")|e("js")}),
+                modal_title_twig: _T("Translate labels")|e("js"),
+                modal_content_class: "scrolling",
                 modal_onapprove: modal_onapprove
             } %}
 

--- a/ui/semantic/galette/collections/table.overrides
+++ b/ui/semantic/galette/collections/table.overrides
@@ -162,9 +162,29 @@ td.emptylist {
 /*-----------------------------
      <th> outside <thead>
 ------------------------------*/
-tr.with-headers th {
+.ui.table > tbody > tr > th {
     padding: @cellVerticalPadding @cellHorizontalPadding;
+    text-align: @cellTextAlign;
+}
+tr.with-headers th {
     background: @lightSecondaryColor;
+}
+
+.ui.definition.table tr th.definition,
+.ui.definition.table > tbody > tr > th:first-child:not(.ignored),
+.ui.definition.table > tr > th:first-child:not(.ignored) {
+    background: @definitionColumnBackground;
+    font-weight: @definitionColumnFontWeight;
+    color: @definitionColumnColor;
+    font-size: @definitionColumnFontSize;
+}
+.ui.definition.table > tbody > tr > th,
+.ui.definition.table > tr > th {
+  border-top: @rowBorder;
+}
+.ui.definition.table > tbody > tr:first-child > th,
+.ui.definition.table > tr:first-child > th {
+    border-top: none;
 }
 
 /*------------------


### PR DESCRIPTION
The page UI can still be improved a little I think :smile: 

I chose to disable the original text input because I think that it should not be modified, and I added a button to delete translation if needed (translations of preferences cannot be removed automatically when a value is modified).

Other changes are listed in the comment of the commit.

![modify](https://github.com/user-attachments/assets/bec07d74-3e32-4f84-9c81-d3a27c840b41)

![modal](https://github.com/user-attachments/assets/610c2f1c-5c7f-4fe9-b3c3-57ee087f9197)