### PR TITLE
Optimize tables display

### DIFF
--- a/galette/lib/Galette/Controllers/DynamicTranslationsController.php
+++ b/galette/lib/Galette/Controllers/DynamicTranslationsController.php
@@ -73,15 +73,25 @@ class DynamicTranslationsController extends AbstractController
 
         try {
             $orig = $this->l10n->getStringsToTranslate();
+            $text_exists = false;
 
             if ($text_orig_sum === '') {
                 $text_orig_sum = array_key_first($orig);
             }
-            $text_orig = $orig[$text_orig_sum] ?? $text_orig_sum;
 
-            $params['exists'] = isset($orig[$text_orig_sum]);
+            if (isset($orig[$text_orig_sum]) || isset($orig[md5($text_orig_sum)])) {
+                $sum = isset($orig[$text_orig_sum]) ? $text_orig_sum : md5($text_orig_sum);
+                $text_exists = true;
+                $text_trans = $this->l10n->getDynamicTranslations($sum);
+                $text_orig = $orig[$sum];
+            } else {
+                $text_trans = $this->l10n->getDynamicTranslations($text_orig_sum);
+                $text_orig = $text_orig_sum;
+            }
+
+            $params['exists'] = $text_exists;
             $params['orig'] = $orig;
-            $params['trans'] = $this->l10n->getDynamicTranslations($text_orig_sum);
+            $params['trans'] = $text_trans;
             $params['text_orig'] = $text_orig;
         } catch (Throwable $e) {
             Analog::log(

--- a/galette/lib/Galette/Controllers/DynamicTranslationsController.php
+++ b/galette/lib/Galette/Controllers/DynamicTranslationsController.php
@@ -67,7 +67,7 @@ class DynamicTranslationsController extends AbstractController
     public function dynamicTranslation(Request $request, Response $response, string $text_orig_sum): Response
     {
         $params = [
-            'page_title'    => _T("Translate labels"),
+            'page_title'    => _T("Labels translation"),
             'documentation' => 'usermanual/configuration.html#labels-translation'
         ];
 

--- a/galette/lib/Galette/Controllers/DynamicTranslationsController.php
+++ b/galette/lib/Galette/Controllers/DynamicTranslationsController.php
@@ -129,6 +129,7 @@ class DynamicTranslationsController extends AbstractController
         } else {
             $redirect_url = $this->routeparser->urlFor(
                 'dynamicTranslations',
+                [],
                 ['text_orig' => $post['text_orig']]
             );
         }

--- a/galette/lib/Galette/Core/Galette.php
+++ b/galette/lib/Galette/Core/Galette.php
@@ -427,14 +427,6 @@ class Galette
                                 ]
                             ],
                             [
-                                'label' => _T("Translate labels"),
-                                'title' => _T("Translate additional fields labels"),
-                                'route' => [
-                                    'name' => 'dynamicTranslations',
-                                    'aliases' => ['dynamicTranslation']
-                                ]
-                            ],
-                            [
                                 'label' => _T("Contributions types"),
                                 'title' => _T("Manage contributions types"),
                                 'route' => [
@@ -476,6 +468,14 @@ class Galette
                                 'title' => _T("Manage emails texts and subjects"),
                                 'route' => [
                                     'name' => 'texts'
+                                ]
+                            ],
+                            [
+                                'label' => _T("Labels translation"),
+                                'title' => _T("Manage translatable labels"),
+                                'route' => [
+                                    'name' => 'dynamicTranslations',
+                                    'aliases' => ['dynamicTranslation']
                                 ]
                             ]
                         ]

--- a/galette/lib/Galette/Entity/ContributionsTypes.php
+++ b/galette/lib/Galette/Entity/ContributionsTypes.php
@@ -288,7 +288,8 @@ class ContributionsTypes
             } else {
                 foreach ($results as $r) {
                     $list[$r->{self::PK}] = array(
-                        'name'  => _T($r->libelle_type_cotis),
+                        'text_orig' => $r->libelle_type_cotis,
+                        'name' => _T($r->libelle_type_cotis),
                         'amount' => $r->amount,
                         'extra' => $r->cotis_extension
                     );

--- a/galette/lib/Galette/Entity/Status.php
+++ b/galette/lib/Galette/Entity/Status.php
@@ -247,7 +247,8 @@ class Status
             } else {
                 foreach ($results as $r) {
                     $list[$r->{self::PK}] = array(
-                        'name'  => _T($r->libelle_statut),
+                        'text_orig' => $r->libelle_statut,
+                        'name' => _T($r->libelle_statut),
                         'extra' => $r->priorite_statut
                     );
                 }

--- a/galette/templates/default/components/forms/payment_types.html.twig
+++ b/galette/templates/default/components/forms/payment_types.html.twig
@@ -25,7 +25,7 @@
         id="{{ varname }}"
         {% if required is defined and required == true %} required="required"{% endif %}
         {% if disabled is defined and disabled == true %} disabled="disabled"{% endif %}
-        class="ui search dropdown"
+        class="ui{% if compact is defined and compact == true %} compact{% endif %} search dropdown"
     >
 {% if empty is defined %}
         <option value="{{ empty.value }}">{{ empty.label }}</option>

--- a/galette/templates/default/elements/ajax_groups.html.twig
+++ b/galette/templates/default/elements/ajax_groups.html.twig
@@ -23,21 +23,21 @@
         <table id="listing" class="select_members ui celled striped table">
             <thead>
                 <tr>
-                    <th class="listing id_row">#</th>
+                    <th class="listing id_row collapsing">#</th>
                     <th class="listing left">
                         {{ _T("Name") }}
                     </th>
                     <th class="listing left">
                         {{ _T("Manager(s)") }}
                     </th>
-                    <th class="listing"></th>
+                    <th class="listing collapsing"></th>
                 </tr>
             </thead>
             <tbody>
 {% for group in groups_list %}
     {% set managers = group.getManagers() %}
                 <tr>
-                    <td class="right">{{ group.getId() }}</td>
+                    <td class="right collapsing">{{ group.getId() }}</td>
                     <td class="username_row">
                         <a href="{{ url_for('groups', {'id': group.getId()}) }}">{{ group.getName() }}</a>
                     </td>
@@ -47,7 +47,7 @@
                         {{ manager.sname }}
     {% endfor %}
                     </td>
-                    <td class="right">{{ _T("%membercount members")|replace({'%membercount': group.getMemberCount(true)}) }}</td>
+                    <td class="right collapsing">{{ _T("%membercount members")|replace({'%membercount': group.getMemberCount(true)}) }}</td>
                 </tr>
 {% else %}
                 <tr><td colspan="3" class="emptylist">{{ _T("no group") }}</td></tr>

--- a/galette/templates/default/elements/ajax_members.html.twig
+++ b/galette/templates/default/elements/ajax_members.html.twig
@@ -23,7 +23,7 @@
         <table id="listing" class="listing select_members{% if not multiple %} single{% endif %} ui celled table">
             <thead>
                 <tr>
-                    <th class="listing id_row">#</th>
+                    <th class="listing id_row collapsing">#</th>
                     <th class="listing left">
                         {{ _T("Name") }}
                     </th>
@@ -36,7 +36,7 @@
 {% for member in members_list %}
     {% if excluded is not defined or excluded != member.id %}
                 <tr class="{{ member.getRowClass() }}">
-                    <td class="right">{{ member.id }}</td>
+                    <td class="right collapsing">{{ member.id }}</td>
                     <td class="username_row">
                     {% if member.isCompany() %}
                         <span>

--- a/galette/templates/default/elements/display_dynamic_fields.html.twig
+++ b/galette/templates/default/elements/display_dynamic_fields.html.twig
@@ -26,7 +26,7 @@
             {{ _T("Additionnal fields:") }}
         </div>
         <div class="active content field">
-            <table class="ui very basic striped stackable padded table">
+            <table class="ui very basic definition striped stackable padded table">
                 {% for field in object.getDynamicFields().getFields() %}
                     {% if get_class(field) == 'Galette\\DynamicFields\\Separator' %}
                 <tr>

--- a/galette/templates/default/elements/display_socials.html.twig
+++ b/galette/templates/default/elements/display_socials.html.twig
@@ -26,10 +26,10 @@
             {{ _T("Social networks") }}
         </div>
         <div class="active content field">
-            <table class="ui very basic striped collapsing stackable padded table">
+            <table class="ui very basic definition striped stackable padded table">
     {% for social in socials %}
             <tr>
-                <th>{{ social.getSystemType(social.type) }}</th>
+                <th class="three wide column">{{ social.getSystemType(social.type) }}</th>
                 <td>{{ social.displayUrl()|raw }}</td>
             </tr>
     {% endfor %}

--- a/galette/templates/default/elements/edit_core_fields.html.twig
+++ b/galette/templates/default/elements/edit_core_fields.html.twig
@@ -22,12 +22,12 @@
         <table class="listing ui celled striped table">
             <thead>
                 <tr>
-                    <th class="id_row">#</th>
+                    <th class="id_row collapsing">#</th>
                     <th>{{ _T("Name") }}</th>
                     <th>{{ _T("Permissions") }}</th>
-                    <th class="date_row">{{ _T("Required") }}</th>
+                    <th class="date_row{% if preferences.pref_member_form_grid == 'one' %} collapsing{% endif %}">{{ _T("Required") }}</th>
 {% if preferences.pref_member_form_grid != 'one' %}
-                    <th class="date_row">{{ _T("Width in forms") }}</th>
+                    <th class="date_row collapsing">{{ _T("Width in forms") }}</th>
 {% endif %}
                 </tr>
             </thead>
@@ -55,7 +55,7 @@
                             </select>
                         </span>
                     </td>
-                    <td class="required_cell" data-col-label="{{ _T("Required") }}">
+                    <td class="required_cell{% if preferences.pref_member_form_grid == 'one' %} collapsing{% endif %}" data-col-label="{{ _T("Required") }}">
                         <span data-prop-label="{{ _T("Required") }}" class="required" title="{% if fid in non_required %}{{ _T("Field '%field' cannot be set as required.")|replace({'%field': field.label}) }}{% else %}{{ _T("Mark '%field' as (not) required")|replace({'%field': field.label}) }}{% endif %}">
                             <div class="inline fields">
                                 <div class="field inline">
@@ -74,7 +74,7 @@
                         </span>
                     </td>
         {% if preferences.pref_member_form_grid != 'one' %}
-                    <td class="left" data-col-label="{{ _T("Width in forms") }}">
+                    <td class="left collapsing" data-col-label="{{ _T("Width in forms") }}">
                         <span data-prop-label="{{ _T("Width in forms") }}" title="{{ _T("Change field's width with in forms") }}">
                             <select name="{{ fid }}_width_in_forms" id="{{ fid }}_width_in_forms" class="ui dropdown">
                                 <option value="1"{% if field.width_in_forms == 1 or (preferences.pref_member_form_grid == 'two' and field.width_in_forms == 3) %} selected="selected"{% endif %}>{{ _T("Default") }}</option>

--- a/galette/templates/default/elements/edit_dynamic_fields.html.twig
+++ b/galette/templates/default/elements/edit_dynamic_fields.html.twig
@@ -31,31 +31,31 @@
         <table class="listing ui celled striped table">
             <thead>
                 <tr>
-                    <th class="id_row">#</th>
+                    <th class="id_row collapsing">#</th>
                     <th>{{ _T("Name") }}</th>
                     <th>{{ _T("Permissions") }}</th>
                     <th class="date_row">{{ _T("Type") }}</th>
-                    <th class="date_row">{{ _T("Required") }}</th>
+                    <th class="date_row{% if preferences.pref_member_form_grid == 'one' %} collapsing{% endif %}">{{ _T("Required") }}</th>
 {% if preferences.pref_member_form_grid != 'one' %}
-                    <th class="date_row">{{ _T("Width in forms") }}</th>
+                    <th class="date_row collapsing">{{ _T("Width in forms") }}</th>
 {% endif %}
-                    <th>{{ _T("Actions") }}</th>
+                    <th class="collapsing">{{ _T("Actions") }}</th>
                 </tr>
             </thead>
             <tbody>
 {% for field in fields_list %}
                 <tr>
-                    <td data-scope="id" class="collapsing">{{ field.getIndex() }}</td>
+                    <td class="collapsing" data-scope="id">{{ field.getIndex() }}</td>
                     <td class="left" data-scope="row">{{ field.getName()|escape }}</td>
                     <td class="left" data-col-label="{{ _T("Permissions") }}">{{ field.getPermissionName() }}</td>
                     <td class="left" data-col-label="{{ _T("Type") }}">{{ field.getTypeName() }}</td>
-                    <td data-col-label="{{ _T("Required") }}">
+                    <td{% if preferences.pref_member_form_grid == 'one' %} class="collapsing"{% endif %} data-col-label="{{ _T("Required") }}">
     {% if field.getType != 0 %}
         {% if field.isRequired() %}{{ _T("Yes") }}{% else %}{{ _T("No") }}{% endif %}
     {% endif %}
                     </td>
     {% if preferences.pref_member_form_grid != 'one' %}
-                    <td class="left" data-col-label="{{ _T("Width in forms") }}">
+                    <td class="left collapsing" data-col-label="{{ _T("Width in forms") }}">
         {% if preferences.pref_member_form_grid == 'three' and field.getWidthInForms() == 3  %}
                         {{ _T("Half") }}
         {% elseif field.getWidthInForms() == 2 %}
@@ -65,7 +65,7 @@
         {% endif %}
                     </td>
     {% endif %}
-                    <td class="center actions_row">
+                    <td class="center actions_row collapsing">
                         <a
                             href="{{ url_for('editDynamicField', {'form_name': form_name, 'id': field.getId()}) }}"
                             class="action single-edit"

--- a/galette/templates/default/elements/list.html.twig
+++ b/galette/templates/default/elements/list.html.twig
@@ -80,7 +80,7 @@
                             <tr>
                         {% block header %}
                             {% for column in columns %}
-                                <th class="left">
+                                <th class="left{% if column.collapse is defined %} collapsing{% endif %}">
                                     {% if form is defined and column.order is defined %}
                                     <a href="{{ url_for(form.order.name, form.order.args|default([])|merge({"option": "order", "value": column.order})) }}">
                                         {{ column.label }}
@@ -98,7 +98,7 @@
                                 </th>
                             {% endfor %}
                             {% if mode != 'ajax' and (no_action is not defined or no_action == false) %}
-                                <th class="actions_row">{{ _T('Actions') }}</th>
+                                <th class="actions_row collapsing">{{ _T('Actions') }}</th>
                             {% endif %}
                         {% endblock %}
                             </tr>

--- a/galette/templates/default/pages/configuration_core_lists.html.twig
+++ b/galette/templates/default/pages/configuration_core_lists.html.twig
@@ -31,15 +31,15 @@
             <table id="listed_fields_table" class="listing ui celled striped table">
                 <thead>
                     <tr>
-                        <th class="id_row">#</th>
+                        <th class="id_row collapsing">#</th>
                         <th>{{ _T("Field name") }}</th>
                         <th>{{ _T("Permissions") }}</th>
-                        <th>{{ _T("Actions") }}</th>
+                        <th class="collapsing">{{ _T("Actions") }}</th>
                     </tr>
                 </thead>
                 <tfoot>
                     <tr>
-                        <td data-scope="row"></td>
+                        <td class="collapsing" data-scope="row"></td>
                         <td class="left" data-col-label="{{ _T("Available fields") }}" colspan="2">
                             <div id="remaining_fields_dropdown" class="ui fluid search clearable selection dropdown">
                                 <i class="dropdown icon"></i>
@@ -56,7 +56,7 @@
     {% endfor %}
                                 </div>
                         </td>
-                        <td class="collapsing actions_row">
+                        <td class="actions_row collapsing">
                             <input type="hidden" name="new" value="1" />
                             <a href="#" id="addfield" class="ui labeled icon button">
                                 <i class="plus green icon" aria-hidden="true"></i>
@@ -70,7 +70,7 @@
         {% set fid = field.field_id %}
         {% set permission = permissions[field.visible] %}
                     <tr data-fid="{{ fid }}" data-label="{{ field.label }}" data-permission="{{ permission }}">
-                        <td data-scope="row" class="collapsing">
+                        <td class="collapsing" data-scope="row">
                             <i class="arrows alternate icon" aria-hidden="true"></i>
                         </td>
                         <td class="left" data-col-label="{{ _T("Field name") }}">
@@ -80,7 +80,7 @@
                         <td class="left" data-col-label="{{ _T("Permissions") }}">
                             {{ permission }}
                         </td>
-                        <td class="center actions_row">
+                        <td class="center actions_row collapsing">
                             <a href="#" class="delete">
                                 <i class="ui trash red icon tooltip" aria-hidden="true"></i>
                                 <span class="ui special popup">{{ _T("Delete '%s' field")|replace({'%s': field.label}) }}</span>

--- a/galette/templates/default/pages/configuration_dynamic_translations.html.twig
+++ b/galette/templates/default/pages/configuration_dynamic_translations.html.twig
@@ -32,13 +32,12 @@
                 <input type="hidden" name="new" value="true"/>
             </div>
     {% endif %}
-
-            <div class="ui top attached accordion-styled header">
     {% if exists and mode != 'ajax' %}
-                {{ _T("Original text:") }}
-                <div id="label-selection" class="ui basic labeled icon dropdown button tooltip" title="{{ _T("Choose label to translate") }}">
+            <div class="ui basic fitted segment">
+                <strong>{{ _T("Original text:") }}</strong>
+                <div id="label-selection" class="ui right labeled basic icon dropdown button tooltip" title="{{ _T("Choose label to translate") }}">
                     <input type="hidden" name="filters">
-                    <i class="language icon"></i>
+                    <i class="dropdown icon"></i>
                     <span class="text">{{ text_orig }}</span>
                     <div class="menu">
                         <div class="ui icon search input">
@@ -52,25 +51,21 @@
                         </div>
                     </div>
                 </div>
+            </div>
     {% else %}
-                {{ _T("Original text:") }} {{ text_orig }}
+            <strong>{{ _T("Original text:") }} {{ text_orig }}</strong>
     {% endif %}
-            </div>
-            <div class="ui bottom attached accordion-styled segment">
-                <div class="active content field">
-                    <table class="ui striped table">
+            <table class="ui striped definition table">
     {% for k, text in trans %}
-                        <tr>
-                            <td class="three wide"><label for="text_trans_{{ text.key }}">{{ text.name }}</label></td>
-                            <td class="thirteen wide">
-                                <input type="text" name="text_trans_{{ text.key }}" id="text_trans_{{ text.key }}" value="{% if text.text %}{{ text.text|escape }}{% endif %}"/>
-                            </td>
-                        </tr>
+                <tr>
+                    <th class="collapsing"><label for="text_trans_{{ text.key }}">{{ text.name }}</label></th>
+                    <td>
+                        <input type="text" name="text_trans_{{ text.key }}" id="text_trans_{{ text.key }}" value="{% if text.text %}{{ text.text|escape }}{% endif %}"/>
+                    </td>
+                </tr>
     {% endfor %}
-                    </table>
-                    <input type=hidden name="text_orig" value="{{ text_orig|escape }}"/>
-                </div>
-            </div>
+            </table>
+            <input type=hidden name="text_orig" value="{{ text_orig|escape }}"/>
     {% if mode != 'ajax' %}
             <div class="ui basic center aligned segment">
                 <button type="submit" name="trans" class="ui labeled icon primary button action">

--- a/galette/templates/default/pages/configuration_payment_types.html.twig
+++ b/galette/templates/default/pages/configuration_payment_types.html.twig
@@ -26,14 +26,14 @@
                 <table class="listing ui celled striped table">
                     <thead>
                         <tr>
-                            <th class="id_row">#</th>
+                            <th class="id_row collapsing">#</th>
                             <th>{{ _T("Name") }}</th>
-                            <th>{{ _T("Actions") }}</th>
+                            <th class="collapsing">{{ _T("Actions") }}</th>
                         </tr>
                     </thead>
                     <tfoot>
                         <tr>
-                            <td data-scope="row">
+                            <td class="collapsing" data-scope="row">
                                 <span class="visually-hidden">
                                     {{ _T("Add payment type") }}
                                 </span>
@@ -44,7 +44,7 @@
                                     <input size="20" type="text" name="name" required="required"/>
                                 </div>
                             </td>
-                            <td class="center actions_row">
+                            <td class="center actions_row collapsing">
                                 <input type="hidden" name="new" value="1" />
                                 <button type="submit" name="valid" class="ui labeled icon button">
                                     <i class="plus green icon" aria-disabled="true"></i>
@@ -56,7 +56,7 @@
                     <tbody>
             {% for ptype in list %}
                         <tr>
-                            <td data-scope="id" class="collapsing">
+                            <td class="collapsing" data-scope="id">
                 {% if preferences.pref_show_id %}
                                 {{ ptype.__get('id') }}
                 {% else %}
@@ -64,7 +64,7 @@
                 {% endif %}
                             </td>
                             <td class="left" data-col-label="{{ _T("Name") }}">{{ ptype.getName() }}</td>
-                            <td class="center actions_row">
+                            <td class="center actions_row collapsing">
                                 <a
                                     href="{{ url_for('editPaymentType', {'id': ptype.__get('id')}) }}"
                                     class="action single-edit"

--- a/galette/templates/default/pages/configuration_payment_types.html.twig
+++ b/galette/templates/default/pages/configuration_payment_types.html.twig
@@ -73,7 +73,7 @@
                                     <span class="ui special popup">{{ _T("Edit '%s' payment type")|replace({'%s': ptype.getName()}) }}</span>
                                 </a>
                                 <a
-                                    href="{{ url_for('dynamicTranslations', {'text_orig': ptype.getName(false)|escape}) }}"
+                                    href="{{ url_for('dynamicTranslations', {}, {'text_orig': ptype.getName(false)}) }}"
                                     class="action single-translate"
                                 >
                                     <i class="ui language grey icon tooltip" aria-hidden="true"></i>

--- a/galette/templates/default/pages/configuration_titles.html.twig
+++ b/galette/templates/default/pages/configuration_titles.html.twig
@@ -26,15 +26,15 @@
             <table class="listing ui celled striped table">
                 <thead>
                     <tr>
-                        <th class="id_row">#</th>
+                        <th class="id_row collapsing">#</th>
                         <th>{{ _T("Short form") }}</th>
                         <th>{{ _T("Long form") }}</th>
-                        <th>{{ _T("Actions") }}</th>
+                        <th class="collapsing">{{ _T("Actions") }}</th>
                     </tr>
                 </thead>
                 <tfoot>
                     <tr>
-                        <td data-scope="row">
+                        <td class="collapsing" data-scope="row">
                             <span class="visually-hidden">
                                 {{ _T("Add title") }}
                             </span>
@@ -51,7 +51,7 @@
                                 <input size="20" type="text" name="long_label" required="required"/>
                             </div>
                         </td>
-                        <td class="center actions_row">
+                        <td class="center actions_row collapsing">
                             <input type="hidden" name="new" value="1" />
                             <button type="submit" name="valid" class="ui labeled icon button">
                                 <i class="plus green icon" aria-hidden="true"></i>
@@ -63,7 +63,7 @@
                 <tbody>
         {% for title in titles_list %}
                     <tr>
-                        <td data-scope="row">
+                        <td class="collapsing" data-scope="row">
             {% if preferences.pref_show_id %}
                             {{ title.id }}
             {% else %}
@@ -72,7 +72,7 @@
                         </td>
                         <td class="left" data-col-label="{{ _T("Short form") }}">{{ title.short|escape }}</td>
                         <td class="left" data-col-label="{{ _T("Long form") }}">{{ title.long|escape }}</td>
-                        <td class="center actions_row">
+                        <td class="center actions_row collapsing">
                             <a
                                 href="{{ url_for('editTitle', {'id': title.id}) }}"
                                 class="action single-edit"

--- a/galette/templates/default/pages/contributions_list.html.twig
+++ b/galette/templates/default/pages/contributions_list.html.twig
@@ -217,10 +217,22 @@
 
 {% block header %}
     {% set columns = [
-        {'label': '#', 'order': constant("Galette\\Filters\\ContributionsList::ORDERBY_ID")},
-        {'label': _T("Date"), 'order': constant("Galette\\Filters\\ContributionsList::ORDERBY_DATE")},
-        {'label': _T("Begin"), 'order': constant("Galette\\Filters\\ContributionsList::ORDERBY_BEGIN_DATE")},
-        {'label': _T("End"), 'order': constant("Galette\\Filters\\ContributionsList::ORDERBY_END_DATE")}
+        {
+            'label': '#', 'order': constant("Galette\\Filters\\ContributionsList::ORDERBY_ID"),
+            'collapse': true
+        },
+        {
+            'label': _T("Date"), 'order': constant("Galette\\Filters\\ContributionsList::ORDERBY_DATE"),
+            'collapse': true
+        },
+        {
+            'label': _T("Begin"), 'order': constant("Galette\\Filters\\ContributionsList::ORDERBY_BEGIN_DATE"),
+            'collapse': true
+        },
+        {
+            'label': _T("End"), 'order': constant("Galette\\Filters\\ContributionsList::ORDERBY_END_DATE"),
+            'collapse': true
+        }
     ] %}
 
     {% if ((login.isAdmin() or login.isStaff()) and member is not defined) or pmember is defined %}
@@ -229,9 +241,15 @@
 
     {% set columns = columns|merge([
         {'label': _T('Type'), 'order': constant("Galette\\Filters\\ContributionsList::ORDERBY_TYPE")},
-        {'label': _T('Amount'), 'order': constant("Galette\\Filters\\ContributionsList::ORDERBY_AMOUNT")},
+        {
+            'label': _T('Amount'), 'order': constant("Galette\\Filters\\ContributionsList::ORDERBY_AMOUNT"),
+            'collapse': true
+        },
         {'label': _T("Payment type"), 'order': constant("Galette\\Filters\\ContributionsList::ORDERBY_PAYMENT_TYPE")},
-        {'label': _T("Duration")}
+        {
+            'label': _T("Duration"),
+            'collapse': true
+        }
     ]) %}
 
     {{ parent() }}
@@ -297,9 +315,9 @@
                     <i class="ui icon">&nbsp;</i>
                 {% endif %}
             </td>
-            <td data-col-label="{{ _T("Date") }}">{{ contribution.date }}</td>
-            <td data-col-label="{{ _T("Begin") }}">{{ contribution.begin_date }}</td>
-            <td data-col-label="{{ _T("End") }}">{{ contribution.end_date }}</td>
+            <td class="collapsing" data-col-label="{{ _T("Date") }}">{{ contribution.date }}</td>
+            <td class="collapsing" data-col-label="{{ _T("Begin") }}">{{ contribution.begin_date }}</td>
+            <td class="collapsing" data-col-label="{{ _T("End") }}">{{ contribution.end_date }}</td>
             {% if ((login.isAdmin() or login.isStaff()) and member is not defined) or pmember is defined %}
                 <td data-col-label="{{ _T("Member") }}">
                     {% if member is defined %}
@@ -325,9 +343,9 @@
                 </td>
             {% endif %}
             <td data-col-label="{{ _T("Type") }}">{{ contribution.type.libelle }}</td>
-            <td data-col-label="{{ _T("Amount") }}">{{ contribution.amount }}</td>
+            <td class="collapsing" data-col-label="{{ _T("Amount") }}">{{ contribution.amount }}</td>
             <td data-col-label="{{ _T("Payment type") }}">{{ contribution.getPaymentType() }}</td>
-            <td data-col-label="{{ _T("Duration") }}">{{ contribution.duration }}</td>
+            <td class="collapsing" data-col-label="{{ _T("Duration") }}">{{ contribution.duration }}</td>
             {% if mode != 'ajax' %}
                 <td class="actions_row center collapsing">
                     <a

--- a/galette/templates/default/pages/contributions_types_list.html.twig
+++ b/galette/templates/default/pages/contributions_types_list.html.twig
@@ -26,16 +26,16 @@
         <table class="listing ui celled striped table">
             <thead>
                 <tr>
-                    <th class="id_row">#</th>
+                    <th class="id_row collapsing">#</th>
                     <th>{{ _T("Name") }}</th>
                     <th>{{ _T('Amount') }}</th>
                     <th>{{ _T("Membership extension") }}</th>
-                    <th>{{ _T("Actions") }}</th>
+                    <th class="collapsing">{{ _T("Actions") }}</th>
                 </tr>
             </thead>
             <tfoot>
                 <tr>
-                    <td data-scope="row">
+                    <td data-scope="row collapsing">
                         <span class="visually-hidden">
                             {{ _T("New contribution type") }}
                         </span>
@@ -68,7 +68,7 @@
                             nolabel: true
                         } %}
                     </td>
-                    <td class="center actions_row">
+                    <td class="center actions_row collapsing">
                         <input type="hidden" name="new" value="1" />
                         <button type="submit" name="valid" class="ui labeled icon button">
                             <i class="plus green icon" aria-hidden="true"></i>
@@ -80,7 +80,7 @@
             <tbody>
 {% for eid, entry in entries %}
                 <tr>
-                    <td data-scope="id" class="collapsing">
+                    <td class="collapsing" data-scope="id">
                         {{ eid }}
                     </td>
                     <td class="left" data-col-label="{{ _T("Name") }}">
@@ -98,7 +98,7 @@
                         {{ _Tn('%1$s month', '%1$s months', entry.extra)|format(entry.extra) }}
     {% endif %}
                     </td>
-                    <td class="center actions_row">
+                    <td class="center actions_row collapsing">
                         <a
                             href="{{ url_for('editContributionType', {'id': eid}) }}"
                             class="action single-edit"

--- a/galette/templates/default/pages/contributions_types_list.html.twig
+++ b/galette/templates/default/pages/contributions_types_list.html.twig
@@ -104,14 +104,21 @@
                             class="action single-edit"
                         >
                             <i class="ui edit icon tooltip" aria-hidden="true"></i>
-                            <span class="ui special popup">{{ _T("Edit '%s' field")|replace({'%s': entry.name|escape}) }}</span>
+                            <span class="ui special popup">{{ _T("Edit '%s' field")|replace({'%s': entry.name}) }}</span>
+                        </a>
+                        <a
+                            href="{{ url_for('dynamicTranslations', {}, {'text_orig': entry.text_orig}) }}"
+                            class="action single-translate"
+                        >
+                            <i class="ui language grey icon tooltip" aria-hidden="true"></i>
+                            <span class="ui special popup">{{ _T("Translate '%s'")|replace({'%s': entry.name}) }}</span>
                         </a>
                         <a
                             href="{{ url_for('removeContributionType', {'id': eid}) }}"
                             class="delete"
                         >
                             <i class="ui trash red icon tooltip" aria-hidden="true"></i>
-                            <span class="ui special popup">{{ _T("Delete '%s' field")|replace({'%s': entry.name|escape}) }}</span>
+                            <span class="ui special popup">{{ _T("Delete '%s' field")|replace({'%s': entry.name}) }}</span>
                         </a>
                     </td>
                 </tr>
@@ -134,6 +141,44 @@
                 selector: ".single-edit",
                 modal_title_twig: _T("Edit contribution type")|e("js"),
                 modal_class: "mini",
+                modal_onapprove: modal_onapprove
+            } %}
+
+            {% set extra_success = "
+                $('.modal-form form').on('submit', function(event) {
+                    event.preventDefault();
+                    var _form = $(this);
+                    var _data = _form.serialize();
+                    $.ajax({
+                        url: _form.attr('action'),
+                        type: 'POST',
+                        datatype: 'json',
+                        data: _data,
+                        error: function() {
+                            $.modal({
+                                title: '%error%',
+                                class: 'mini',
+                                actions: [{
+                                    text: '%close%',
+                                    icon: 'times',
+                                    class: 'icon labeled cancel'
+                                }],
+                                className: {
+                                    modal: 'ui redalert modal',
+                                    title: 'center aligned header',
+                                    content: 'center aligned content',
+                                    actions: 'center aligned actions'
+                                }
+                            }).modal('show');
+                        }
+                    });
+                });
+            " %}
+            {% include "elements/js/modal_action.js.twig" with {
+                selector: ".single-translate",
+                extra_success: extra_success|replace({'%error%': _T("An error occurred :(")|e("js"), '%close%': _T("Close")|e("js")}),
+                modal_title_twig: _T("Translate labels")|e("js"),
+                modal_content_class: "scrolling",
                 modal_onapprove: modal_onapprove
             } %}
 

--- a/galette/templates/default/pages/documents_list.html.twig
+++ b/galette/templates/default/pages/documents_list.html.twig
@@ -47,11 +47,17 @@
 
 {% block header %}
     {% set columns = [
-        {'label': '#'},
+        {
+            'label': '#',
+            'collapse': true
+        },
         {'label': _T("Filename")},
         {'label': _T('Type')},
         {'label': _T('Visibility')},
-        {'label': _T("Creation date")}
+        {
+            'label': _T("Creation date"),
+            'collapse': true
+        }
     ] %}
 
     {{ parent() }}
@@ -60,7 +66,7 @@
 {% block body %}
     {% for document in documents %}
         <tr class="" id="row_{{ document.id }}">
-            <td data-scope="id" class="collapsing">
+            <td class="collapsing" data-scope="id">
                 {% if preferences.pref_show_id %}
                     {{ document.id }}
                 {% else %}
@@ -74,9 +80,9 @@
             </td>
             <td data-col-label="{{ _T("Type") }}">{{ _T(document.getType()) }}</td>
             <td data-col-label="{{ _T("Visibility") }}">{{ document.getPermissionName() }}</td>
-            <td data-col-label="{{ _T("Creation date") }}">{{ document.getCreationDate() }}</td>
+            <td class="collapsing" data-col-label="{{ _T("Creation date") }}">{{ document.getCreationDate() }}</td>
             {% if mode != 'ajax' %}
-                <td class="actions_row center">
+                <td class="actions_row center collapsing">
                     {% if (login.isAdmin() or login.isStaff()) %}
                         <a
                                 href="{{ url_for("editDocument", {"id": document.getID()}) }}"

--- a/galette/templates/default/pages/export.html.twig
+++ b/galette/templates/default/pages/export.html.twig
@@ -57,26 +57,26 @@
                         <table class="listing ui celled striped table">
                             <thead>
                                 <tr>
-                                    <th class="id_row">#</th>
+                                    <th class="id_row collapsing">#</th>
                                     <th>{{ _T('Name') }}</th>
-                                    <th>{{ _T('Date') }}</th>
-                                    <th>{{ _T('Size') }}</th>
-                                    <th class="actions_row"></th>
+                                    <th class="collapsing">{{ _T('Date') }}</th>
+                                    <th class="collapsing">{{ _T('Size') }}</th>
+                                    <th class="actions_row collapsing">{{ _T('Actions') }}</th>
                                 </tr>
                             </thead>
                             <tbody>
         {% for export in existing %}
                                 <tr>
-                                    <td data-scope="id" class="collapsing">
+                                    <td class="collapsing" data-scope="id">
                                         {{ loop.index }}
                                     </td>
                                     <td data-scope="row">
                                         <a href="{{ url_for("getCsv", {"type": "export", "file": export.name}) }}">{{ export.name }}</a>
                                     </td>
-                                    <td data-col-label="{{ _T('Date') }}">
+                                    <td class="collapsing" data-col-label="{{ _T('Date') }}">
                                         {{ export.date }}
                                     </td>
-                                    <td data-col-label="{{ _T('Size') }}">
+                                    <td class="collapsing" data-col-label="{{ _T('Size') }}">
                                         {{ export.size }}
                                     </td>
                                     <td class="actions_row collapsing">
@@ -108,7 +108,7 @@
                         <table class="ui celled striped table">
                             <thead>
                                 <tr>
-                                    <th class="small_head"/>
+                                    <th class="small_head collapsing"/>
                                     <th>{{ _T('Name') }}</th>
                                     <th>{{ _T('Description') }}</th>
                                 </tr>
@@ -148,7 +148,7 @@
                         <table class="same ui celled striped table">
                             <thead>
                                 <tr>
-                                    <th class="small_head"/>
+                                    <th class="small_head collapsing"/>
                                     <th>{{ _T('Table name') }}</th>
                                 </tr>
                             </thead>

--- a/galette/templates/default/pages/history.html.twig
+++ b/galette/templates/default/pages/history.html.twig
@@ -135,7 +135,7 @@
 
 {% block body %}
     {% for log in logs %}
-        <tr class="{% if loop.index % 2 == 0 %}even{% else %}odd{% endif %}">
+        <tr>
             <td class="collapsing" data-scope="row">
                 {{ loop.index }}
                 <span class="visually-hidden">

--- a/galette/templates/default/pages/history.html.twig
+++ b/galette/templates/default/pages/history.html.twig
@@ -53,8 +53,14 @@
 
 {% block header %}
     {% set columns = [
-        {'label': '#'},
-        {'label': _T("Date"), 'order': constant("Galette\\Filters\\HistoryList::ORDERBY_DATE")},
+        {
+            'label': '#',
+            'collapse': true
+        },
+        {
+            'label': _T("Date"), 'order': constant("Galette\\Filters\\HistoryList::ORDERBY_DATE"),
+            'collapse': true
+        },
         {'label': _T("IP"), 'order': constant("Galette\\Filters\\HistoryList::ORDERBY_IP")},
         {'label': _T("User"), 'order': constant("Galette\\Filters\\HistoryList::ORDERBY_USER")},
         {'label': _T('Action'), 'order': constant("Galette\\Filters\\HistoryList::ORDERBY_ACTION")},
@@ -130,13 +136,13 @@
 {% block body %}
     {% for log in logs %}
         <tr class="{% if loop.index % 2 == 0 %}even{% else %}odd{% endif %}">
-            <td data-scope="row">
+            <td class="collapsing" data-scope="row">
                 {{ loop.index }}
                 <span class="visually-hidden">
                         {{ _T("History entry %id")|replace({"%id": loop.index}) }}
                     </span>
             </td>
-            <td data-col-label="{{ _T("Date") }}">{{ log.date_log|date(_T("Y-m-d H:i:s")) }}</td>
+            <td class="collapsing" data-col-label="{{ _T("Date") }}">{{ log.date_log|date(_T("Y-m-d H:i:s")) }}</td>
             <td data-col-label="{{ _T("IP") }}">{{ log.ip_log }}</td>
             <td data-col-label="{{ _T("User") }}">{{ log.adh_log }}</td>
             <td data-col-label="{{ _T("Action") }}">{{ log.action_log|escape }}</td>

--- a/galette/templates/default/pages/import.html.twig
+++ b/galette/templates/default/pages/import.html.twig
@@ -40,26 +40,29 @@
                             <table class="listing ui celled striped table">
                                 <thead>
                                     <tr>
+                                        <th class="small_head collapsing"></th>
                                         <th>{{ _T('Name') }}</th>
-                                        <th>{{ _T('Date') }}</th>
-                                        <th>{{ _T('Size') }}</th>
-                                        <th class="actions_row">{{ _T('Actions') }}</th>
+                                        <th class="collapsing">{{ _T('Date') }}</th>
+                                        <th class="collapsing">{{ _T('Size') }}</th>
+                                        <th class="actions_row collapsing">{{ _T('Actions') }}</th>
                                     </tr>
                                 </thead>
                                 <tbody>
     {% for import in existing %}
                                     <tr>
-                                        <td data-scope="row">
+                                        <td class="collapsing" data-scope="id">
                                             <span class="ui radio checkbox">
                                                 <input type="radio" name="import_file" id="file{{ loop.index }}" value="{{ import.name }}"{% if import_file is defined and import_file == import.name %} checked="checked"{% endif %}/>
-                                                <label for="file{{ loop.index }}">{{ import.name }}</label>
                                             </span>
+                                        </td>
+                                        <td data-scope="row">
+                                            <label for="file{{ loop.index }}">{{ import.name }}</label>
                                             (<a href="{{ url_for("getCsv", {"type": "import", "file": import.name}) }}">{{ _T('see') }}</a>)
                                         </td>
-                                        <td data-col-label="{{ _T('Date') }}">
+                                        <td class="collapsing" data-col-label="{{ _T('Date') }}">
                                             {{ import.date }}
                                         </td>
-                                        <td data-col-label="{{ _T('Size') }}">
+                                        <td class="collapsing" data-col-label="{{ _T('Size') }}">
                                             {{ import.size }}
                                         </td>
                                         <td class="actions_row collapsing">

--- a/galette/templates/default/pages/import_model.html.twig
+++ b/galette/templates/default/pages/import_model.html.twig
@@ -75,7 +75,7 @@
         <table class="listing ui celled striped table">
             <thead>
                 <tr>
-                    <th></th>
+                    <th class="collapsing"></th>
                     <th>{{ _T('Field') }}</th>
                 </tr>
             </thead>

--- a/galette/templates/default/pages/mailings_list.html.twig
+++ b/galette/templates/default/pages/mailings_list.html.twig
@@ -62,13 +62,28 @@
 
 {% block header %}
     {% set columns = [
-        {'label': '#'},
-        {'label': _T("Date"), 'order': constant("Galette\\Filters\\MailingsList::ORDERBY_DATE")},
+        {
+            'label': '#',
+            'collapse': true
+        },
+        {
+            'label': _T("Date"), 'order': constant("Galette\\Filters\\MailingsList::ORDERBY_DATE"),
+            'collapse': true
+        },
         {'label': _T('Sender'), 'order': constant("Galette\\Filters\\MailingsList::ORDERBY_SENDER")},
-        {'label': _T('Recipients')},
+        {
+            'label': _T('Recipients'),
+            'collapse': true
+        },
         {'label': _T('Subject'), 'order': constant("Galette\\Filters\\MailingsList::ORDERBY_SUBJECT")},
-        {'label': _T('Att.')},
-        {'label': _T("Sent"), 'order': constant("Galette\\Filters\\MailingsList::ORDERBY_SENT")}
+        {
+            'label': _T('Att.'),
+            'collapse': true
+        },
+        {
+            'label': _T("Sent"), 'order': constant("Galette\\Filters\\MailingsList::ORDERBY_SENT"),
+            'collapse': true
+        }
     ] %}
     {{ parent() }}
 {% endblock %}
@@ -144,7 +159,7 @@
     {% for log in logs %}
         {% set date_format = _T('Y-m-d H:i:s') %}
         <tr>
-            <td data-scope="row">
+            <td class="collapsing" data-scope="row">
                 {% if preferences.pref_show_id %}
                     {{ log.mailing_id }}
                 {% else %}
@@ -154,19 +169,19 @@
                             {{ _T('Mailing entry %id')|replace({'%id': log.mailing_id}) }}
                         </span>
             </td>
-            <td data-col-label="{{ _T('Date') }}">{{ log.mailing_date|date(date_format) }}</td>
+            <td class="collapsing" data-col-label="{{ _T('Date') }}">{{ log.mailing_date|date(date_format) }}</td>
             <td data-col-label="{{ _T('Sender') }}">{% if log.mailing_sender == 0 %}{{ _T('Superadmin') }}{% else %}{{ log.mailing_sender_name }}{% endif %}</td>
-            <td data-col-label="{{ _T('Recipients') }}">{{ log.mailing_recipients|length }}</td>
+            <td class="collapsing" data-col-label="{{ _T('Recipients') }}">{{ log.mailing_recipients|length }}</td>
             <td data-col-label="{{ _T('Subject') }}">{{ log.mailing_subject }}</td>
-            <td class="center" data-col-label="{{ _T('Attachments') }}">{{ log.attachments }}</td>
-            <td class="center{% if log.mailing_sent == 1 %} use{% endif %}" data-col-label="{{ _T('Sent') }}">
+            <td class="center collapsing" data-col-label="{{ _T('Attachments') }}">{{ log.attachments }}</td>
+            <td class="center collapsing{% if log.mailing_sent == 1 %} use{% endif %}" data-col-label="{{ _T('Sent') }}">
                 {% if log.mailing_sent == 1 %}
                     <i class="ui thumbs up green icon" aria-hidden="true"></i>
                 {% else %}
                     <i class="ui thumbs down red icon" aria-hidden="true"></i>
                 {% endif %}
             </td>
-            <td class="center actions_row">
+            <td class="center actions_row collapsing">
                 <a
                         href="{{ url_for("mailingPreview", {"id": log.mailing_id}) }}"
                         class="showdetails"

--- a/galette/templates/default/pages/member_show.html.twig
+++ b/galette/templates/default/pages/member_show.html.twig
@@ -130,7 +130,7 @@
                             {{ _T("Family") }}
                         </div>
                         <div class="active content field">
-                            <table class="ui very basic striped collapsing stackable padded table">
+                            <table class="ui very basic definition striped collapsing stackable padded table">
                 {% if member.hasParent() %}
                                 <tr>
                                     <th>{{ _T("Attached to:") }}</th>
@@ -166,7 +166,7 @@
                         {{ _T(display_element.label) }}
                     </div>
                     <div class="active content field">
-                        <table class="ui very basic striped stackable padded table">
+                        <table class="ui very basic definition striped stackable padded table">
     {% for element in elements %}
                 {% if element.field_id == 'parent_id' %}
                     {continue}

--- a/galette/templates/default/pages/members_list.html.twig
+++ b/galette/templates/default/pages/members_list.html.twig
@@ -74,14 +74,26 @@
                 {% set columns = columns|merge([
                     {
                         label: _T('Mbr id'),
-                        order: constant("Galette\\Repository\\Members::ORDERBY_ID")
+                        order: constant("Galette\\Repository\\Members::ORDERBY_ID"),
+                        collapse: true
                     }
                 ]) %}
             {% else %}
                 {% set columns = columns|merge([
-                    {label: '#'}
+                    {
+                        label: '#',
+                        collapse: true
+                    }
                 ]) %}
             {% endif %}
+        {% elseif column.field_id starts with 'date_' %}
+            {% set columns = columns|merge([
+                {
+                    label: column.label,
+                    order: column.field_id,
+                    collapse: true
+                }
+            ]) %}
         {% else %}
             {% set columns = columns|merge([
                 {
@@ -321,7 +333,7 @@
                     <tr class="{{ member.getRowClass() }}">
     {% for column in galette_list %}
         {% if column.field_id == 'id_adh' %}
-                        <td class="right" data-scope="id">
+                        <td class="right collapsing" data-scope="id">
             {% if preferences.pref_show_id %}
                         {{ member.id }}
             {% else %}
@@ -435,7 +447,7 @@
                 {% set value = value|e('html') %}
             {% endif %}
 
-                        <td data-col-label="{{ column.label }}">
+                        <td{% if column.field_id starts with 'date_' %} class="collapsing"{% endif %} data-col-label="{{ column.label }}">
             {# Display column.
                 A check is done here to adapt display, this is may not the best way to go
                 but for now, that works as expected.

--- a/galette/templates/default/pages/plugins.html.twig
+++ b/galette/templates/default/pages/plugins.html.twig
@@ -28,9 +28,9 @@
                 <th class="listing">{{ _T('Name') }}</th>
                 <th class="listing">{{ _T('Description') }}</th>
                 <th class="listing">{{ _T('Author') }}</th>
-                <th class="listing">{{ _T('Version') }}</th>
-                <th class="listing">{{ _T('Release date') }}</th>
-                <th class="listing actions_row"></th>
+                <th class="listing collapsing">{{ _T('Version') }}</th>
+                <th class="listing collapsing">{{ _T('Release date') }}</th>
+                <th class="listing actions_row collapsing"></th>
             </tr>
         </thead>
         <tbody>
@@ -42,9 +42,9 @@
                 <td data-scope="row"><a href="{{ url_for(plugin.route ~ "Info", {"plugin": name}) }}" class="info-plugin">{{ plugin.name }} ({{ name }})</a></td>
                 <td data-col-label="{{ _T('Description') }}">{{ plugin.desc }}</td>
                 <td data-col-label="{{ _T('Author') }}">{{ plugin.author }}</td>
-                <td data-col-label="{{ _T('Version') }}">{{ plugin.version }}</td>
-                <td data-col-label="{{ _T('Release date') }}">{{ plugin.date }}</td>
-                <td class="actions_row">
+                <td class="collapsing" data-col-label="{{ _T('Version') }}">{{ plugin.version }}</td>
+                <td class="collapsing" data-col-label="{{ _T('Release date') }}">{{ plugin.date }}</td>
+                <td class="actions_row collapsing">
                     <a
                         href="{{ url_for("pluginsActivation", {"action": "deactivate", "module_id": name}) }}"
                         class="toggleActivation use"
@@ -78,7 +78,7 @@
             <tr>
                 <th class="listing">{{ _T('Name') }}</th>
                 <th class="listing" colspan="4">{{ _T('Cause') }}</th>
-                <th class="listing actions_row"></th>
+                <th class="listing actions_row collapsing"></th>
             </tr>
             </thead>
 {% for name, plugin in plugins_disabled_list %}

--- a/galette/templates/default/pages/plugins.html.twig
+++ b/galette/templates/default/pages/plugins.html.twig
@@ -38,7 +38,7 @@
                 <th colspan="6" class="center aligned"><strong>{{ _T('Active plugins') }}</strong></th>
             </tr>
 {% for name, plugin in plugins_list %}
-            <tr class="{% if loop.index0 % 2 == 0 %}even{% else %}odd{% endif %}">
+            <tr>
                 <td data-scope="row"><a href="{{ url_for(plugin.route ~ "Info", {"plugin": name}) }}" class="info-plugin">{{ plugin.name }} ({{ name }})</a></td>
                 <td data-col-label="{{ _T('Description') }}">{{ plugin.desc }}</td>
                 <td data-col-label="{{ _T('Author') }}">{{ plugin.author }}</td>

--- a/galette/templates/default/pages/preferences.html.twig
+++ b/galette/templates/default/pages/preferences.html.twig
@@ -51,8 +51,8 @@
                         <div class="ui action input">
                             <input type="text" name="pref_slogan" id="pref_slogan" value="{{ pref.pref_slogan }}"/>
                             <a
-                                href="{{ url_for("dynamicTranslations", {"text_orig": pref.pref_slogan|escape}) }}"
-                                class="tooltip ui icon button"
+                                href="{{ url_for("dynamicTranslations", {}, {"text_orig": pref.pref_slogan}) }}"
+                                class="tooltip ui icon button{% if pref.pref_slogan is empty %} disabled{% endif %}"
                                 title="{{ _T("Translate '%s'")|replace({'%s': pref.pref_slogan}) }}"
                             >
                                 <i class="language icon" aria-hidden="true"></i>
@@ -881,7 +881,7 @@
                         <div class="ui action input">
                             <input type="text" name="pref_card_abrev" id="pref_card_abrev" value="{{ pref.pref_card_abrev }}" maxlength="10"/>
                             <a
-                                href="{{ url_for("dynamicTranslations", {"text_orig": pref.pref_card_abrev|escape}) }}"
+                                href="{{ url_for("dynamicTranslations", {}, {"text_orig": pref.pref_card_abrev}) }}"
                                 class="tooltip ui icon button{% if pref.pref_card_abrev is empty %} disabled{% endif %}"
                                 title="{{ _T("Translate '%s'")|replace({"%s": pref.pref_card_abrev}) }}"
                             >
@@ -896,7 +896,7 @@
                         <div class="ui action input">
                             <input type="text" name="pref_card_strip" id="pref_card_strip" value="{{ pref.pref_card_strip }}" maxlength="65"/>
                             <a
-                                href="{{ url_for("dynamicTranslations", {"text_orig": pref.pref_card_strip|escape}) }}"
+                                href="{{ url_for("dynamicTranslations", {}, {"text_orig": pref.pref_card_strip}) }}"
                                 class="tooltip ui icon button{% if pref.pref_card_strip is empty %} disabled{% endif %}"
                                 title="{{ _T("Translate '%s'")|replace({"%s": pref.pref_card_strip}) }}"
                             >

--- a/galette/templates/default/pages/preferences.html.twig
+++ b/galette/templates/default/pages/preferences.html.twig
@@ -52,7 +52,7 @@
                             <input type="text" name="pref_slogan" id="pref_slogan" value="{{ pref.pref_slogan }}"/>
                             <a
                                 href="{{ url_for("dynamicTranslations", {}, {"text_orig": pref.pref_slogan}) }}"
-                                class="tooltip ui icon button{% if pref.pref_slogan is empty %} disabled{% endif %}"
+                                class="single-translate tooltip ui icon button{% if pref.pref_slogan is empty %} disabled{% endif %}"
                                 title="{{ _T("Translate '%s'")|replace({'%s': pref.pref_slogan}) }}"
                             >
                                 <i class="language icon" aria-hidden="true"></i>
@@ -882,7 +882,7 @@
                             <input type="text" name="pref_card_abrev" id="pref_card_abrev" value="{{ pref.pref_card_abrev }}" maxlength="10"/>
                             <a
                                 href="{{ url_for("dynamicTranslations", {}, {"text_orig": pref.pref_card_abrev}) }}"
-                                class="tooltip ui icon button{% if pref.pref_card_abrev is empty %} disabled{% endif %}"
+                                class="single-translate tooltip ui icon button{% if pref.pref_card_abrev is empty %} disabled{% endif %}"
                                 title="{{ _T("Translate '%s'")|replace({"%s": pref.pref_card_abrev}) }}"
                             >
                                 <i class="language icon" aria-hidden="true"></i>
@@ -897,7 +897,7 @@
                             <input type="text" name="pref_card_strip" id="pref_card_strip" value="{{ pref.pref_card_strip }}" maxlength="65"/>
                             <a
                                 href="{{ url_for("dynamicTranslations", {}, {"text_orig": pref.pref_card_strip}) }}"
-                                class="tooltip ui icon button{% if pref.pref_card_strip is empty %} disabled{% endif %}"
+                                class="single-translate tooltip ui icon button{% if pref.pref_card_strip is empty %} disabled{% endif %}"
                                 title="{{ _T("Translate '%s'")|replace({"%s": pref.pref_card_strip}) }}"
                             >
                                 <i class="language icon" aria-hidden="true"></i>
@@ -1306,6 +1306,51 @@
 
                 {% include "modals/telemetry.html.twig" with {part: "jsdialog"} %}
                 {% include "modals/telemetry.html.twig" with {part: "jsregister"} %}
+
+                {% set modal_onapprove = "
+                    $('.modal-form form #redirect_uri').val(window.location.href);
+                    $('.modal-form form').submit();
+                " %}
+                {% set extra_success = "
+                    $('.modal-form form').on('submit', function(event) {
+                        event.preventDefault();
+                        var _form = $(this);
+                        var _data = _form.serialize();
+                        $.ajax({
+                            url: _form.attr('action'),
+                            type: 'POST',
+                            datatype: 'json',
+                            data: _data,
+                            error: function() {
+                                $.modal({
+                                    title: '%error%',
+                                    class: 'mini',
+                                    actions: [{
+                                        text: '%close%',
+                                        icon: 'times',
+                                        class: 'icon labeled cancel'
+                                    }],
+                                    className: {
+                                        modal: 'ui redalert modal',
+                                        title: 'center aligned header',
+                                        content: 'center aligned content',
+                                        actions: 'center aligned actions'
+                                    }
+                                }).modal('show');
+                            }
+                        });
+                    });
+                " %}
+                var _transDynField = function() {
+                    {% include "elements/js/modal_action.js.twig" with {
+                        selector: ".single-translate",
+                        extra_success: extra_success|replace({'%error%': _T("An error occurred :(")|e("js"), '%close%': _T("Close")|e("js")}),
+                        modal_title_twig: _T("Translate labels")|e("js"),
+                        modal_content_class: "scrolling",
+                        modal_onapprove: modal_onapprove
+                    } %}
+                }
+                _transDynField();
             });
         </script>
 {% endblock %}

--- a/galette/templates/default/pages/saved_searches_list.html.twig
+++ b/galette/templates/default/pages/saved_searches_list.html.twig
@@ -29,8 +29,14 @@
 
 {% block header %}
     {% set columns = [
-        {'label': '#'},
-        {'label': _T("Creation date")},
+        {
+            'label': '#',
+            collapse: true
+        },
+        {
+            'label': _T("Creation date"),
+            collapse: true
+        },
         {'label': _T("Name")},
         {'label': _T("Parameters")}
     ] %}
@@ -47,7 +53,7 @@
                     {{ loop.index }}
                 {% endif %}
             </td>
-            <td class="left" data-col-label="{{ _T("Creation date") }}">{{ search.creation_date }}</td>
+            <td class="left collapsing" data-col-label="{{ _T("Creation date") }}">{{ search.creation_date }}</td>
             <td class="left" data-col-label="{{ _T("Name") }}">{{ search.name|default("-") }}</td>
             <td class="left" data-col-label="{{ _T("Search parameters") }}">
                 <details class="ui basic styled accordion">

--- a/galette/templates/default/pages/saved_searches_list.html.twig
+++ b/galette/templates/default/pages/saved_searches_list.html.twig
@@ -45,7 +45,7 @@
 
 {% block body %}
     {% for search in searches %}
-        <tr class="{% if loop.index % 2 == 0 %}even{% else %}odd{% endif %}">
+        <tr>
             <td class="collapsing" data-scope="row">
                 {% if preferences.pref_show_id %}
                     {{ search.id }}

--- a/galette/templates/default/pages/scheduledpayments_list.html.twig
+++ b/galette/templates/default/pages/scheduledpayments_list.html.twig
@@ -126,11 +126,23 @@
 
 {% block header %}
     {% set columns = [
-        {'label': '#', 'order': constant("Galette\\Filters\\ScheduledPaymentsList::ORDERBY_ID")},
+        {
+            'label': '#', 'order': constant("Galette\\Filters\\ScheduledPaymentsList::ORDERBY_ID"),
+            'collapse': true
+        },
         {'label': _T("Member"), 'order': constant("Galette\\Filters\\ScheduledPaymentsList::ORDERBY_MEMBER")},
-        {'label': _T("Date"), 'order': constant("Galette\\Filters\\ScheduledPaymentsList::ORDERBY_DATE")},
-        {'label': _T("Scheduled date"), 'order': constant("Galette\\Filters\\ScheduledPaymentsList::ORDERBY_SCHEDULED_DATE")},
-        {'label': _T('Amount'), 'order': constant("Galette\\Filters\\ScheduledPaymentsList::ORDERBY_AMOUNT")},
+        {
+            'label': _T("Date"), 'order': constant("Galette\\Filters\\ScheduledPaymentsList::ORDERBY_DATE"),
+            'collapse': true
+        },
+        {
+            'label': _T("Scheduled date"), 'order': constant("Galette\\Filters\\ScheduledPaymentsList::ORDERBY_SCHEDULED_DATE"),
+            'collapse': true
+        },
+        {
+            'label': _T('Amount'), 'order': constant("Galette\\Filters\\ScheduledPaymentsList::ORDERBY_AMOUNT"),
+            'collapse': true
+        },
         {'label': _T("Payment type"), 'order': constant("Galette\\Filters\\ScheduledPaymentsList::ORDERBY_PAYMENT_TYPE")}
     ] %}
 
@@ -183,9 +195,9 @@
                 {% endif %}
             </td>
             <td data-col-label="{{ _T("Member") }}">{{ memberName({id: scheduled.getContribution().member}) }}</td>
-            <td data-col-label="{{ _T("Date") }}">{{ scheduled.getCreationDate() }}</td>
-            <td data-col-label="{{ _T("Scheduled date") }}">{{ scheduled.getScheduledDate() }}</td>
-            <td data-col-label="{{ _T("Amount") }}">{{ scheduled.getAmount() }}</td>
+            <td class="collapsing" data-col-label="{{ _T("Date") }}">{{ scheduled.getCreationDate() }}</td>
+            <td class="collapsing" data-col-label="{{ _T("Scheduled date") }}">{{ scheduled.getScheduledDate() }}</td>
+            <td class="collapsing" data-col-label="{{ _T("Amount") }}">{{ scheduled.getAmount() }}</td>
             <td data-col-label="{{ _T("Payment type") }}">{{ scheduled.getPaymentType() }}</td>
             {% if (login.isAdmin() or login.isStaff()) and mode != 'ajax' %}
                 <td class="actions_row center collapsing">

--- a/galette/templates/default/pages/status_list.html.twig
+++ b/galette/templates/default/pages/status_list.html.twig
@@ -89,14 +89,21 @@
                                     class="action single-edit"
                             >
                                 <i class="ui edit icon tooltip" aria-hidden="true"></i>
-                                <span class="ui special popup">{{ _T("Edit '%s' field")|replace({'%s': entry.name|escape}) }}</span>
+                                <span class="ui special popup">{{ _T("Edit '%s' field")|replace({'%s': entry.name}) }}</span>
                             </a>
+                        <a
+                            href="{{ url_for('dynamicTranslations', {}, {'text_orig': entry.text_orig}) }}"
+                            class="action single-translate"
+                        >
+                            <i class="ui language grey icon tooltip" aria-hidden="true"></i>
+                            <span class="ui special popup">{{ _T("Translate '%s'")|replace({'%s': entry.name}) }}</span>
+                        </a>
                             <a
                                     href="{{ url_for('removeStatus', {'id': eid}) }}"
                                     class="delete"
                             >
                                 <i class="ui trash red icon tooltip" aria-hidden="true"></i>
-                                <span class="ui special popup">{{ _T("Delete '%s' field")|replace({'%s': entry.name|escape}) }}</span>
+                                <span class="ui special popup">{{ _T("Delete '%s' field")|replace({'%s': entry.name}) }}</span>
                             </a>
                         </td>
                     </tr>
@@ -121,6 +128,44 @@
                 selector: ".single-edit",
                 modal_title_twig: modal_title_twig,
                 modal_class: "mini",
+                modal_onapprove: modal_onapprove
+            } %}
+
+            {% set extra_success = "
+                $('.modal-form form').on('submit', function(event) {
+                    event.preventDefault();
+                    var _form = $(this);
+                    var _data = _form.serialize();
+                    $.ajax({
+                        url: _form.attr('action'),
+                        type: 'POST',
+                        datatype: 'json',
+                        data: _data,
+                        error: function() {
+                            $.modal({
+                                title: '%error%',
+                                class: 'mini',
+                                actions: [{
+                                    text: '%close%',
+                                    icon: 'times',
+                                    class: 'icon labeled cancel'
+                                }],
+                                className: {
+                                    modal: 'ui redalert modal',
+                                    title: 'center aligned header',
+                                    content: 'center aligned content',
+                                    actions: 'center aligned actions'
+                                }
+                            }).modal('show');
+                        }
+                    });
+                });
+            " %}
+            {% include "elements/js/modal_action.js.twig" with {
+                selector: ".single-translate",
+                extra_success: extra_success|replace({'%error%': _T("An error occurred :(")|e("js"), '%close%': _T("Close")|e("js")}),
+                modal_title_twig: _T("Translate labels")|e("js"),
+                modal_content_class: "scrolling",
                 modal_onapprove: modal_onapprove
             } %}
 

--- a/galette/templates/default/pages/status_list.html.twig
+++ b/galette/templates/default/pages/status_list.html.twig
@@ -32,15 +32,15 @@
             <table class="listing ui celled striped table">
                 <thead>
                 <tr>
-                    <th class="id_row">#</th>
+                    <th class="id_row collapsing">#</th>
                     <th>{{ _T("Name") }}</th>
                     <th>{{ _T("Priority") }}</th>
-                    <th>{{ _T("Actions") }}</th>
+                    <th class="collapsing">{{ _T("Actions") }}</th>
                 </tr>
                 </thead>
                 <tfoot>
                 <tr>
-                    <td data-scope="row">
+                    <td class="collapsing" data-scope="row">
                         <span class="visually-hidden">
                             {{ _T("New status") }}
                         </span>
@@ -54,7 +54,7 @@
                     <td class="left" data-col-label="{{ _T("Priority") }}">
                         <input size="4" type="text" name="priorite_statut" value="99" />
                     </td>
-                    <td class="center actions_row">
+                    <td class="center actions_row collapsing">
                         <input type="hidden" name="new" value="1" />
                         <button type="submit" name="valid" class="ui labeled icon button">
                             <i class="plus green icon" aria-hidden="true"></i>
@@ -66,7 +66,7 @@
                 <tbody>
                 {% for eid, entry in entries %}
                     <tr>
-                        <td data-scope="id" class="collapsing">
+                        <td class="collapsing" data-scope="id">
                             {{ eid }}
                         </td>
                         <td class="left" data-col-label="{{ _T("Name") }}">
@@ -83,7 +83,7 @@
                         <td data-col-label="{{ _T("Priority") }}">
                             {{ entry.extra }}
                         </td>
-                        <td class="center actions_row">
+                        <td class="center actions_row collapsing">
                             <a
                                     href="{{ url_for('editStatus', {'id': eid}) }}"
                                     class="action single-edit"

--- a/galette/templates/default/pages/transaction_form.html.twig
+++ b/galette/templates/default/pages/transaction_form.html.twig
@@ -96,18 +96,18 @@
                         <table class="listing ui very compact small celled yellow table">
                             <thead>
                                 <tr>
-                                    <th class="id_row">#</th>
-                                    <th class="left date_row">{{ _T("Date") }}</th>
-                                    <th class="left date_row">{{ _T("Begin") }}</th>
-                                    <th class="left date_row">{{ _T("End") }}</th>
-                                    <th class="left">{{ _T("Duration") }}</th>
+                                    <th class="id_row collapsing">#</th>
+                                    <th class="left date_row collapsing">{{ _T("Date") }}</th>
+                                    <th class="left date_row collapsing">{{ _T("Begin") }}</th>
+                                    <th class="left date_row collapsing">{{ _T("End") }}</th>
+                                    <th class="left collapsing">{{ _T("Duration") }}</th>
             {% if login.isAdmin() or login.isStaff() or login.isGroupManager() %}
                                     <th class="left">{{ _T("Member") }}</th>
             {% endif %}
                                     <th class="left">{{ _T("Type") }}</th>
-                                    <th class="left">{{ _T("Amount") }}</th>
+                                    <th class="left collapsing">{{ _T("Amount") }}</th>
             {% if login.isAdmin() or login.isStaff() or login.isGroupManager() %}
-                                    <th class="actions_row">{{ _T("Actions") }}</th>
+                                    <th class="actions_row collapsing">{{ _T("Actions") }}</th>
             {% endif %}
                                 </tr>
                             </thead>
@@ -162,20 +162,20 @@
             {% for ordre, contrib in contribs %}
                 {% set mid = contrib.member %}
                                 <tr class="{{ contrib.getRowClass() }}">
-                                    <td class="center">
+                                    <td class="center collapsing">
                                         {{ ordre + 1 }}
                                     </td>
-                                    <td class="center">{{ contrib.date }}</td>
-                                    <td class="center">{{ contrib.begin_date }}</td>
-                                    <td class="center">{{ contrib.end_date }}</td>
-                                    <td>{{ contrib.duration }}</td>
+                                    <td class="center collapsing">{{ contrib.date }}</td>
+                                    <td class="center collapsing">{{ contrib.begin_date }}</td>
+                                    <td class="center collapsing">{{ contrib.end_date }}</td>
+                                    <td class="collapsing">{{ contrib.duration }}</td>
                 {% if login.isAdmin() or login.isStaff() or login.isGroupManager() %}
                                     <td>{{ memberName({'id': mid}) }}</td>
                 {% endif %}
                                     <td>{{ contrib.type.libelle }}</td>
-                                    <td class="right">{{ contrib.amount }}</td>
+                                    <td class="right collapsing">{{ contrib.amount }}</td>
                 {% if login.isAdmin() or login.isStaff() or login.isGroupManager() %}
-                                    <td class="actions_row">
+                                    <td class="actions_row collapsing">
                                         <a
                                             href="{{ url_for("detach_contribution", {"id": transaction.id, "cid": contrib.id}) }}"
                                             class="delete"

--- a/galette/templates/default/pages/transaction_form.html.twig
+++ b/galette/templates/default/pages/transaction_form.html.twig
@@ -62,6 +62,7 @@
                                     'current': ptype,
                                     'varname': 'type_paiement_trans',
                                     'show_inline': true,
+                                    'compact': true,
                                     'empty': {
                                         'label': _T("None"),
                                         'value': '0'

--- a/galette/templates/default/pages/transactions_list.html.twig
+++ b/galette/templates/default/pages/transactions_list.html.twig
@@ -141,8 +141,14 @@
 
 {% block header %}
     {% set columns = [
-        {'label': '#', 'order': constant("Galette\\Filters\\TransactionsList::ORDERBY_ID")},
-        {'label': _T("Date"), 'order': constant("Galette\\Filters\\TransactionsList::ORDERBY_DATE")}
+        {
+            'label': '#', 'order': constant("Galette\\Filters\\TransactionsList::ORDERBY_ID"),
+            'collapse': true
+        },
+        {
+            'label': _T("Date"), 'order': constant("Galette\\Filters\\TransactionsList::ORDERBY_DATE"),
+            'collapse': true
+        }
     ] %}
 
     {% if ((login.isAdmin() or login.isStaff()) and member is not defined) or pmember is defined %}
@@ -154,7 +160,10 @@
     ]) %}
 
     {% set columns = columns|merge([
-        {'label': _T('Amount'), 'order': constant("Galette\\Filters\\TransactionsList::ORDERBY_AMOUNT")}
+        {
+            'label': _T('Amount'), 'order': constant("Galette\\Filters\\TransactionsList::ORDERBY_AMOUNT"),
+            'collapse': true
+        }
     ]) %}
 
     {% set columns = columns|merge([
@@ -174,7 +183,7 @@
         {% endif %}
 
         <tr class="{{ transaction.getRowClass() }}">
-            <td data-scope="row">
+            <td class="collapsing" data-scope="row">
                 {% if preferences.pref_show_id %}
                     {{ transaction.id }}
                 {% else %}
@@ -186,7 +195,7 @@
                             </a>
                         </span>
             </td>
-            <td data-col-label="{{ _T("Date") }}">{{ transaction.date }}</td>
+            <td class="collapsing" data-col-label="{{ _T("Date") }}">{{ transaction.date }}</td>
         {% if ((login.isAdmin() or login.isStaff()) and member is not defined) or pmember is defined %}
             <td data-col-label="{{ _T("Member") }}">
             {% if filters.filtre_cotis_adh == "" or filters.filtre_cotis_adh == null %}
@@ -206,7 +215,7 @@
             </td>
         {% endif %}
             <td data-col-label="{{ _T("Description") }}">{{ transaction.description|escape }}</td>
-            <td data-col-label="{{ _T("Amount") }}">{{ transaction.amount }}</td>
+            <td class="collapsing" data-col-label="{{ _T("Amount") }}">{{ transaction.amount }}</td>
             <td data-col-label="{{ _T("Payment type") }}">{{ transaction.getPaymentType() }}</td>
             {% if login.isAdmin() or login.isStaff() or login.isGroupManager() %}
             <td class="center actions_row">

--- a/ui/semantic/galette/collections/table.overrides
+++ b/ui/semantic/galette/collections/table.overrides
@@ -162,9 +162,29 @@ td.emptylist {
 /*-----------------------------
      <th> outside <thead>
 ------------------------------*/
-tr.with-headers th {
+.ui.table > tbody > tr > th {
     padding: @cellVerticalPadding @cellHorizontalPadding;
+    text-align: @cellTextAlign;
+}
+tr.with-headers th {
     background: @lightSecondaryColor;
+}
+
+.ui.definition.table tr th.definition,
+.ui.definition.table > tbody > tr > th:first-child:not(.ignored),
+.ui.definition.table > tr > th:first-child:not(.ignored) {
+    background: @definitionColumnBackground;
+    font-weight: @definitionColumnFontWeight;
+    color: @definitionColumnColor;
+    font-size: @definitionColumnFontSize;
+}
+.ui.definition.table > tbody > tr > th,
+.ui.definition.table > tr > th {
+  border-top: @rowBorder;
+}
+.ui.definition.table > tbody > tr:first-child > th,
+.ui.definition.table > tr:first-child > th {
+    border-top: none;
 }
 
 /*------------------

--- a/ui/semantic/galette/collections/table.overrides
+++ b/ui/semantic/galette/collections/table.overrides
@@ -175,7 +175,7 @@ tr.with-headers th {
 .ui.definition.table > tr > th:first-child:not(.ignored) {
     background: @definitionColumnBackground;
     font-weight: @definitionColumnFontWeight;
-    color: @definitionColumnColor;
+    color: @headerColor;
     font-size: @definitionColumnFontSize;
 }
 .ui.definition.table > tbody > tr > th,


### PR DESCRIPTION
**This PR is based on #630.**

The first commit added uses definition tables introduced in #630 to better display the first column of headers when viewing a member's details (as suggested by @Tezorc on the development mailing list).

The second commit added uses [FUI collapsing cells](https://fomantic-ui.com/collections/table.html#collapsing-cell) on a selection of specific columns (usually : ids, actions, dates, counts, amounts, ...). This way such columns only use as much space as required.