### PR TITLE
Improve news system

### DIFF
--- a/galette/lib/Galette/Controllers/GaletteController.php
+++ b/galette/lib/Galette/Controllers/GaletteController.php
@@ -37,7 +37,6 @@ use Galette\Entity\FieldsCategories;
 use Galette\Entity\Status;
 use Galette\Entity\Texts;
 use Galette\Filters\MembersList;
-use Galette\IO\News;
 use Galette\IO\Charts;
 use Galette\Repository\Members;
 use Galette\Repository\Reminders;
@@ -103,12 +102,11 @@ class GaletteController extends AbstractController
      */
     public function dashboard(Request $request, Response $response): Response
     {
-        $news = new News($this->preferences->pref_rss_url);
-
+        $news = Galette::getNews();
         $params = [
             'page_title'        => _T("Dashboard"),
             'contentcls'        => 'desktop',
-            'news'              => $news->getPosts(),
+            'news'              => $news,
             'show_dashboard'    => $request->getCookieParams()['show_galette_dashboard'],
             'documentation'     => 'usermanual'
         ];

--- a/galette/lib/Galette/Core/GalettePlugin.php
+++ b/galette/lib/Galette/Core/GalettePlugin.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Galette\Core;
 
 use Galette\Entity\Adherent;
+use Galette\IO\News\Entry;
 
 /**
  * Galette plugins
@@ -177,4 +178,15 @@ abstract class GalettePlugin
      * @return array<int, string|array<string,mixed>>
      */
     abstract public static function getDetailedActionsContents(Adherent $member): array;
+
+    /**
+     * Get news for this plugin
+     *
+     * @return ?Entry
+     */
+    public function getNews(): ?Entry
+    {
+        //per default, plugins do not have news to display.
+        return null;
+    }
 }

--- a/galette/lib/Galette/Core/Plugins.php
+++ b/galette/lib/Galette/Core/Plugins.php
@@ -120,7 +120,6 @@ class Plugins
                                 $$varname->register();
                             }
                         } else {
-                            //plugin is not compatible with that version of galette.
                             Analog::log(
                                 'Plugin ' . $entry . ' is explicitly disabled',
                                 Analog::INFO

--- a/galette/lib/Galette/Core/Preferences.php
+++ b/galette/lib/Galette/Core/Preferences.php
@@ -313,7 +313,7 @@ class Preferences
         /* New contribution script */
         'pref_new_contrib_script' => '',
         'pref_bool_wrap_mails' => true,
-        'pref_rss_url' => 'https://galette.eu/dc/index.php/feed/atom',
+        'pref_rss_url' => Galette::RSS_URL,
         'pref_adhesion_form' => '\Galette\IO\PdfAdhesionForm',
         'pref_mail_allow_unsecure' => false,
         'pref_instance_uuid' => '',

--- a/galette/lib/Galette/IO/News/Entry.php
+++ b/galette/lib/Galette/IO/News/Entry.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * Copyright © 2003-2025 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Galette\IO\News;
+
+/**
+ * News entry
+ *
+ * @author Johan Cwiklinski <johan@x-tnd.be>
+ */
+class Entry
+{
+    private string $title;
+    /** @var Post[] */
+    private array $posts;
+    private int $position = 0;
+
+    /**
+     * Default constructor
+     *
+     * @param string $title    Entry title
+     * @param Post[] $posts    Posts
+     * @param int    $position Position of entry in the list
+     */
+    public function __construct(string $title, array $posts, int $position = 0)
+    {
+        $this->title = $title;
+        $this->posts = $posts;
+        $this->position = $position;
+    }
+
+    /**
+     * Get entry title
+     *
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * Get posts
+     *
+     * @return Post[] Posts
+     */
+    public function getPosts(): array
+    {
+        return $this->posts;
+    }
+
+    /**
+     * Get entry position
+     *
+     * @return int Position
+     */
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+}

--- a/galette/lib/Galette/IO/News/Post.php
+++ b/galette/lib/Galette/IO/News/Post.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Copyright © 2003-2025 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Galette\IO\News;
+
+use InvalidArgumentException;
+
+/**
+ * News post
+ *
+ * @author Johan Cwiklinski <johan@x-tnd.be>
+ */
+class Post
+{
+    private string $title;
+    private ?string $url;
+    private ?string $date;
+
+    /**
+     * Default constructor
+     *
+     * @param string  $title Post title
+     * @param ?string $url   Post URL
+     * @param ?string $date  Post date
+     */
+    public function __construct(string $title, ?string $url = null, ?string $date = null)
+    {
+        if (empty($title) && !empty($url)) {
+            $title = $url;
+        } elseif (empty($title) && empty($url)) {
+            throw new InvalidArgumentException('Post title or URL must be provided.');
+        }
+        $this->title = $title;
+        $this->url = $url;
+        $this->date = $date;
+    }
+
+    /**
+     * Get post title
+     *
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * Get post URL
+     *
+     * @return ?string
+     */
+    public function getUrl(): ?string
+    {
+        return $this->url;
+    }
+
+    /**
+     * Get post date
+     *
+     * @return ?string
+     */
+    public function getDate(): ?string
+    {
+        return $this->date;
+    }
+}

--- a/galette/templates/default/pages/desktop.html.twig
+++ b/galette/templates/default/pages/desktop.html.twig
@@ -97,20 +97,26 @@
             {% endif %}
         </div>
 {% if news|length > 0 %}
-        <div class="sixteen wide tablet six wide computer column">
-            <div class="ui attached yellow segment">
-                <div class="ui medium header">{{ _T("News") }}</div>
+    <div class="sixteen wide tablet six wide computer column">
+    {% for entry in news %}
+            <div class="ui top attached yellow segment">
+                <div class="ui medium header">{{ entry.title }}</div>
             </div>
             <div class="ui bottom attached segment">
                 <div class="ui bulleted list">
-    {% for post in news %}
+        {% for post in entry.getPosts() %}
                     <div class="item">
-                        <a href="{{ post.url }}" target="_blank">{{ post.title }}</a>
+            {% if post.getUrl() %}
+                        <a href="{{ post.getURL() }}" target="_blank">{{ post.getTitle() }}</a>
+            {% else %}
+                        {{ post.getTitle() }}
+            {% endif %}
                     </div>
-    {% endfor %}
+        {% endfor %}
                 </div>
             </div>
-        </div>
+    {% endfor %}
+    </div>
 {% endif %}
         <div class="jsonly displaynone sixteen wide column">
             <div class="ui basic vertically fitted segment">

--- a/tests/Galette/Core/tests/units/Galette.php
+++ b/tests/Galette/Core/tests/units/Galette.php
@@ -590,4 +590,59 @@ class Galette extends GaletteTestCase
         $this->assertNull($post->getUrl());
         $this->assertNotEmpty($post->getDate());
     }
+
+    /**
+     * Test isNightly
+     *
+     * @return void
+     */
+    public function testIsNightly(): void
+    {
+        $this->assertFalse(\Galette\Core\Galette::isNightly());
+    }
+
+    /**
+     * Test jsonDecode
+     *
+     * @return void
+     */
+    public function testJsonDecode(): void
+    {
+        $json = '{"key1": "value1", "key2": "value2"}';
+        $decoded = \Galette\Core\Galette::jsonDecode($json);
+        $this->assertEquals(
+            [
+                'key1' => 'value1',
+                'key2' => 'value2',
+            ],
+            $decoded
+        );
+
+        $invalid_json = '{"key1": "value1", "key2": "value2"'; // missing closing brace
+        $this->expectExceptionMessage('JSON decode error: Syntax error');
+        \Galette\Core\Galette::jsonDecode($invalid_json);
+    }
+
+    /**
+     * Test jsonEncode
+     *
+     * @return void
+     */
+    public function testJsonEncode(): void
+    {
+        $data = [
+            'key1' => 'value1',
+            'key2' => 'value2',
+        ];
+        $encoded = \Galette\Core\Galette::jsonEncode($data);
+        $this->assertJsonStringEqualsJsonString(
+            '{"key1":"value1","key2":"value2"}',
+            $encoded
+        );
+
+        // Test with an invalid data type
+        $data['key3'] = mb_convert_encoding('éè', 'ISO-8859-1', 'UTF-8'); //invalid UTF-8 characters
+        $this->expectExceptionMessage('JSON encode error: Malformed UTF-8 characters, possibly incorrectly encoded');
+        \Galette\Core\Galette::jsonEncode($data);
+    }
 }

--- a/tests/Galette/IO/News/tests/units/Entry.php
+++ b/tests/Galette/IO/News/tests/units/Entry.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Copyright © 2003-2025 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Galette\IO\test\units;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * News entry tests class
+ *
+ * @author Johan Cwiklinski <johan@x-tnd.be>
+ */
+class Entry extends TestCase
+{
+    /**
+     * Test entry
+     *
+     * @return void
+     */
+    public function testEntry(): void
+    {
+        $title = 'Entry title';
+        $posts = [];
+
+        $entry = new \Galette\IO\News\Entry($title, $posts);
+        $this->assertSame($title, $entry->getTitle());
+        $this->assertSame($posts, $entry->getPosts());
+        $this->assertSame(0, $entry->getPosition());
+
+        $entry = new \Galette\IO\News\Entry($title, $posts, 10);
+        $this->assertSame($title, $entry->getTitle());
+        $this->assertSame($posts, $entry->getPosts());
+        $this->assertSame(10, $entry->getPosition());
+
+        $posts = [
+            new \Galette\IO\News\Post('Post 1', 'https://example.com/post1', '2025-08-14'),
+            new \Galette\IO\News\Post('Post 2', 'https://example.com/post2', '2025-08-15'),
+        ];
+        $entry = new \Galette\IO\News\Entry($title, $posts, 10);
+        $this->assertSame($title, $entry->getTitle());
+        $this->assertSame($posts, $entry->getPosts());
+        $this->assertSame(10, $entry->getPosition());
+    }
+}

--- a/tests/Galette/IO/News/tests/units/Post.php
+++ b/tests/Galette/IO/News/tests/units/Post.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Copyright © 2003-2025 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Galette\IO\test\units;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * News post tests class
+ *
+ * @author Johan Cwiklinski <johan@x-tnd.be>
+ */
+class Post extends TestCase
+{
+    /**
+     * Test post
+     *
+     * @return void
+     */
+    public function testPost(): void
+    {
+        $title = 'Post title';
+        $url = 'https://example.com/post';
+        $date = '2025-08-15';
+
+        $post = new \Galette\IO\News\Post($title);
+        $this->assertSame($title, $post->getTitle());
+        $this->assertNull($post->getUrl());
+        $this->assertNull($post->getDate());
+
+        $post = new \Galette\IO\News\Post($title, $url, $date);
+        $this->assertSame($title, $post->getTitle());
+        $this->assertSame($url, $post->getUrl());
+        $this->assertSame($date, $post->getDate());
+
+        // Test with empty title but URL provided
+        $post = new \Galette\IO\News\Post('', $url);
+        $this->assertSame($url, $post->getTitle());
+
+        // Test with empty title and URL
+        $this->expectException(\InvalidArgumentException::class);
+        new \Galette\IO\News\Post('');
+    }
+}

--- a/tests/Galette/IO/tests/units/News.php
+++ b/tests/Galette/IO/tests/units/News.php
@@ -64,6 +64,30 @@ class News extends TestCase
     }
 
     /**
+     * Test news loading
+     *
+     * @return void
+     */
+    public function testLoadRSSNews(): void
+    {
+        //ensure allow_url_fopen is on
+        ini_set('allow_url_fopen', true);
+        //load news without caching
+        $news = new \Galette\IO\News('file:///' . realpath(GALETTE_ROOT . '../tests/rss.xml'), true);
+        $posts = $news->getPosts();
+        $this->assertCount(10, $posts);
+
+        $first_post = $posts[0];
+        $second_post = $posts[1];
+
+        $this->assertSame('Test post', $first_post->getTitle());
+        $this->assertSame('https://galette.eu/post1', $first_post->getUrl());
+
+        $this->assertSame('This is a test post description without title, so Galette will use a truncated version of this de...', $second_post->getTitle());
+        $this->assertSame('https://galette.eu/post2', $second_post->getUrl());
+    }
+
+    /**
      * Test news caching
      *
      * @return void

--- a/tests/plugins/plugin-news/_define.php
+++ b/tests/plugins/plugin-news/_define.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Copyright © 2003-2025 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+$this->register(
+    'Galette News',            //Name
+    'Plugin with news',        //Short description
+    'Johan Cwiklinski',        //Author
+    '1.0',                     //Version
+    GALETTE_COMPAT_VERSION,    //Galette compatible version
+    'news',                    //routing name
+    '2025-08-16',              //Release date
+    [   //Permissions needed
+    ]
+);

--- a/tests/plugins/plugin-news/_routes.php
+++ b/tests/plugins/plugin-news/_routes.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Copyright © 2003-2025 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);

--- a/tests/plugins/plugin-news/lib/GaletteNews/PluginGaletteNews.php
+++ b/tests/plugins/plugin-news/lib/GaletteNews/PluginGaletteNews.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * Copyright © 2003-2025 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace GaletteNews;
+
+use DI\Attribute\Inject;
+use Galette\Core\Db;
+use Galette\Core\Login;
+use Galette\Entity\Adherent;
+use Galette\Core\GalettePlugin;
+use Galette\IO\News\Entry;
+use Galette\IO\News\Post;
+use GaletteEvents\Filters\EventsList;
+use GaletteEvents\Repository\Events;
+
+/**
+ * Galette News plugin
+ *
+ * @author Johan Cwiklinski <johan@x-tnd.be>
+ */
+
+class PluginGaletteNews extends GalettePlugin
+{
+    /**
+     * Extra menus entries
+     *
+     * @return array<string, string|array<string, mixed>>
+     */
+    public static function getMenusContents(): array
+    {
+        return [];
+    }
+
+    /**
+     * Extra public menus entries
+     *
+     * @return array<int, string|array<string, mixed>>
+     */
+    public static function getPublicMenusItemsList(): array
+    {
+        return [];
+    }
+
+    /**
+     * Get dashboards contents
+     *
+     * @return array<int, string|array<string, mixed>>
+     */
+    public static function getDashboardsContents(): array
+    {
+        return [];
+    }
+
+    /**
+     * Get actions contents
+     *
+     * @param Adherent $member Member instance
+     *
+     * @return array<int, string|array<string, mixed>>
+     */
+    public static function getListActionsContents(Adherent $member): array
+    {
+        return [];
+    }
+
+    /**
+     * Get detailed actions contents
+     *
+     * @param Adherent $member Member instance
+     *
+     * @return array<int, string|array<string, mixed>>
+     */
+    public static function getDetailedActionsContents(Adherent $member): array
+    {
+        return static::getListActionsContents($member);
+    }
+
+    /**
+     * Get batch actions contents
+     *
+     * @return array<int, string|array<string, mixed>>
+     */
+    public static function getBatchActionsContents(): array
+    {
+        return [];
+    }
+
+    /**
+     * Get current logged-in user dashboards contents
+     *
+     * @return array<int, string|array<string,mixed>>
+     */
+    public static function getMyDashboardsContents(): array
+    {
+        return [];
+    }
+
+    /**
+     * Get plugin news
+     *
+     * @return ?Entry
+     */
+    public function getNews(): ?Entry
+    {
+        $posts = [
+            new Post(
+                title: 'A news',
+                date: date('Y-m-d H:i:s'),
+            ),
+            new Post(
+                title: 'Older news',
+                date: date('Y-m-d H:i:s', strtotime('-1 day')),
+            ),
+        ];
+
+        return new Entry(
+            title: 'Test plugin news',
+            posts: $posts,
+            position: 42
+        );
+    }
+}

--- a/tests/rss.xml
+++ b/tests/rss.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:content="http://purl.org/rss/1.0/modules/content/" version="2.0">
+  <channel>
+    <title>Galette RSS feed</title>
+    <link>https://galette.eu/</link>
+    <item>
+      <title>Test post</title>
+      <link>https://galette.eu/post1</link>
+      <description>Test post description</description>
+      <pubDate>Fri, 15 Aug 2025 07:54:16 GMT</pubDate>
+    </item>
+    <item>
+      <link>https://galette.eu/post2</link>
+      <description>&lt;p&gt;This is a test post description &lt;strong&gt;without title&lt;/strong&gt;, so Galette will use a truncated version of this description as post title, this is better than just an URL displayed to the user :)&lt;/p&gt;</description>
+      <pubDate>Fri, 15 Aug 2025 07:40:31 GMT</pubDate>
+    </item>
+    <item>
+      <title>Test post 3</title>
+      <link>https://galette.eu/post3</link>
+      <description>Test post 3 description</description>
+      <pubDate>Fri, 14 Aug 2025 07:54:16 GMT</pubDate>
+    </item>
+    <item>
+      <title>Test post 4</title>
+      <link>https://galette.eu/post4</link>
+      <description>Test post 4 description</description>
+      <pubDate>Fri, 13 Aug 2025 07:54:16 GMT</pubDate>
+    </item>
+    <item>
+      <title>Test post 5</title>
+      <link>https://galette.eu/post5</link>
+      <description>Test post 5 description</description>
+      <pubDate>Fri, 12 Aug 2025 07:54:16 GMT</pubDate>
+    </item>
+    <item>
+      <title>Test post 6</title>
+      <link>https://galette.eu/post6</link>
+      <description>Test post 6 description</description>
+      <pubDate>Fri, 11 Aug 2025 07:54:16 GMT</pubDate>
+    </item>
+    <item>
+      <title>Test post 7</title>
+      <link>https://galette.eu/post7</link>
+      <description>Test post 7 description</description>
+      <pubDate>Fri, 10 Aug 2025 07:54:16 GMT</pubDate>
+    </item>
+    <item>
+      <title>Test post 8</title>
+      <link>https://galette.eu/post8</link>
+      <description>Test post 8 description</description>
+      <pubDate>Fri, 09 Aug 2025 07:54:16 GMT</pubDate>
+    </item>
+    <item>
+      <title>Test post 9</title>
+      <link>https://galette.eu/post9</link>
+      <description>Test post 9 description</description>
+      <pubDate>Fri, 08 Aug 2025 07:54:16 GMT</pubDate>
+    </item>
+    <item>
+      <title>Test post 10</title>
+      <link>https://galette.eu/post10</link>
+      <description>Test post 10 description</description>
+      <pubDate>Fri, 07 Aug 2025 07:54:16 GMT</pubDate>
+    </item>
+    <item>
+      <title>Test post 11</title>
+      <link>https://galette.eu/post11</link>
+      <description>Test post 11 description</description>
+      <pubDate>Fri, 06 Aug 2025 07:54:16 GMT</pubDate>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
Improve News mechanism on dashboard, to allow several entries to be displayed (including from plugins).
* Galette news (from website) will be displayed only to Staff and Admin
* Asso news (RSS URL from Preferences - if different from the previous), will be used to be displayed to all users
* Plugin news will be displayed if present (plugins are in charge to handle ACLs)