### PR TITLE
Add a glow effect on recalculated dates fields

### DIFF
--- a/galette/templates/default/elements/js/choose_adh.js.twig
+++ b/galette/templates/default/elements/js/choose_adh.js.twig
@@ -197,6 +197,8 @@
                         success: function(res){
                             $('#contribution-rangeend').calendar('set date', res.date_debut_cotis);
                             $('#membership-rangeend').calendar('set date', res.date_fin_cotis);
+                            $('#date_debut_cotis').transition('glow');
+                            $('#date_fin_cotis').transition('glow');
                         },
                         error: function() {
                             {% include "elements/js/modal.js.twig" with {


### PR DESCRIPTION
As it has been done for the amount field on the contribution form when the contribution type is changed (when adding a new membership fee only), this PR adds a glow effect on dates fields when they are recalculated after the contributor is chosen in the form.