### PR TITLE
Handle webp images transparency

### DIFF
--- a/galette/includes/fields_defs/pdfmodels_fields.php
+++ b/galette/includes/fields_defs/pdfmodels_fields.php
@@ -42,7 +42,7 @@ $pdfmodels_fields = [
         'model_body'    => null,
         'model_styles'  => 'div#pdf_title {
     font-size: 1.4em;
-    font-wieght:bold;
+    font-weight:bold;
     text-align: center;
 }
 

--- a/galette/lib/Galette/Core/Logo.php
+++ b/galette/lib/Galette/Core/Logo.php
@@ -81,8 +81,8 @@ class Logo extends Picture
                 $special
             )
         );
-        $this->format = 'png';
-        $this->mime = 'image/png';
+        $this->format = 'webp';
+        $this->mime = 'image/webp';
         $this->custom = false;
     }
 

--- a/galette/lib/Galette/Core/Picture.php
+++ b/galette/lib/Galette/Core/Picture.php
@@ -33,6 +33,7 @@ use Analog\Analog;
 use Galette\Entity\Adherent;
 use Galette\Repository\Members;
 use Galette\IO\FileTrait;
+use UnhandledMatchError;
 
 /**
  * Picture handling
@@ -842,72 +843,38 @@ class Picture
         // Resized image.
         $thumb = imagecreatetruecolor($w, $h);
 
-        $image = false;
-        switch ($ext) {
-            case 'jpg':
-                $image = imagecreatefromjpeg($source);
-                if ($thumb_cropped !== false) {
-                    // Crop: first, crop.
-                    imagecopyresampled($thumb_cropped, $image, 0, 0, $crop_x, $crop_y, $cur_width, $cur_height, $cur_width, $cur_height);
-                    // Then, resize.
-                    imagecopyresampled($thumb, $thumb_cropped, 0, 0, 0, 0, $w, $h, $crop_width, $crop_height);
-                } else {
-                    // Resize
-                    imagecopyresampled($thumb, $image, 0, 0, 0, 0, $w, $h, $cur_width, $cur_height);
-                }
-                imagejpeg($thumb, $dest);
-                break;
-            case 'png':
-                $image = imagecreatefrompng($source);
-                // Turn off alpha blending and set alpha flag. That prevent alpha
-                // transparency to be saved as an arbitrary color (black in my tests)
-                imagealphablending($image, false);
-                imagesavealpha($image, true);
-                imagealphablending($thumb, false);
-                imagesavealpha($thumb, true);
-                if ($thumb_cropped !== false) {
-                    // Crop
-                    imagealphablending($thumb_cropped, false);
-                    imagesavealpha($thumb_cropped, true);
-                    // First, crop.
-                    imagecopyresampled($thumb_cropped, $image, 0, 0, $crop_x, $crop_y, $cur_width, $cur_height, $cur_width, $cur_height);
-                    // Then, resize.
-                    imagecopyresampled($thumb, $thumb_cropped, 0, 0, 0, 0, $w, $h, $crop_width, $crop_height);
-                } else {
-                    // Resize
-                    imagecopyresampled($thumb, $image, 0, 0, 0, 0, $w, $h, $cur_width, $cur_height);
-                }
-                imagepng($thumb, $dest);
-                break;
-            case 'gif':
-                $image = imagecreatefromgif($source);
-                if ($thumb_cropped !== false) {
-                    // Crop: first, crop.
-                    imagecopyresampled($thumb_cropped, $image, 0, 0, $crop_x, $crop_y, $cur_width, $cur_height, $cur_width, $cur_height);
-                    // Then, resize.
-                    imagecopyresampled($thumb, $thumb_cropped, 0, 0, 0, 0, $w, $h, $crop_width, $crop_height);
-                } else {
-                    // Resize
-                    imagecopyresampled($thumb, $image, 0, 0, 0, 0, $w, $h, $cur_width, $cur_height);
-                }
-                imagegif($thumb, $dest);
-                break;
-            case 'webp':
-                $image = imagecreatefromwebp($source);
-                if ($thumb_cropped !== false) {
-                    // Crop: first, crop.
-                    imagecopyresampled($thumb_cropped, $image, 0, 0, $crop_x, $crop_y, $cur_width, $cur_height, $cur_width, $cur_height);
-                    // Then, resize.
-                    imagecopyresampled($thumb, $thumb_cropped, 0, 0, 0, 0, $w, $h, $crop_width, $crop_height);
-                } else {
-                    // Resize
-                    imagecopyresampled($thumb, $image, 0, 0, 0, 0, $w, $h, $cur_width, $cur_height);
-                }
-                imagewebp($thumb, $dest);
-                break;
+        $image = match ($ext) {
+            'jpg' => imagecreatefromjpeg($source),
+            'png' => imagecreatefrompng($source),
+            'gif' => imagecreatefromgif($source),
+            'webp' => imagecreatefromwebp($source),
+            default => throw new UnhandledMatchError($ext),
+        };
+
+        // Turn off alpha blending and set alpha flag. That prevent alpha
+        // transparency to be saved as an arbitrary color (black in my tests)
+        imagealphablending($image, false);
+        imagesavealpha($image, true);
+        imagealphablending($thumb, false);
+        imagesavealpha($thumb, true);
+        if ($thumb_cropped !== false) { // Crop
+            imagealphablending($thumb_cropped, false);
+            imagesavealpha($thumb_cropped, true);
+            // First, crop.
+            imagecopyresampled($thumb_cropped, $image, 0, 0, $crop_x, $crop_y, $cur_width, $cur_height, $cur_width, $cur_height);
+            // Then, resize.
+            imagecopyresampled($thumb, $thumb_cropped, 0, 0, 0, 0, $w, $h, $crop_width, $crop_height);
+        } else { // Resize
+            imagecopyresampled($thumb, $image, 0, 0, 0, 0, $w, $h, $cur_width, $cur_height);
         }
 
-        return true;
+        return match ($ext) {
+            'jpg' => imagejpeg($thumb, $dest),
+            'png' => imagepng($thumb, $dest),
+            'gif' => imagegif($thumb, $dest),
+            'webp' => imagewebp($thumb, $dest),
+            default => false
+        };
     }
 
     /**

--- a/galette/lib/Galette/Core/PrintLogo.php
+++ b/galette/lib/Galette/Core/PrintLogo.php
@@ -51,7 +51,29 @@ class PrintLogo extends Logo
         $this->file_path = $pic->getPath();
         $this->format = $pic->getFormat();
         $this->mime = $pic->getMime();
-        //anyways, we have no custom print logo
+        //anyway, we have no custom print logo
         $this->custom = false;
+    }
+
+    /**
+     * Returns current file full path
+     *
+     * @return string full file path
+     */
+    public function getPath(): string
+    {
+        if ($this->getFormat() !== 'webp') {
+            return $this->file_path;
+        }
+
+        //TCPDF does not support background transparency for WEBP images, create a PNG version
+        $this->format = 'png';
+        $this->mime = 'image/png';
+        $converted_logo_path = sprintf('%s/%s.%s', GALETTE_CACHE_DIR, 'galette_printlogo_converted', 'png');
+        if (!file_exists($converted_logo_path)) {
+            $print_logo = imagecreatefromwebp($this->file_path);
+            imagepng($print_logo, $converted_logo_path);
+        }
+        return $converted_logo_path;
     }
 }

--- a/galette/lib/Galette/Features/Replacements.php
+++ b/galette/lib/Galette/Features/Replacements.php
@@ -27,6 +27,7 @@ use Galette\Core\Db;
 use Galette\Core\Login;
 use Galette\Core\Logo;
 use Galette\Core\Preferences;
+use Galette\Core\PrintLogo;
 use Galette\DynamicFields\Choice;
 use Galette\DynamicFields\Separator;
 use Galette\Entity\Adherent;
@@ -492,7 +493,7 @@ trait Replacements
             $logo->getOptimalHeight()
         );
 
-        $print_logo = new Logo();
+        $print_logo = new PrintLogo();
         if ($this->mail !== null) {
             $print_logo_content = $this->preferences->getURL() . $this->routeparser->urlFor('printLogo');
         } else {

--- a/tests/Galette/Core/Logo.php
+++ b/tests/Galette/Core/Logo.php
@@ -77,8 +77,8 @@ class Logo extends TestCase
         $this->assertNull($instance->getDestDir());
         $this->assertNull($instance->getFileName());
         $this->assertTrue(in_array($instance->getPath(), $expected_paths, true));
-        $this->assertSame('image/png', $instance->getMime());
-        $this->assertSame('png', $instance->getFormat());
+        $this->assertSame('image/webp', $instance->getMime());
+        $this->assertSame('webp', $instance->getFormat());
         $this->assertFalse($instance->isCustom());
         $this->assertSame(200, $instance->getOptimalWidth());
         $this->assertSame(133, $instance->getOptimalHeight());

--- a/tests/Galette/Core/PrintLogo.php
+++ b/tests/Galette/Core/PrintLogo.php
@@ -71,12 +71,10 @@ class PrintLogo extends TestCase
         $this->assertNull($logo->getDestDir());
         $this->assertNull($logo->getFileName());
 
-        $expected_paths = [
-            realpath(GALETTE_ROOT . 'webroot/themes/default/images/galette.webp'),
-            realpath(GALETTE_ROOT . 'webroot/themes/default/images/galette_halloween.webp'),
-            realpath(GALETTE_ROOT . 'webroot/themes/default/images/galette_xmas.webp'),
-        ];
-        $this->assertTrue(in_array($logo->getPath(), $expected_paths, true));
+        $this->assertSame(
+            $logo->getPath(),
+            GALETTE_CACHE_DIR . '/galette_printlogo_converted.png'
+        );
 
         $this->assertSame('image/png', $logo->getMime());
         $this->assertSame('png', $logo->getFormat());


### PR DESCRIPTION
Fix https://bugs.galette.eu/issues/1976

* handle transparency on all file formats (in facts, only JPG does not comes with transparency capabilities, but that does not seem to cause any issue)
* refactor to prevent copy-pasted code 
* when logo is a WEBP, use a converted to PNG for use with TCPDF
* Fix wrong format and mime on default logo
* use PrintLogo for... ASSO_PRINT_LOGO replacement