### PR TITLE
Post contribution script improvements

### DIFF
--- a/.composer-require-checker.config.json
+++ b/.composer-require-checker.config.json
@@ -73,6 +73,9 @@
     "TYPE_DB",
     "USER_DB",
 
+    "// Galette post contribution script constants (not detected as they are dynamically declared)",
+    "SCRIPT_AUTH_TOKEN",
+
     "//XHProf constants",
 
     "//know but not detected Galette function,",

--- a/galette/config/config.inc.php.dist
+++ b/galette/config/config.inc.php.dist
@@ -40,3 +40,5 @@ define("PWD_DB", "demo");
 define("NAME_DB", "galette");
 /* tables name prefix (default is galette_) */
 define("PREFIX_DB", "galette_");
+/* authentication token to use in your post contribution script */
+define("SCRIPT_AUTH_TOKEN", "change_this_value_with_a_very_strong_password");

--- a/galette/lib/Galette/Entity/Contribution.php
+++ b/galette/lib/Galette/Entity/Contribution.php
@@ -1104,6 +1104,7 @@ class Contribution implements AccessManagementInterface
         global $preferences;
 
         $payment = [
+            'id'    => $this->getPaymentTypeId(),
             'type'  => $this->getPaymentType()
         ];
 
@@ -1202,6 +1203,21 @@ class Contribution implements AccessManagementInterface
         } else {
             return _T("Donation");
         }
+    }
+
+    /**
+     * Get payment type id
+     *
+     * @return int
+     */
+    public function getPaymentTypeId(): int
+    {
+        if ($this->payment_type === null) {
+            return 0;
+        }
+
+        $ptype = new PaymentType($this->zdb, $this->payment_type);
+        return $ptype->id;
     }
 
     /**

--- a/galette/lib/Galette/Entity/Contribution.php
+++ b/galette/lib/Galette/Entity/Contribution.php
@@ -1157,6 +1157,8 @@ class Contribution implements AccessManagementInterface
             $contrib['member'] = $member;
         }
 
+        $contrib['auth_token'] = defined('SCRIPT_AUTH_TOKEN') ? SCRIPT_AUTH_TOKEN : '';
+
         if ($extra !== null) {
             $contrib = array_merge($contrib, $extra);
         }

--- a/galette/webroot/post_contribution_test.php
+++ b/galette/webroot/post_contribution_test.php
@@ -23,10 +23,14 @@ declare(strict_types=1);
 
 
 /**
- * Post configuration script test
+ * Post contribution script test
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>
+ * @author Guillaume AGNIERAY <dev@agnieray.net>
  */
+
+//use the SCRIPT_AUTH_TOKEN constant defined in your config.inc.php file
+$script_auth_token = 'change_this_value_with_a_very_strong_password';
 
 $args = [];
 $internal = false;
@@ -55,17 +59,28 @@ if (defined('STDIN')) {
     $args = $_GET;
 }
 
-if (count($args) == 0) {
+if (empty($args)) {
     //we're called without arguments => exit.
-    die('No arguments.');
+    echo 'No arguments.';
+    die(1);
+}
+
+if (defined('STDIN')) {
+    $json_args = json_decode((string) $args);
+} else {
+    $json_args = isset($args['params']) ? json_decode((string) $args['params']) : json_decode('{"auth_token": ""}');
+}
+if ($script_auth_token !== $json_args->auth_token) {
+    //we're called without authentication token => exit.
+    echo 'Unauthorized call.';
+    die(1);
 }
 
 if (defined('STDIN')) {
     //a successful script returns 0, we do not output anything
-    $fp = fopen(__DIR__ . '/cache/galette_post_contrib_file.txt', 'w');
+    $fp = fopen(__DIR__ . '/../data/cache/galette_post_contrib_file.txt', 'w');
     fwrite($fp, $args);
     fclose($fp);
 } else {
-    $json_args = json_decode((string) $args['params']);
     echo json_encode($json_args, JSON_PRETTY_PRINT);
 }

--- a/tests/Galette/Entity/Contribution.php
+++ b/tests/Galette/Entity/Contribution.php
@@ -709,21 +709,45 @@ class Contribution extends GaletteTestCase
 
         $contrib->payment_type = \Galette\Entity\PaymentType::CASH;
         $this->assertSame('Cash', $contrib->getPaymentType());
+        $this->assertSame(\Galette\Entity\PaymentType::CASH, $contrib->getPaymentTypeId());
 
         $contrib->payment_type = \Galette\Entity\PaymentType::CHECK;
         $this->assertSame('Check', $contrib->getPaymentType());
+        $this->assertSame(\Galette\Entity\PaymentType::CHECK, $contrib->getPaymentTypeId());
 
         $contrib->payment_type = \Galette\Entity\PaymentType::OTHER;
         $this->assertSame('Other', $contrib->getPaymentType());
+        $this->assertSame(\Galette\Entity\PaymentType::OTHER, $contrib->getPaymentTypeId());
 
         $contrib->payment_type = \Galette\Entity\PaymentType::CREDITCARD;
         $this->assertSame('Credit card', $contrib->getPaymentType());
+        $this->assertSame(\Galette\Entity\PaymentType::CREDITCARD, $contrib->getPaymentTypeId());
 
         $contrib->payment_type = \Galette\Entity\PaymentType::TRANSFER;
         $this->assertSame('Transfer', $contrib->getPaymentType());
+        $this->assertSame(\Galette\Entity\PaymentType::TRANSFER, $contrib->getPaymentTypeId());
 
         $contrib->payment_type = \Galette\Entity\PaymentType::PAYPAL;
         $this->assertSame('Paypal', $contrib->getPaymentType());
+        $this->assertSame(\Galette\Entity\PaymentType::PAYPAL, $contrib->getPaymentTypeId());
+
+        $contrib->payment_type = \Galette\Entity\PaymentType::STRIPE;
+        $this->assertSame('Stripe', $contrib->getPaymentType());
+        $this->assertSame(\Galette\Entity\PaymentType::STRIPE, $contrib->getPaymentTypeId());
+
+        $contrib->payment_type = \Galette\Entity\PaymentType::HELLOASSO;
+        $this->assertSame('HelloAsso', $contrib->getPaymentType());
+        $this->assertSame(\Galette\Entity\PaymentType::HELLOASSO, $contrib->getPaymentTypeId());
+
+        $this->logSuperAdmin();
+        $contrib = new \Galette\Entity\Contribution(
+            $this->zdb,
+            $this->login,
+            ['type' => 1]
+        );
+        $contrib->payment_type = \Galette\Entity\PaymentType::SCHEDULED;
+        $this->assertSame('Payment schedule', $contrib->getPaymentType());
+        $this->assertSame(\Galette\Entity\PaymentType::SCHEDULED, $contrib->getPaymentTypeId());
     }
 
     /**


### PR DESCRIPTION
* send the payment type id to the script (useful to test the payment type used)
* send a token to authenticate calls to the script and prevent forged requests