### PR TITLE
Rework phpdoc rules

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -5,6 +5,7 @@ $finder = (new PhpCsFixer\Finder())
         __DIR__ . '/galette/lib',
         __DIR__ . '/galette/includes',
         //__DIR__ . '/galette/install',
+        __DIR__ . '/tests',
     ])
 ;
 
@@ -18,7 +19,56 @@ return (new PhpCsFixer\Config())
         'trailing_comma_in_multiline' => false,
         'cast_spaces' => false,
         'single_line_empty_body' => false,
-        'no_unused_imports' => true
+        'no_unused_imports' => true,
+        // rules for phpdoc
+        // Removes @param, @return and @var tags that don't provide any useful information - https://mlocati.github.io/php-cs-fixer-configurator/#version:3.90|fixer:no_superfluous_phpdoc_tags
+        'no_superfluous_phpdoc_tags' => [
+            'allow_mixed' => true,
+            'remove_inheritdoc' => true,
+        ],
+        // require phpdoc for non typed arguments - https://mlocati.github.io/php-cs-fixer-configurator/#version:3.90|fixer:phpdoc_add_missing_param_annotation
+        'phpdoc_add_missing_param_annotation' => true,
+        // no @access - https://mlocati.github.io/php-cs-fixer-configurator/#version:3.90|fixer:phpdoc_no_access
+        'phpdoc_no_access' => true,
+        // no @package - https://mlocati.github.io/php-cs-fixer-configurator/#version:3.90|fixer:phpdoc_no_package
+        'phpdoc_no_package' => true,
+        // order phpdoc tags - https://mlocati.github.io/php-cs-fixer-configurator/#version:3.90|fixer:phpdoc_order
+        'phpdoc_order' => ['order' => ['since', 'var', 'see', 'param', 'return', 'throw', 'todo', 'deprecated']],
+        // phpdoc param in same order as signature - https://mlocati.github.io/php-cs-fixer-configurator/#version:3.90|fixer:phpdoc_param_order
+        'phpdoc_param_order' => true,
+        // align tags - https://mlocati.github.io/php-cs-fixer-configurator/#version:3.90|fixer:phpdoc_align
+        'phpdoc_align' => [
+            'align' => 'vertical',
+            'tags' => [
+                'param',
+                'property',
+                'property-read',
+                'property-write',
+                'phpstan-param',
+                'phpstan-property',
+                'phpstan-property-read',
+                'phpstan-property-write',
+                'phpstan-assert',
+                'phpstan-assert-if-true',
+                'phpstan-assert-if-false',
+                'psalm-param',
+                'psalm-param-out',
+                'psalm-property',
+                'psalm-property-read',
+                'psalm-property-write',
+                'psalm-assert',
+                'psalm-assert-if-true',
+                'psalm-assert-if-false'
+            ],
+        ],
+        // Check types case - https://mlocati.github.io/php-cs-fixer-configurator/#version:3.90|fixer:phpdoc_types
+        'phpdoc_types' => true,
+        // Use native scalar types - https://mlocati.github.io/php-cs-fixer-configurator/#version:3.90|fixer:phpdoc_scalar
+        'phpdoc_scalar' => true,
+        // remove extra empty lines - https://mlocati.github.io/php-cs-fixer-configurator/#version:3.90|fixer:phpdoc_trim
+        'phpdoc_trim' => true,
+        // remove empty lines inside phpdoc block - https://mlocati.github.io/php-cs-fixer-configurator/#version:3.90|fixer:phpdoc_trim_consecutive_blank_line_separation
+        'phpdoc_trim_consecutive_blank_line_separation' => true,
     ])
     ->setFinder($finder)
 ;

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -37,16 +37,19 @@
          <exclude name="PEAR.Commenting.ClassComment.MissingLicenseTag"/>
          <exclude name="PEAR.Commenting.ClassComment.MissingLinkTag"/>
      </rule>
-     <rule ref="PEAR.Commenting.FunctionComment"/>
+     <rule ref="Galette.Commenting.FunctionComment"/>
      <rule ref="PEAR.Commenting.InlineComment"/>
+
+     <!-- Type hinting -->
      <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
          <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification"/>
      </rule>
+     <!-- Force native typehint on methods properties -->
      <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
          <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification"/>
      </rule>
+     <!-- Force native typehint on methods return -->
      <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
-         <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessAnnotation"/>
          <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification"/>
      </rule>
      <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">

--- a/galette/composer.json
+++ b/galette/composer.json
@@ -74,17 +74,18 @@
         "thecodingmachine/safe": "^3.3"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "^3.7",
+        "squizlabs/php_codesniffer": "^4.0",
         "friendsoftwig/twigcs": "^6.2",
         "phpstan/phpstan": "^2.0",
         "phpunit/phpunit": "^10.0",
         "malukenho/docheader": "^1.0",
-        "slevomat/coding-standard": "^8.14",
+        "slevomat/coding-standard": "^8.26",
         "alisqi/twigqi": "^3.0",
         "friendsofphp/php-cs-fixer": "^3.91",
         "rector/rector": "^2.0",
         "shipmonk/composer-dependency-analyser": "^1.8",
-        "thecodingmachine/phpstan-safe-rule": "^1.4"
+        "thecodingmachine/phpstan-safe-rule": "^1.4",
+        "galette/coding-standard": "^1.0"
     },
     "config": {
         "optimize-autoloader": true,

--- a/galette/composer.lock
+++ b/galette/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c0e792b62925f626af17b9636259c8f4",
+    "content-hash": "154137109ed3439e232a16230711deb6",
     "packages": [
         {
             "name": "akrabat/rka-slim-session-middleware",
@@ -5001,6 +5001,47 @@
             "time": "2025-12-11T21:14:59+00:00"
         },
         {
+            "name": "galette/coding-standard",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/galette/coding-standard.git",
+                "reference": "6775be99a44bf1b4d377f976bcecc20cdeda0dee"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/galette/coding-standard/zipball/6775be99a44bf1b4d377f976bcecc20cdeda0dee",
+                "reference": "6775be99a44bf1b4d377f976bcecc20cdeda0dee",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.2.0",
+                "php": "^8.0",
+                "squizlabs/php_codesniffer": "^4.0.1"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Galette Coding Standard for PHP_CodeSniffer.",
+            "keywords": [
+                "dev",
+                "phpcs"
+            ],
+            "support": {
+                "issues": "https://github.com/galette/coding-standard/issues",
+                "source": "https://github.com/galette/coding-standard/tree/1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://donate.stripe.com/dR6bJz7mX1Na0GQ5kk",
+                    "type": "custom"
+                }
+            ],
+            "time": "2025-12-30T16:15:03+00:00"
+        },
+        {
             "name": "malukenho/docheader",
             "version": "1.1.0",
             "source": {
@@ -7606,32 +7647,32 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "8.22.1",
+            "version": "8.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "1dd80bf3b93692bedb21a6623c496887fad05fec"
+                "reference": "d247cdc04b91956bdcfaa0b1313c01960b189d3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/1dd80bf3b93692bedb21a6623c496887fad05fec",
-                "reference": "1dd80bf3b93692bedb21a6623c496887fad05fec",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/d247cdc04b91956bdcfaa0b1313c01960b189d3c",
+                "reference": "d247cdc04b91956bdcfaa0b1313c01960b189d3c",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.1.2",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.2.0",
                 "php": "^7.4 || ^8.0",
                 "phpstan/phpdoc-parser": "^2.3.0",
-                "squizlabs/php_codesniffer": "^3.13.4"
+                "squizlabs/php_codesniffer": "^4.0.1"
             },
             "require-dev": {
                 "phing/phing": "3.0.1|3.1.0",
                 "php-parallel-lint/php-parallel-lint": "1.4.0",
-                "phpstan/phpstan": "2.1.24",
+                "phpstan/phpstan": "2.1.33",
                 "phpstan/phpstan-deprecation-rules": "2.0.3",
-                "phpstan/phpstan-phpunit": "2.0.7",
-                "phpstan/phpstan-strict-rules": "2.0.6",
-                "phpunit/phpunit": "9.6.8|10.5.48|11.4.4|11.5.36|12.3.10"
+                "phpstan/phpstan-phpunit": "2.0.11",
+                "phpstan/phpstan-strict-rules": "2.0.7",
+                "phpunit/phpunit": "9.6.31|10.5.60|11.4.4|11.5.46|12.5.4"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -7655,7 +7696,7 @@
             ],
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/8.22.1"
+                "source": "https://github.com/slevomat/coding-standard/tree/8.26.0"
             },
             "funding": [
                 {
@@ -7667,30 +7708,30 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-13T08:53:30+00:00"
+            "time": "2025-12-21T18:01:15+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "0525c73950de35ded110cffafb9892946d7771b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0525c73950de35ded110cffafb9892946d7771b5",
+                "reference": "0525c73950de35ded110cffafb9892946d7771b5",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=5.4.0"
+                "php": ">=7.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+                "phpunit/phpunit": "^8.4.0 || ^9.3.4 || ^10.5.32 || 11.3.3 - 11.5.28 || ^11.5.31"
             },
             "bin": [
                 "bin/phpcbf",
@@ -7715,7 +7756,7 @@
                     "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
                 }
             ],
-            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "description": "PHP_CodeSniffer tokenizes PHP files and detects violations of a defined set of coding standards.",
             "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
@@ -7746,7 +7787,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2025-11-10T16:43:36+00:00"
         },
         {
             "name": "symfony/event-dispatcher",

--- a/galette/includes/functions.inc.php
+++ b/galette/includes/functions.inc.php
@@ -30,8 +30,6 @@ const NOT_TRANSLATED = ' (not translated)';
  * Check URL validity
  *
  * @param string $url The URL to check
- *
- * @return bool
  */
 function isValidWebUrl(string $url): bool
 {
@@ -47,8 +45,6 @@ function isValidWebUrl(string $url): bool
  * @param string $string The string to translate
  * @param string $domain Translation domain. Default to galette
  * @param bool   $nt     Indicate not translated strings; defaults to true
- *
- * @return string
  */
 function _T(string $string, string $domain = 'galette', bool $nt = true): string
 {
@@ -97,8 +93,6 @@ function _T(string $string, string $domain = 'galette', bool $nt = true): string
  * @param int    $count    Number for count
  * @param string $domain   Translation domain. Default to galette
  * @param bool   $nt       Indicate not translated strings; defaults to true
- *
- * @return string
  */
 function _Tn(string $singular, string $plural, int $count, string $domain = 'galette', bool $nt = true): string
 {
@@ -155,8 +149,6 @@ function _Tn(string $singular, string $plural, int $count, string $domain = 'gal
  * @param string $string  The string to translate
  * @param string $domain  Translation domain (defaults to galette)
  * @param bool   $nt      Indicate not translated strings; defaults to true
- *
- * @return string
  */
 function _Tx(string $context, string $string, string $domain = 'galette', bool $nt = true): string
 {
@@ -201,8 +193,6 @@ function _Tx(string $context, string $string, string $domain = 'galette', bool $
  * @param int    $count    Number for count
  * @param string $domain   Translation domain. Default to galette
  * @param bool   $nt       Indicate not translated strings; defaults to true
- *
- * @return string
  */
 function _Tnx(string $context, string $singular, string $plural, int $count, string $domain = 'galette', bool $nt = true): string
 {
@@ -256,8 +246,6 @@ function _Tnx(string $context, string $singular, string $plural, int $count, str
  *
  * @param string $string  The string to translate
  * @param string $context The context
- *
- * @return string
  */
 function contextualizedString(string $string, string $context): string
 {
@@ -269,8 +257,6 @@ function contextualizedString(string $string, string $context): string
  *
  * @param string $string The string to translate
  * @param string $domain Translation domain. Default to false (will take default domain)
- *
- * @return string
  */
 function __(string $string, string $domain = 'galette'): string
 {

--- a/galette/includes/sql_parse.php
+++ b/galette/includes/sql_parse.php
@@ -62,8 +62,6 @@ use function Safe\preg_match_all;
  * remove_remarks will strip the sql comment lines out of an uploaded sql file
  *
  * @param string $sql sql
- *
- * @return string
  */
 function remove_remarks(string $sql): string
 {

--- a/galette/includes/sys_config/galette_tcpdf_config.php
+++ b/galette/includes/sys_config/galette_tcpdf_config.php
@@ -55,7 +55,6 @@ use function Safe\define;
 /**
  * Alternative configuration file for TCPDF.
  * @author Nicola Asuni
- * @package com.tecnick.tcpdf
  * @version 4.9.005
  * @since 2004-10-27
  */

--- a/galette/lib/Galette/Common/ClassLoader.php
+++ b/galette/lib/Galette/Common/ClassLoader.php
@@ -37,7 +37,6 @@
  * <http://www.doctrine-project.org>.
  *
  * @category Libraries
- * @package  ClassLoader
  * @author Doctrine project <contact@doctrine-project.org>
  * @author Johan Cwiklinski <johan@x-tnd.be>
  * @license  LGPL https://www.gnu.org/licenses/lgpl-3.0.fr.html
@@ -61,7 +60,6 @@ use function Safe\spl_autoload_unregister;
  * relies on the PHP <code>include_path</code>.
  *
  * @category Libraries
- * @package  ClassLoader
  * @author Roman Borschel <roman@code-factory.org>
  * @license  LGPL https://www.gnu.org/licenses/lgpl-3.0.fr.html
  * @link     http://www.doctrine-project.org - https://galette.eu
@@ -107,8 +105,6 @@ class ClassLoader
      * Sets the namespace separator used by classes in the namespace of this ClassLoader.
      *
      * @param string $sep The separator to use.
-     *
-     * @return void
      */
     public function setNamespaceSeparator(string $sep): void
     {
@@ -117,8 +113,6 @@ class ClassLoader
 
     /**
      * Gets the namespace separator used by classes in the namespace of this ClassLoader.
-     *
-     * @return string
      */
     public function getNamespaceSeparator(): string
     {
@@ -129,8 +123,6 @@ class ClassLoader
      * Sets the base include path for all class files in the namespace of this ClassLoader.
      *
      * @param string $includePath Include path
-     *
-     * @return void
      */
     public function setIncludePath(string $includePath): void
     {
@@ -139,8 +131,6 @@ class ClassLoader
 
     /**
      * Gets the base include path for all class files in the namespace of this ClassLoader.
-     *
-     * @return string
      */
     public function getIncludePath(): string
     {
@@ -151,8 +141,6 @@ class ClassLoader
      * Sets the file extension of class files in the namespace of this ClassLoader.
      *
      * @param string $fileExtension File extension
-     *
-     * @return void
      */
     public function setFileExtension(string $fileExtension): void
     {
@@ -161,8 +149,6 @@ class ClassLoader
 
     /**
      * Gets the file extension of class files in the namespace of this ClassLoader.
-     *
-     * @return string
      */
     public function getFileExtension(): string
     {
@@ -171,8 +157,6 @@ class ClassLoader
 
     /**
      * Registers this ClassLoader on the SPL autoload stack.
-     *
-     * @return void
      */
     public function register(): void
     {
@@ -183,8 +167,6 @@ class ClassLoader
 
     /**
      * Removes this ClassLoader from the SPL autoload stack.
-     *
-     * @return void
      */
     public function unregister(): void
     {

--- a/galette/lib/Galette/Common/XHProf.php
+++ b/galette/lib/Galette/Common/XHProf.php
@@ -77,8 +77,6 @@ class XHProf
      * Start profiling
      *
      * @param string $msg Message (default '')
-     *
-     * @return void
      */
     public function start(string $msg = ''): void
     {
@@ -101,8 +99,6 @@ class XHProf
 
     /**
      * Stops profiling
-     *
-     * @return void
      */
     public function stop(): void
     {

--- a/galette/lib/Galette/Console/Command/Checks.php
+++ b/galette/lib/Galette/Console/Command/Checks.php
@@ -43,11 +43,6 @@ class Checks extends AbstractCommand
 {
     /**
      * Command execution
-     *
-     * @param InputInterface  $input  Input interface
-     * @param OutputInterface $output Output interface
-     *
-     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/galette/lib/Galette/Console/Command/Install.php
+++ b/galette/lib/Galette/Console/Command/Install.php
@@ -54,8 +54,6 @@ class Install extends AbstractCommand
 
     /**
      * Configure command
-     *
-     * @return void
      */
     protected function configure(): void
     {
@@ -76,11 +74,6 @@ class Install extends AbstractCommand
 
     /**
      * Command execution
-     *
-     * @param InputInterface  $input  Input interface
-     * @param OutputInterface $output Output interface
-     *
-     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/galette/lib/Galette/Console/Command/MakeTwigCache.php
+++ b/galette/lib/Galette/Console/Command/MakeTwigCache.php
@@ -61,8 +61,6 @@ class MakeTwigCache extends AbstractCommand
 {
     /**
      * Configure command
-     *
-     * @return void
      */
     protected function configure(): void
     {
@@ -73,11 +71,6 @@ class MakeTwigCache extends AbstractCommand
 
     /**
      * Command execution
-     *
-     * @param InputInterface  $input  Input interface
-     * @param OutputInterface $output Output interface
-     *
-     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
@@ -144,8 +137,6 @@ class MakeTwigCache extends AbstractCommand
      * Remove a directory and its content recursively.
      *
      * @param string $path Path to remove
-     *
-     * @return bool
      */
     private function rmdirRecursive(string $path): bool
     {
@@ -211,8 +202,6 @@ class MakeTwigCache extends AbstractCommand
      * Return a mocked Twig environment, with custom functions, filters and tests.
      *
      * @param LoaderInterface $loader Twig loader
-     *
-     * @return Environment
      */
     private function getMockedTwigEnvironment(LoaderInterface $loader): Environment
     {
@@ -221,8 +210,6 @@ class MakeTwigCache extends AbstractCommand
              * Custom functions
              *
              * @param string $name Function name
-             *
-             * @return TwigFunction
              */
             public function getFunction(string $name): TwigFunction
             {
@@ -247,8 +234,6 @@ class MakeTwigCache extends AbstractCommand
              * Custom filters
              *
              * @param string $name Filter name
-             *
-             * @return TwigFilter
              */
             public function getFilter(string $name): TwigFilter
             {
@@ -260,8 +245,6 @@ class MakeTwigCache extends AbstractCommand
              * Custom tests
              *
              * @param string $name Test name
-             *
-             * @return ?TwigTest
              */
             public function getTest(string $name): ?TwigTest
             {
@@ -282,8 +265,6 @@ class MakeTwigCache extends AbstractCommand
      * This handler is useful to be able to preserve filenames of compiled files.
      *
      * @param string $directory Directory to store cache
-     *
-     * @return CacheInterface
      */
     private function getTwigCacheHandler(string $directory): CacheInterface
     {
@@ -307,8 +288,6 @@ class MakeTwigCache extends AbstractCommand
              *
              * @param string $name      The template name
              * @param string $className The template class name
-             *
-             * @return string
              */
             public function generateKey(string $name, string $className): string
             {

--- a/galette/lib/Galette/Console/Command/Plugins/AbstractPlugins.php
+++ b/galette/lib/Galette/Console/Command/Plugins/AbstractPlugins.php
@@ -58,8 +58,6 @@ abstract class AbstractPlugins extends AbstractCommand
 
     /**
      * Configure command
-     *
-     * @return void
      */
     protected function configure(): void
     {
@@ -71,11 +69,6 @@ abstract class AbstractPlugins extends AbstractCommand
 
     /**
      * Interacts to request missing arguments or options
-     *
-     * @param InputInterface  $input  Input interface
-     * @param OutputInterface $output Output interface
-     *
-     * @return void
      */
     protected function interact(InputInterface $input, OutputInterface $output): void
     {
@@ -185,8 +178,6 @@ abstract class AbstractPlugins extends AbstractCommand
     /**
      * Get relevant choices (getRelevantPlugins formatted) for the command
      *
-     * @param SymfonyStyle $io Output interface
-     *
      * @return array<string, string>
      */
     protected function getRelevantChoices(SymfonyStyle $io): array
@@ -203,8 +194,6 @@ abstract class AbstractPlugins extends AbstractCommand
 
     /**
      * Get relevant plugins for current command
-     *
-     * @param SymfonyStyle $io Output interface
      *
      * @return array<string, array<string, string>>
      */

--- a/galette/lib/Galette/Console/Command/Plugins/PluginDisable.php
+++ b/galette/lib/Galette/Console/Command/Plugins/PluginDisable.php
@@ -43,11 +43,6 @@ class PluginDisable extends AbstractPlugins
 {
     /**
      * Command execution
-     *
-     * @param InputInterface  $input  Input interface
-     * @param OutputInterface $output Output interface
-     *
-     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
@@ -67,8 +62,6 @@ class PluginDisable extends AbstractPlugins
 
     /**
      * Get relevant plugins (enabled ones) for current command
-     *
-     * @param SymfonyStyle $io Output interface
      *
      * @return array<string, array<string, string>>
      */

--- a/galette/lib/Galette/Console/Command/Plugins/PluginEnable.php
+++ b/galette/lib/Galette/Console/Command/Plugins/PluginEnable.php
@@ -43,11 +43,6 @@ class PluginEnable extends AbstractPlugins
 {
     /**
      * Command execution
-     *
-     * @param InputInterface  $input  Input interface
-     * @param OutputInterface $output Output interface
-     *
-     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
@@ -67,8 +62,6 @@ class PluginEnable extends AbstractPlugins
 
     /**
      * Get relevant plugins (disabled ones) for current command
-     *
-     * @param SymfonyStyle $io Output interface
      *
      * @return array<string, array<string, string>>
      */

--- a/galette/lib/Galette/Console/Command/Plugins/PluginInstallDb.php
+++ b/galette/lib/Galette/Console/Command/Plugins/PluginInstallDb.php
@@ -42,11 +42,6 @@ class PluginInstallDb extends AbstractPlugins
 {
     /**
      * Command execution
-     *
-     * @param InputInterface  $input  Input interface
-     * @param OutputInterface $output Output interface
-     *
-     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
@@ -75,8 +70,6 @@ class PluginInstallDb extends AbstractPlugins
 
     /**
      * Get relevant plugins (actives, with database) for current command
-     *
-     * @param SymfonyStyle $io Output interface
      *
      * @return array<string, array<string, string>>
      */

--- a/galette/lib/Galette/Console/Command/Plugins/PluginsList.php
+++ b/galette/lib/Galette/Console/Command/Plugins/PluginsList.php
@@ -45,8 +45,6 @@ class PluginsList extends AbstractCommand
 {
     /**
      * Configure command
-     *
-     * @return void
      */
     protected function configure(): void
     {
@@ -59,11 +57,6 @@ class PluginsList extends AbstractCommand
 
     /**
      * Command execution
-     *
-     * @param InputInterface  $input  Input interface
-     * @param OutputInterface $output Output interface
-     *
-     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
@@ -102,8 +95,6 @@ class PluginsList extends AbstractCommand
      * @param InputInterface $input       Console input
      * @param SymfonyStyle   $io          Console style
      * @param string[]       $definitions Definitions (for simple output)
-     *
-     * @return void
      */
     private function listEnabledPlugins(
         Plugins $plugins,
@@ -137,8 +128,6 @@ class PluginsList extends AbstractCommand
      * @param InputInterface $input       Console input
      * @param SymfonyStyle   $io          Console style
      * @param string[]       $definitions Definitions (for simple output)
-     *
-     * @return void
      */
     private function listDisabledPlugins(
         Plugins $plugins,

--- a/galette/lib/Galette/Console/GaletteApplication.php
+++ b/galette/lib/Galette/Console/GaletteApplication.php
@@ -44,8 +44,6 @@ class GaletteApplication extends Application
 
     /**
      * Initialize application
-     *
-     * @return void
      */
     public function init(): void
     {

--- a/galette/lib/Galette/Controllers/AbstractController.php
+++ b/galette/lib/Galette/Controllers/AbstractController.php
@@ -116,8 +116,6 @@ abstract class AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     protected function galetteRedirect(Request $request, Response $response): Response
     {
@@ -190,8 +188,6 @@ abstract class AbstractController
      * @param Response            $response Response instance
      * @param array<string,mixed> $data     Data to send
      * @param int                 $status   HTTP status code
-     *
-     * @return Response
      */
     protected function withJson(Response $response, array $data, int $status = 200): Response
     {
@@ -206,8 +202,6 @@ abstract class AbstractController
      *
      * @param string                   $filter_name Filter name
      * @param array<string,mixed>|null $args        Arguments
-     *
-     * @return string
      */
     public function getFilterName(string $filter_name, ?array $args = null): string
     {
@@ -237,8 +231,6 @@ abstract class AbstractController
      * @param Response $response     PSR Response
      * @param string[] $errors       Errors to report
      * @param string   $redirect_url URL to redirect to
-     *
-     * @return Response
      */
     protected function redirectWithErrors(Response $response, array $errors, string $redirect_url): Response
     {
@@ -257,8 +249,6 @@ abstract class AbstractController
      * @param string[] $successes    Successes to report
      * @param string[] $warnings     Warnings to report
      * @param string[] $errors       Errors to report
-     *
-     * @return Response
      */
     protected function redirect(
         Response $response,

--- a/galette/lib/Galette/Controllers/AdminToolsController.php
+++ b/galette/lib/Galette/Controllers/AdminToolsController.php
@@ -44,8 +44,6 @@ class AdminToolsController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function adminTools(Request $request, Response $response): Response
     {
@@ -77,8 +75,6 @@ class AdminToolsController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function process(Request $request, Response $response): Response
     {

--- a/galette/lib/Galette/Controllers/AjaxController.php
+++ b/galette/lib/Galette/Controllers/AjaxController.php
@@ -49,8 +49,6 @@ class AjaxController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function messages(Request $request, Response $response): Response
     {
@@ -110,8 +108,6 @@ class AjaxController extends AbstractController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param string   $term     Search term
-     *
-     * @return Response
      */
     public function suggestTowns(Request $request, Response $response, string $term): Response
     {
@@ -159,8 +155,6 @@ class AjaxController extends AbstractController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param string   $term     Search term
-     *
-     * @return Response
      */
     public function suggestCountries(Request $request, Response $response, string $term): Response
     {
@@ -199,8 +193,6 @@ class AjaxController extends AbstractController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param string   $term     Search term
-     *
-     * @return Response
      */
     public function suggestRegions(Request $request, Response $response, string $term): Response
     {
@@ -238,8 +230,6 @@ class AjaxController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function telemetryInfos(Request $request, Response $response): Response
     {
@@ -258,8 +248,6 @@ class AjaxController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function telemetrySend(Request $request, Response $response): Response
     {
@@ -289,8 +277,6 @@ class AjaxController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function telemetryRegistered(Request $request, Response $response): Response
     {
@@ -303,8 +289,6 @@ class AjaxController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function contributionDates(Request $request, Response $response): Response
     {
@@ -335,8 +319,6 @@ class AjaxController extends AbstractController
      * @param Response    $response PSR Response
      * @param int|null    $page     Page number
      * @param string|null $search   Search string
-     *
-     * @return Response
      */
     public function contributionMembers(Request $request, Response $response, ?int $page = null, ?string $search = null): Response
     {
@@ -384,8 +366,6 @@ class AjaxController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function passwordStrength(Request $request, Response $response): Response
     {

--- a/galette/lib/Galette/Controllers/AuthController.php
+++ b/galette/lib/Galette/Controllers/AuthController.php
@@ -49,8 +49,6 @@ class AuthController extends AbstractController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param ?string  $r        Redirect after login
-     *
-     * @return Response
      */
     public function login(Request $request, Response $response, ?string $r = null): Response
     {
@@ -83,8 +81,6 @@ class AuthController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function doLogin(Request $request, Response $response): Response
     {
@@ -205,8 +201,6 @@ class AuthController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function logout(Request $request, Response $response): Response
     {
@@ -224,8 +218,6 @@ class AuthController extends AbstractController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id       Member to impersonate
-     *
-     * @return Response
      */
     public function impersonate(Request $request, Response $response, int $id): Response
     {
@@ -267,8 +259,6 @@ class AuthController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function unimpersonate(Request $request, Response $response): Response
     {
@@ -291,8 +281,6 @@ class AuthController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function lostPassword(Request $request, Response $response): Response
     {
@@ -316,8 +304,6 @@ class AuthController extends AbstractController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param ?int     $id_adh   Member id
-     *
-     * @return Response
      */
     public function retrievePassword(Request $request, Response $response, ?int $id_adh = null): Response
     {
@@ -478,8 +464,6 @@ class AuthController extends AbstractController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param string   $hash     Hash
-     *
-     * @return Response
      */
     public function recoverPassword(Request $request, Response $response, string $hash): Response
     {
@@ -514,8 +498,6 @@ class AuthController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function doRecoverPassword(Request $request, Response $response): Response
     {

--- a/galette/lib/Galette/Controllers/Crud/ContributionsController.php
+++ b/galette/lib/Galette/Controllers/Crud/ContributionsController.php
@@ -58,8 +58,6 @@ class ContributionsController extends CrudController
      * @param Response     $response PSR Response
      * @param string       $type     Contribution type
      * @param Contribution $contrib  Contribution instance
-     *
-     * @return Response
      */
     public function addEditPage(
         Request $request,
@@ -152,8 +150,6 @@ class ContributionsController extends CrudController
      * @param Request     $request  PSR Request
      * @param Response    $response PSR Response
      * @param string|null $type     Contribution type
-     *
-     * @return Response
      */
     public function add(Request $request, Response $response, ?string $type = null): Response
     {
@@ -218,8 +214,6 @@ class ContributionsController extends CrudController
      * @param Request     $request  PSR Request
      * @param Response    $response PSR Response
      * @param string|null $type     Contribution type
-     *
-     * @return Response
      */
     public function doAdd(Request $request, Response $response, ?string $type = null): Response
     {
@@ -251,8 +245,6 @@ class ContributionsController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function massAddChooseType(Request $request, Response $response): Response
     {
@@ -285,8 +277,6 @@ class ContributionsController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function massAddContributions(Request $request, Response $response): Response
     {
@@ -337,8 +327,6 @@ class ContributionsController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function doMassAddContributions(Request $request, Response $response): Response
     {
@@ -399,8 +387,6 @@ class ContributionsController extends CrudController
      * @param string|null     $option   One of 'page', 'order' or 'member'
      * @param int|string|null $value    Value of the option
      * @param ?string         $type     One of 'transactions' or 'contributions'
-     *
-     * @return Response
      */
     public function list(
         Request $request,
@@ -587,8 +573,6 @@ class ContributionsController extends CrudController
      * @param Request     $request  PSR Request
      * @param Response    $response PSR Response
      * @param string|null $type     One of 'transactions' or 'contributions'
-     *
-     * @return Response
      */
     public function myList(Request $request, Response $response, ?string $type = null): Response
     {
@@ -611,8 +595,6 @@ class ContributionsController extends CrudController
      * @param Request     $request  PSR Request
      * @param Response    $response PSR Response
      * @param string|null $type     One of 'transactions' or 'contributions'
-     *
-     * @return Response
      */
     public function filter(Request $request, Response $response, ?string $type = null): Response
     {
@@ -704,8 +686,6 @@ class ContributionsController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param string   $type     One of 'transactions' or 'contributions'
-     *
-     * @return Response
      */
     public function handleBatch(Request $request, Response $response, string $type): Response
     {
@@ -751,8 +731,6 @@ class ContributionsController extends CrudController
      * @param Response    $response PSR Response
      * @param ?int        $id       Contribution id
      * @param string|null $type     Contribution type
-     *
-     * @return Response
      */
     public function edit(Request $request, Response $response, ?int $id, ?string $type = null): Response
     {
@@ -798,8 +776,6 @@ class ContributionsController extends CrudController
      * @param Response    $response PSR Response
      * @param int         $id       Contribution id
      * @param string|null $type     Contribution type
-     *
-     * @return Response
      */
     public function doEdit(Request $request, Response $response, int $id, ?string $type = null): Response
     {
@@ -827,8 +803,6 @@ class ContributionsController extends CrudController
      * @param string       $type     Contribution type
      * @param Contribution $contrib  Contribution instance
      * @param ?int         $id       Contribution id
-     *
-     * @return Response
      */
     public function store(Request $request, Response $response, string $action, string $type, Contribution $contrib, ?int $id = null): Response
     {
@@ -927,8 +901,6 @@ class ContributionsController extends CrudController
      * Get redirection URI
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function redirectUri(array $args): string
     {
@@ -939,8 +911,6 @@ class ContributionsController extends CrudController
      * Get form URI
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function formUri(array $args): string
     {
@@ -954,8 +924,6 @@ class ContributionsController extends CrudController
      * Get confirmation removal page title
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function confirmRemoveTitle(array $args): string
     {
@@ -990,8 +958,6 @@ class ContributionsController extends CrudController
      *
      * @param array<string,mixed> $args Route arguments
      * @param array<string,mixed> $post POST values
-     *
-     * @return bool
      */
     protected function doDelete(array $args, array $post): bool
     {

--- a/galette/lib/Galette/Controllers/Crud/ContributionsTypesController.php
+++ b/galette/lib/Galette/Controllers/Crud/ContributionsTypesController.php
@@ -43,8 +43,6 @@ class ContributionsTypesController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function add(Request $request, Response $response): Response
     {
@@ -57,8 +55,6 @@ class ContributionsTypesController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function doAdd(Request $request, Response $response): Response
     {
@@ -75,8 +71,6 @@ class ContributionsTypesController extends CrudController
      * @param Response        $response PSR Response
      * @param string|null     $option   One of 'page' or 'order'
      * @param int|string|null $value    Value of the option
-     *
-     * @return Response
      */
     public function list(
         Request $request,
@@ -115,8 +109,6 @@ class ContributionsTypesController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function filter(Request $request, Response $response): Response
     {
@@ -133,8 +125,6 @@ class ContributionsTypesController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id       Contribution type id
-     *
-     * @return Response
      */
     public function edit(Request $request, Response $response, int $id): Response
     {
@@ -161,8 +151,6 @@ class ContributionsTypesController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id       Contribution type id
-     *
-     * @return Response
      */
     public function doEdit(Request $request, Response $response, int $id): Response
     {
@@ -176,8 +164,6 @@ class ContributionsTypesController extends CrudController
      * @param Response $response PSR Response
      * @param ?int     $id       Contribution type id
      * @param string   $action   Action
-     *
-     * @return Response
      */
     public function store(
         Request $request,
@@ -249,8 +235,6 @@ class ContributionsTypesController extends CrudController
      * Get redirection URI
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function redirectUri(array $args): string
     {
@@ -261,8 +245,6 @@ class ContributionsTypesController extends CrudController
      * Get form URI
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function formUri(array $args): string
     {
@@ -278,8 +260,6 @@ class ContributionsTypesController extends CrudController
      * Get confirmation removal page title
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function confirmRemoveTitle(array $args): string
     {
@@ -298,8 +278,6 @@ class ContributionsTypesController extends CrudController
      *
      * @param array<string,mixed> $args Route arguments
      * @param array<string,mixed> $post POST values
-     *
-     * @return bool
      */
     protected function doDelete(array $args, array $post): bool
     {

--- a/galette/lib/Galette/Controllers/Crud/DocumentsController.php
+++ b/galette/lib/Galette/Controllers/Crud/DocumentsController.php
@@ -54,8 +54,6 @@ class DocumentsController extends CrudController
      * @param Request  $request   PSR Request
      * @param Response $response  PSR Response
      * @param ?string  $form_name Form name
-     *
-     * @return Response
      */
     public function add(Request $request, Response $response, ?string $form_name = null): Response
     {
@@ -91,8 +89,6 @@ class DocumentsController extends CrudController
      * @param Request  $request   PSR Request
      * @param Response $response  PSR Response
      * @param ?string  $form_name Form name
-     *
-     * @return Response
      */
     public function doAdd(Request $request, Response $response, ?string $form_name = null): Response
     {
@@ -110,8 +106,6 @@ class DocumentsController extends CrudController
      * @param Response        $response PSR Response
      * @param string|null     $option   One of 'page' or 'order'
      * @param int|string|null $value    Value of the option
-     *
-     * @return Response
      */
     public function list(
         Request $request,
@@ -151,8 +145,6 @@ class DocumentsController extends CrudController
      * @param Response        $response PSR Response
      * @param string|null     $option   One of 'page' or 'order'
      * @param int|string|null $value    Value of the option
-     *
-     * @return Response
      */
     public function publicList(
         Request $request,
@@ -183,8 +175,6 @@ class DocumentsController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function filter(Request $request, Response $response): Response
     {
@@ -198,8 +188,6 @@ class DocumentsController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id       Document ID
-     *
-     * @return Response
      */
     public function getDocument(
         Request $request,
@@ -265,8 +253,6 @@ class DocumentsController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id       Document id
-     *
-     * @return Response
      */
     public function edit(Request $request, Response $response, int $id): Response
     {
@@ -302,8 +288,6 @@ class DocumentsController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id       Document id
-     *
-     * @return Response
      */
     public function doEdit(Request $request, Response $response, int $id): Response
     {
@@ -317,8 +301,6 @@ class DocumentsController extends CrudController
      * @param Request  $request  PSR request
      * @param Response $response PSR response
      * @param Document $document Document to work on
-     *
-     * @return Response
      */
     private function store(Request $request, Response $response, Document $document): Response
     {
@@ -376,8 +358,6 @@ class DocumentsController extends CrudController
      * Get redirection URI
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function redirectUri(array $args): string
     {
@@ -388,8 +368,6 @@ class DocumentsController extends CrudController
      * Get form URI
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function formUri(array $args): string
     {
@@ -403,8 +381,6 @@ class DocumentsController extends CrudController
      * Get confirmation removal page title
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function confirmRemoveTitle(array $args): string
     {
@@ -416,8 +392,6 @@ class DocumentsController extends CrudController
      *
      * @param array<string,mixed> $args Route arguments
      * @param array<string,mixed> $post POST values
-     *
-     * @return bool
      */
     protected function doDelete(array $args, array $post): bool
     {

--- a/galette/lib/Galette/Controllers/Crud/DynamicFieldsController.php
+++ b/galette/lib/Galette/Controllers/Crud/DynamicFieldsController.php
@@ -55,8 +55,6 @@ class DynamicFieldsController extends CrudController
      * @param Request  $request   PSR Request
      * @param Response $response  PSR Response
      * @param ?string  $form_name Form name
-     *
-     * @return Response
      */
     public function add(Request $request, Response $response, ?string $form_name = null): Response
     {
@@ -89,8 +87,6 @@ class DynamicFieldsController extends CrudController
      * @param Request  $request   PSR Request
      * @param Response $response  PSR Response
      * @param ?string  $form_name Form name
-     *
-     * @return Response
      */
     public function doAdd(Request $request, Response $response, ?string $form_name = null): Response
     {
@@ -173,8 +169,6 @@ class DynamicFieldsController extends CrudController
      * @param string|null     $option    One of 'page' or 'order'
      * @param int|string|null $value     Value of the option
      * @param string          $form_name Form name
-     *
-     * @return Response
      */
     public function list(
         Request $request,
@@ -228,8 +222,6 @@ class DynamicFieldsController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function filter(Request $request, Response $response): Response
     {
@@ -247,8 +239,6 @@ class DynamicFieldsController extends CrudController
      * @param int      $fid       Dynamic fields ID
      * @param int      $pos       Dynamic field position
      * @param string   $name      File name
-     *
-     * @return Response
      */
     public function getDynamicFile(
         Request $request,
@@ -361,8 +351,6 @@ class DynamicFieldsController extends CrudController
      * @param Response $response  PSR Response
      * @param int      $id        Dynamic field id
      * @param ?string  $form_name Form name
-     *
-     * @return Response
      */
     public function edit(Request $request, Response $response, int $id, ?string $form_name = null): Response
     {
@@ -407,8 +395,6 @@ class DynamicFieldsController extends CrudController
      * @param Response $response  PSR Response
      * @param int      $id        Dynamic field id
      * @param ?string  $form_name Form name
-     *
-     * @return Response
      */
     public function doEdit(Request $request, Response $response, int $id, ?string $form_name = null): Response
     {
@@ -487,8 +473,6 @@ class DynamicFieldsController extends CrudController
      * Get redirection URI
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function redirectUri(array $args): string
     {
@@ -499,8 +483,6 @@ class DynamicFieldsController extends CrudController
      * Get form URI
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function formUri(array $args): string
     {
@@ -514,8 +496,6 @@ class DynamicFieldsController extends CrudController
      * Get confirmation removal page title
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function confirmRemoveTitle(array $args): string
     {
@@ -535,8 +515,6 @@ class DynamicFieldsController extends CrudController
      *
      * @param array<string,mixed> $args Route arguments
      * @param array<string,mixed> $post POST values
-     *
-     * @return bool
      */
     protected function doDelete(array $args, array $post): bool
     {
@@ -563,8 +541,6 @@ class DynamicFieldsController extends CrudController
      * @param int      $id        Field id
      * @param string   $form_name Form name
      * @param string   $direction One of DynamicField::MOVE_*
-     *
-     * @return Response
      */
     public function move(
         Request $request,

--- a/galette/lib/Galette/Controllers/Crud/GroupsController.php
+++ b/galette/lib/Galette/Controllers/Crud/GroupsController.php
@@ -48,8 +48,6 @@ class GroupsController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function add(Request $request, Response $response): Response
     {
@@ -63,8 +61,6 @@ class GroupsController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param string   $name     Group name
-     *
-     * @return Response
      */
     public function doAdd(Request $request, Response $response, ?string $name = null): Response
     {
@@ -88,8 +84,6 @@ class GroupsController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function checkUniqueness(Request $request, Response $response): Response
     {
@@ -126,8 +120,6 @@ class GroupsController extends CrudController
      * @param Response        $response PSR Response
      * @param string|null     $option   One of 'page' or 'order'
      * @param int|string|null $value    Value of the option
-     *
-     * @return Response
      */
     public function list(
         Request $request,
@@ -169,8 +161,6 @@ class GroupsController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function reorderList(Request $request, Response $response): Response
     {
@@ -215,8 +205,6 @@ class GroupsController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function getGroup(Request $request, Response $response): Response
     {
@@ -247,8 +235,6 @@ class GroupsController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function simpleList(Request $request, Response $response): Response
     {
@@ -274,8 +260,6 @@ class GroupsController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function ajaxMembers(Request $request, Response $response): Response
     {
@@ -312,8 +296,6 @@ class GroupsController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function filter(Request $request, Response $response): Response
     {
@@ -330,8 +312,6 @@ class GroupsController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id       Record id
-     *
-     * @return Response
      */
     public function edit(Request $request, Response $response, int $id): Response
     {
@@ -377,8 +357,6 @@ class GroupsController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id       Group id
-     *
-     * @return Response
      */
     public function doEdit(Request $request, Response $response, int $id): Response
     {
@@ -449,8 +427,6 @@ class GroupsController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function reorder(Request $request, Response $response): Response
     {
@@ -495,8 +471,6 @@ class GroupsController extends CrudController
      * Get redirection URI
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function redirectUri(array $args): string
     {
@@ -507,8 +481,6 @@ class GroupsController extends CrudController
      * Get form URI
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function formUri(array $args): string
     {
@@ -522,8 +494,6 @@ class GroupsController extends CrudController
      * Get confirmation removal page title
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function confirmRemoveTitle(array $args): string
     {
@@ -539,8 +509,6 @@ class GroupsController extends CrudController
      *
      * @param array<string,mixed> $args Route arguments
      * @param array<string,mixed> $post POST values
-     *
-     * @return bool
      */
     protected function doDelete(array $args, array $post): bool
     {

--- a/galette/lib/Galette/Controllers/Crud/MailingsController.php
+++ b/galette/lib/Galette/Controllers/Crud/MailingsController.php
@@ -53,8 +53,6 @@ class MailingsController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function add(Request $request, Response $response): Response
     {
@@ -187,8 +185,6 @@ class MailingsController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function doAdd(Request $request, Response $response): Response
     {
@@ -389,8 +385,6 @@ class MailingsController extends CrudController
      * @param Response        $response PSR Response
      * @param string|null     $option   One of 'page' or 'order'
      * @param int|string|null $value    Value of the option
-     *
-     * @return Response
      */
     public function list(Request $request, Response $response, ?string $option = null, int|string|null $value = null): Response
     {
@@ -451,8 +445,6 @@ class MailingsController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function filter(Request $request, Response $response): Response
     {
@@ -507,8 +499,6 @@ class MailingsController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id       Record id
-     *
-     * @return Response
      */
     public function edit(Request $request, Response $response, int $id): Response
     {
@@ -522,8 +512,6 @@ class MailingsController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id       Record id
-     *
-     * @return Response
      */
     public function doEdit(Request $request, Response $response, int $id): Response
     {
@@ -538,8 +526,6 @@ class MailingsController extends CrudController
      * Get redirection URI
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function redirectUri(array $args): string
     {
@@ -550,8 +536,6 @@ class MailingsController extends CrudController
      * Get form URI
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function formUri(array $args): string
     {
@@ -565,8 +549,6 @@ class MailingsController extends CrudController
      * Get confirmation removal page title
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function confirmRemoveTitle(array $args): string
     {
@@ -581,8 +563,6 @@ class MailingsController extends CrudController
      *
      * @param array<string,mixed> $args Route arguments
      * @param array<string,mixed> $post POST values
-     *
-     * @return bool
      */
     protected function doDelete(array $args, array $post): bool
     {
@@ -598,8 +578,6 @@ class MailingsController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param ?int     $id       Mailing id
-     *
-     * @return Response
      */
     public function preview(Request $request, Response $response, ?int $id = null): Response
     {
@@ -672,8 +650,6 @@ class MailingsController extends CrudController
      * @param Response $response PSR Response
      * @param int      $id       Mailing id
      * @param int      $pos      Attachment position in list
-     *
-     * @return Response
      */
     public function previewAttachment(Request $request, Response $response, int $id, int $pos): Response
     {
@@ -695,8 +671,6 @@ class MailingsController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function setRecipients(Request $request, Response $response): Response
     {
@@ -736,8 +710,6 @@ class MailingsController extends CrudController
 
     /**
      * Get default filter name
-     *
-     * @return string
      */
     public function getDefaultFilterName(): string
     {

--- a/galette/lib/Galette/Controllers/Crud/MembersController.php
+++ b/galette/lib/Galette/Controllers/Crud/MembersController.php
@@ -69,8 +69,6 @@ class MembersController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function add(Request $request, Response $response): Response
     {
@@ -82,8 +80,6 @@ class MembersController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function addChild(Request $request, Response $response): Response
     {
@@ -101,8 +97,6 @@ class MembersController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function selfSubscribe(Request $request, Response $response): Response
     {
@@ -179,8 +173,6 @@ class MembersController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function doAdd(Request $request, Response $response): Response
     {
@@ -192,8 +184,6 @@ class MembersController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function doAddChild(Request $request, Response $response): Response
     {
@@ -211,8 +201,6 @@ class MembersController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function doSelfSubscribe(Request $request, Response $response): Response
     {
@@ -233,8 +221,6 @@ class MembersController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id_adh   Member ID to duplicate
-     *
-     * @return Response
      */
     public function duplicate(Request $request, Response $response, int $id_adh): Response
     {
@@ -258,8 +244,6 @@ class MembersController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id       Member ID
-     *
-     * @return Response
      */
     public function show(Request $request, Response $response, int $id): Response
     {
@@ -310,8 +294,6 @@ class MembersController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id       Member ID
-     *
-     * @return Response
      */
     public function vcard(Request $request, Response $response, int $id): Response
     {
@@ -345,8 +327,6 @@ class MembersController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function showMe(Request $request, Response $response): Response
     {
@@ -365,8 +345,6 @@ class MembersController extends CrudController
      * @param Response        $response PSR Response
      * @param string|null     $option   One of 'page' or 'order'
      * @param string|int|null $value    Value of the option
-     *
-     * @return Response
      */
     public function publicMembersList(
         Request $request,
@@ -396,8 +374,6 @@ class MembersController extends CrudController
      * @param Response        $response PSR Response
      * @param string|null     $option   One of 'page' or 'order'
      * @param string|int|null $value    Value of the option
-     *
-     * @return Response
      */
     public function publicMembersGallery(
         Request $request,
@@ -427,8 +403,6 @@ class MembersController extends CrudController
      * @param Response        $response PSR Response
      * @param string|null     $option   One of 'page' or 'order'
      * @param string|int|null $value    Value of the option
-     *
-     * @return Response
      */
     public function publicStaffList(
         Request $request,
@@ -463,8 +437,6 @@ class MembersController extends CrudController
      * @param Response        $response PSR Response
      * @param string|null     $option   One of 'page' or 'order'
      * @param string|int|null $value    Value of the option
-     *
-     * @return Response
      */
     public function publicStaffGallery(
         Request $request,
@@ -500,8 +472,6 @@ class MembersController extends CrudController
      * @param array<string, mixed> $args     Route arguments
      * @param string|null          $option   One of 'page' or 'order'
      * @param string|int|null      $value    Value of the option
-     *
-     * @return Response
      */
     private function publicList(
         Request $request,
@@ -558,8 +528,6 @@ class MembersController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function filterPublicMembersList(Request $request, Response $response): Response
     {
@@ -571,8 +539,6 @@ class MembersController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function filterPublicMembersGallery(Request $request, Response $response): Response
     {
@@ -586,8 +552,6 @@ class MembersController extends CrudController
      * @param Response $response PSR Response
      * @param string   $type     Type
      * @param string   $route    Filter route
-     *
-     * @return Response
      */
     private function filterPublicList(Request $request, Response $response, string $type, string $route): Response
     {
@@ -618,8 +582,6 @@ class MembersController extends CrudController
      * @param Response        $response PSR Response
      * @param string|null     $option   One of 'page' or 'order'
      * @param int|string|null $value    Value of the option
-     *
-     * @return Response
      */
     public function list(Request $request, Response $response, ?string $option = null, int|string|null $value = null): Response
     {
@@ -681,8 +643,6 @@ class MembersController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function filter(Request $request, Response $response): Response
     {
@@ -820,8 +780,6 @@ class MembersController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function advancedSearch(Request $request, Response $response): Response
     {
@@ -901,8 +859,6 @@ class MembersController extends CrudController
      * @param Response        $response PSR Response
      * @param string|null     $option   One of 'page' or 'order'
      * @param string|int|null $value    Value of the option
-     *
-     * @return Response
      */
     public function ajaxList(Request $request, Response $response, ?string $option = null, string|int|null $value = null): Response
     {
@@ -1032,8 +988,6 @@ class MembersController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function handleBatch(Request $request, Response $response): Response
     {
@@ -1091,8 +1045,6 @@ class MembersController extends CrudController
      * @param Response $response PSR Response
      * @param ?int     $id       Member id/array of members id
      * @param string   $action   null or 'add'
-     *
-     * @return Response
      */
     public function edit(
         Request $request,
@@ -1238,8 +1190,6 @@ class MembersController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id       Member id
-     *
-     * @return Response
      */
     public function doEdit(Request $request, Response $response, int $id): Response
     {
@@ -1251,8 +1201,6 @@ class MembersController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function massChange(Request $request, Response $response): Response
     {
@@ -1306,8 +1254,6 @@ class MembersController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function validateMassChange(Request $request, Response $response): Response
     {
@@ -1421,8 +1367,6 @@ class MembersController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function doMassChange(Request $request, Response $response): Response
     {
@@ -1609,8 +1553,6 @@ class MembersController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function store(Request $request, Response $response): Response
     {
@@ -1899,8 +1841,6 @@ class MembersController extends CrudController
      * Get redirection URI
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function redirectUri(array $args): string
     {
@@ -1911,8 +1851,6 @@ class MembersController extends CrudController
      * Get form URI
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function formUri(array $args): string
     {
@@ -1926,8 +1864,6 @@ class MembersController extends CrudController
      * Get confirmation removal page title
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function confirmRemoveTitle(array $args): string
     {
@@ -1955,8 +1891,6 @@ class MembersController extends CrudController
      *
      * @param array<string,mixed> $args Route arguments
      * @param array<string,mixed> $post POST values
-     *
-     * @return bool
      */
     protected function doDelete(array $args, array $post): bool
     {
@@ -1976,8 +1910,6 @@ class MembersController extends CrudController
 
     /**
      * Set self memebrship flag
-     *
-     * @return MembersController
      */
     private function setSelfMembership(): MembersController
     {
@@ -1987,8 +1919,6 @@ class MembersController extends CrudController
 
     /**
      * Is self membership?
-     *
-     * @return bool
      */
     private function isSelfMembership(): bool
     {
@@ -1997,8 +1927,6 @@ class MembersController extends CrudController
 
     /**
      * Set add child flag
-     *
-     * @return MembersController
      */
     private function setAddChild(): MembersController
     {
@@ -2008,8 +1936,6 @@ class MembersController extends CrudController
 
     /**
      * Is adding child?
-     *
-     * @return bool
      */
     private function isAddChild(): bool
     {
@@ -2073,8 +1999,6 @@ class MembersController extends CrudController
 
     /**
      * Get default filter name
-     *
-     * @return string
      */
     public static function getDefaultFilterName(): string
     {
@@ -2086,8 +2010,6 @@ class MembersController extends CrudController
      *
      * @param Response $response PSR Response
      * @param int      $id       Requested member id
-     *
-     * @return Response
      */
     private function redirectNoMember(Response $response, int $id): Response
     {

--- a/galette/lib/Galette/Controllers/Crud/PaymentTypeController.php
+++ b/galette/lib/Galette/Controllers/Crud/PaymentTypeController.php
@@ -44,8 +44,6 @@ class PaymentTypeController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function add(Request $request, Response $response): Response
     {
@@ -58,8 +56,6 @@ class PaymentTypeController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function doAdd(Request $request, Response $response): Response
     {
@@ -76,8 +72,6 @@ class PaymentTypeController extends CrudController
      * @param Response        $response PSR Response
      * @param string|null     $option   One of 'page' or 'order'
      * @param int|string|null $value    Value of the option
-     *
-     * @return Response
      */
     public function list(Request $request, Response $response, ?string $option = null, int|string|null $value = null): Response
     {
@@ -105,8 +99,6 @@ class PaymentTypeController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function filter(Request $request, Response $response): Response
     {
@@ -123,8 +115,6 @@ class PaymentTypeController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id       Type id
-     *
-     * @return Response
      */
     public function edit(Request $request, Response $response, int $id): Response
     {
@@ -151,8 +141,6 @@ class PaymentTypeController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id       Type id
-     *
-     * @return Response
      */
     public function doEdit(Request $request, Response $response, int $id): Response
     {
@@ -165,8 +153,6 @@ class PaymentTypeController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param ?int     $id       Type id
-     *
-     * @return Response
      */
     public function store(Request $request, Response $response, ?int $id = null): Response
     {
@@ -240,8 +226,6 @@ class PaymentTypeController extends CrudController
      * Get redirection URI
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function redirectUri(array $args): string
     {
@@ -252,8 +236,6 @@ class PaymentTypeController extends CrudController
      * Get form URI
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function formUri(array $args): string
     {
@@ -267,8 +249,6 @@ class PaymentTypeController extends CrudController
      * Get confirmation removal page title
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function confirmRemoveTitle(array $args): string
     {
@@ -284,8 +264,6 @@ class PaymentTypeController extends CrudController
      *
      * @param array<string,mixed> $args Route arguments
      * @param array<string,mixed> $post POST values
-     *
-     * @return bool
      */
     protected function doDelete(array $args, array $post): bool
     {

--- a/galette/lib/Galette/Controllers/Crud/SavedSearchesController.php
+++ b/galette/lib/Galette/Controllers/Crud/SavedSearchesController.php
@@ -49,8 +49,6 @@ class SavedSearchesController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function add(Request $request, Response $response): Response
     {
@@ -63,8 +61,6 @@ class SavedSearchesController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function doAdd(Request $request, Response $response): Response
     {
@@ -135,8 +131,6 @@ class SavedSearchesController extends CrudController
      * @param Response        $response PSR Response
      * @param string|null     $option   One of 'page' or 'order'
      * @param int|string|null $value    Value of the option
-     *
-     * @return Response
      */
     public function list(Request $request, Response $response, ?string $option = null, int|string|null $value = null): Response
     {
@@ -185,8 +179,6 @@ class SavedSearchesController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function filter(Request $request, Response $response): Response
     {
@@ -203,8 +195,6 @@ class SavedSearchesController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id       Record id
-     *
-     * @return Response
      */
     public function edit(Request $request, Response $response, int $id): Response
     {
@@ -218,8 +208,6 @@ class SavedSearchesController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id       Record id
-     *
-     * @return Response
      */
     public function doEdit(Request $request, Response $response, int $id): Response
     {
@@ -234,8 +222,6 @@ class SavedSearchesController extends CrudController
      * Get redirection URI
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function redirectUri(array $args): string
     {
@@ -246,8 +232,6 @@ class SavedSearchesController extends CrudController
      * Get form URI
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function formUri(array $args): string
     {
@@ -261,8 +245,6 @@ class SavedSearchesController extends CrudController
      * Get confirmation removal page title
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function confirmRemoveTitle(array $args): string
     {
@@ -283,8 +265,6 @@ class SavedSearchesController extends CrudController
      *
      * @param array<string,mixed> $args Route arguments
      * @param array<string,mixed> $post POST values
-     *
-     * @return bool
      */
     protected function doDelete(array $args, array $post): bool
     {
@@ -308,8 +288,6 @@ class SavedSearchesController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id       Saved search id
-     *
-     * @return Response
      */
     public function load(Request $request, Response $response, int $id): Response
     {
@@ -347,8 +325,6 @@ class SavedSearchesController extends CrudController
 
     /**
      * Get default filter name
-     *
-     * @return string
      */
     public static function getDefaultFilterName(): string
     {

--- a/galette/lib/Galette/Controllers/Crud/ScheduledPaymentController.php
+++ b/galette/lib/Galette/Controllers/Crud/ScheduledPaymentController.php
@@ -51,8 +51,6 @@ class ScheduledPaymentController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id_cotis Contribution id
-     *
-     * @return Response
      */
     public function add(Request $request, Response $response, int $id_cotis = 0): Response
     {
@@ -98,8 +96,6 @@ class ScheduledPaymentController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function doAdd(Request $request, Response $response): Response
     {
@@ -116,8 +112,6 @@ class ScheduledPaymentController extends CrudController
      * @param Response        $response PSR Response
      * @param string|null     $option   One of 'page' or 'order'
      * @param int|string|null $value    Value of the option
-     *
-     * @return Response
      */
     public function list(Request $request, Response $response, ?string $option = null, int|string|null $value = null): Response
     {
@@ -204,8 +198,6 @@ class ScheduledPaymentController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function myList(Request $request, Response $response): Response
     {
@@ -225,8 +217,6 @@ class ScheduledPaymentController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function myFilter(Request $request, Response $response): Response
     {
@@ -246,8 +236,6 @@ class ScheduledPaymentController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function filter(Request $request, Response $response): Response
     {
@@ -324,8 +312,6 @@ class ScheduledPaymentController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function handleBatch(Request $request, Response $response): Response
     {
@@ -369,8 +355,6 @@ class ScheduledPaymentController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id       Scheduled payment id
-     *
-     * @return Response
      */
     public function edit(Request $request, Response $response, int $id): Response
     {
@@ -401,8 +385,6 @@ class ScheduledPaymentController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id       Type id
-     *
-     * @return Response
      */
     public function doEdit(Request $request, Response $response, int $id): Response
     {
@@ -415,8 +397,6 @@ class ScheduledPaymentController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param ?int     $id       Type id
-     *
-     * @return Response
      */
     public function store(Request $request, Response $response, ?int $id = null): Response
     {
@@ -490,8 +470,6 @@ class ScheduledPaymentController extends CrudController
      * Get redirection URI
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function redirectUri(array $args): string
     {
@@ -502,8 +480,6 @@ class ScheduledPaymentController extends CrudController
      * Get form URI
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function formUri(array $args): string
     {
@@ -517,8 +493,6 @@ class ScheduledPaymentController extends CrudController
      * Get confirmation removal page title
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function confirmRemoveTitle(array $args): string
     {
@@ -530,8 +504,6 @@ class ScheduledPaymentController extends CrudController
      *
      * @param array<string,mixed> $args Route arguments
      * @param array<string,mixed> $post POST values
-     *
-     * @return bool
      */
     protected function doDelete(array $args, array $post): bool
     {
@@ -543,8 +515,6 @@ class ScheduledPaymentController extends CrudController
 
     /**
      * Get default filter name
-     *
-     * @return string
      */
     public static function getDefaultFilterName(): string
     {

--- a/galette/lib/Galette/Controllers/Crud/StatusController.php
+++ b/galette/lib/Galette/Controllers/Crud/StatusController.php
@@ -34,7 +34,7 @@ use Galette\Repository\Members;
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>
  *
- * @property int $id
+ * @property int    $id
  * @property string $label
  * @property string $libelle
  * @property string $priority
@@ -49,8 +49,6 @@ class StatusController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function add(Request $request, Response $response): Response
     {
@@ -63,8 +61,6 @@ class StatusController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function doAdd(Request $request, Response $response): Response
     {
@@ -81,8 +77,6 @@ class StatusController extends CrudController
      * @param Response        $response PSR Response
      * @param string|null     $option   One of 'page' or 'order'
      * @param int|string|null $value    Value of the option
-     *
-     * @return Response
      */
     public function list(
         Request $request,
@@ -121,8 +115,6 @@ class StatusController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function filter(Request $request, Response $response): Response
     {
@@ -139,8 +131,6 @@ class StatusController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id       Status id
-     *
-     * @return Response
      */
     public function edit(Request $request, Response $response, int $id): Response
     {
@@ -169,8 +159,6 @@ class StatusController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id       Status id
-     *
-     * @return Response
      */
     public function doEdit(Request $request, Response $response, int $id): Response
     {
@@ -184,8 +172,6 @@ class StatusController extends CrudController
      * @param Response $response PSR Response
      * @param ?int     $id       Status id
      * @param string   $action   Action
-     *
-     * @return Response
      */
     public function store(
         Request $request,
@@ -253,8 +239,6 @@ class StatusController extends CrudController
      * Get redirection URI
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function redirectUri(array $args): string
     {
@@ -265,8 +249,6 @@ class StatusController extends CrudController
      * Get form URI
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function formUri(array $args): string
     {
@@ -282,8 +264,6 @@ class StatusController extends CrudController
      * Get confirmation removal page title
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function confirmRemoveTitle(array $args): string
     {
@@ -302,8 +282,6 @@ class StatusController extends CrudController
      *
      * @param array<string,mixed> $args Route arguments
      * @param array<string,mixed> $post POST values
-     *
-     * @return bool
      */
     protected function doDelete(array $args, array $post): bool
     {

--- a/galette/lib/Galette/Controllers/Crud/TitlesController.php
+++ b/galette/lib/Galette/Controllers/Crud/TitlesController.php
@@ -44,8 +44,6 @@ class TitlesController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function add(Request $request, Response $response): Response
     {
@@ -58,8 +56,6 @@ class TitlesController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function doAdd(Request $request, Response $response): Response
     {
@@ -76,8 +72,6 @@ class TitlesController extends CrudController
      * @param Response        $response PSR Response
      * @param string|null     $option   One of 'page' or 'order'
      * @param int|string|null $value    Value of the option
-     *
-     * @return Response
      */
     public function list(Request $request, Response $response, ?string $option = null, int|string|null $value = null): Response
     {
@@ -100,8 +94,6 @@ class TitlesController extends CrudController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function filter(Request $request, Response $response): Response
     {
@@ -118,8 +110,6 @@ class TitlesController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id       Title id
-     *
-     * @return Response
      */
     public function edit(Request $request, Response $response, int $id): Response
     {
@@ -145,8 +135,6 @@ class TitlesController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id       Title id
-     *
-     * @return Response
      */
     public function doEdit(Request $request, Response $response, int $id): Response
     {
@@ -159,8 +147,6 @@ class TitlesController extends CrudController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param ?int     $id       Title id
-     *
-     * @return Response
      */
     public function store(Request $request, Response $response, ?int $id = null): Response
     {
@@ -233,8 +219,6 @@ class TitlesController extends CrudController
      * Get redirection URI
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function redirectUri(array $args): string
     {
@@ -245,8 +229,6 @@ class TitlesController extends CrudController
      * Get form URI
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function formUri(array $args): string
     {
@@ -260,8 +242,6 @@ class TitlesController extends CrudController
      * Get confirmation removal page title
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function confirmRemoveTitle(array $args): string
     {
@@ -277,8 +257,6 @@ class TitlesController extends CrudController
      *
      * @param array<string,mixed> $args Route arguments
      * @param array<string,mixed> $post POST values
-     *
-     * @return bool
      */
     protected function doDelete(array $args, array $post): bool
     {

--- a/galette/lib/Galette/Controllers/Crud/TransactionsController.php
+++ b/galette/lib/Galette/Controllers/Crud/TransactionsController.php
@@ -48,8 +48,6 @@ class TransactionsController extends ContributionsController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param ?string  $type     Contribution type
-     *
-     * @return Response
      */
     public function add(Request $request, Response $response, ?string $type = null): Response
     {
@@ -62,8 +60,6 @@ class TransactionsController extends ContributionsController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param ?string  $type     Contribution type
-     *
-     * @return Response
      */
     public function doAdd(Request $request, Response $response, ?string $type = null): Response
     {
@@ -99,8 +95,6 @@ class TransactionsController extends ContributionsController
      * @param Response $response PSR Response
      * @param ?int     $id       Transaction id
      * @param ?string  $action   Action
-     *
-     * @return Response
      */
     public function edit(Request $request, Response $response, ?int $id = null, ?string $action = 'edit'): Response
     {
@@ -219,8 +213,6 @@ class TransactionsController extends ContributionsController
      * @param Response $response PSR Response
      * @param int      $id       Transaction id
      * @param ?string  $type     Transaction type
-     *
-     * @return Response
      */
     public function doEdit(Request $request, Response $response, int $id, ?string $type = null): Response
     {
@@ -268,8 +260,6 @@ class TransactionsController extends ContributionsController
      * @param string      $action   Action ('edit' or 'add')
      * @param Transaction $trans    Transaction instance
      * @param ?int        $id       Contribution id
-     *
-     * @return Response
      */
     public function storeTransaction(Request $request, Response $response, string $action, Transaction $trans, ?int $id = null): Response
     {
@@ -366,8 +356,6 @@ class TransactionsController extends ContributionsController
      * @param Response $response PSR Response
      * @param int      $id       Transaction id
      * @param int      $cid      Contribution id
-     *
-     * @return Response
      */
     public function attach(Request $request, Response $response, int $id, int $cid): Response
     {
@@ -411,8 +399,6 @@ class TransactionsController extends ContributionsController
      * @param Response $response PSR Response
      * @param int      $id       Transaction id
      * @param int      $cid      Contribution id
-     *
-     * @return Response
      */
     public function detach(Request $request, Response $response, int $id, int $cid): Response
     {

--- a/galette/lib/Galette/Controllers/CrudController.php
+++ b/galette/lib/Galette/Controllers/CrudController.php
@@ -43,8 +43,6 @@ abstract class CrudController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     abstract public function add(Request $request, Response $response): Response;
 
@@ -53,8 +51,6 @@ abstract class CrudController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     abstract public function doAdd(Request $request, Response $response): Response;
 
@@ -68,8 +64,6 @@ abstract class CrudController extends AbstractController
      * @param Response        $response PSR Response
      * @param string|null     $option   One of 'page' or 'order'
      * @param int|string|null $value    Value of the option
-     *
-     * @return Response
      */
     abstract public function list(Request $request, Response $response, ?string $option = null, int|string|null $value = null): Response;
 
@@ -78,8 +72,6 @@ abstract class CrudController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     abstract public function filter(Request $request, Response $response): Response;
 
@@ -92,8 +84,6 @@ abstract class CrudController extends AbstractController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id       Record id
-     *
-     * @return Response
      */
     abstract public function edit(Request $request, Response $response, int $id): Response;
 
@@ -103,8 +93,6 @@ abstract class CrudController extends AbstractController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id       Record id
-     *
-     * @return Response
      */
     abstract public function doEdit(Request $request, Response $response, int $id): Response;
 
@@ -116,8 +104,6 @@ abstract class CrudController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function confirmDelete(Request $request, Response $response): Response
     {
@@ -213,8 +199,6 @@ abstract class CrudController extends AbstractController
      * Get redirection URI
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     abstract public function redirectUri(array $args): string;
 
@@ -222,8 +206,6 @@ abstract class CrudController extends AbstractController
      * Get cancel URI
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     public function cancelUri(array $args): string
     {
@@ -234,8 +216,6 @@ abstract class CrudController extends AbstractController
      * Get form URI
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     abstract public function formUri(array $args): string;
 
@@ -243,8 +223,6 @@ abstract class CrudController extends AbstractController
      * Get confirmation removal page title
      *
      * @param array<string,mixed> $args Route arguments
-     *
-     * @return string
      */
     abstract public function confirmRemoveTitle(array $args): string;
 
@@ -253,8 +231,6 @@ abstract class CrudController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function delete(Request $request, Response $response): Response
     {
@@ -310,8 +286,6 @@ abstract class CrudController extends AbstractController
      *
      * @param array<string,mixed> $args Route arguments
      * @param array<string,mixed> $post POST values
-     *
-     * @return bool
      */
     abstract protected function doDelete(array $args, array $post): bool;
     // /CRUD - Delete

--- a/galette/lib/Galette/Controllers/CsvController.php
+++ b/galette/lib/Galette/Controllers/CsvController.php
@@ -69,8 +69,6 @@ class CsvController extends AbstractController
      * @param Response $response PSR Response
      * @param string   $filepath File path on disk
      * @param string   $filename File name for output
-     *
-     * @return Response
      */
     protected function sendResponse(Response $response, string $filepath, string $filename): Response
     {
@@ -105,8 +103,6 @@ class CsvController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function export(Request $request, Response $response): Response
     {
@@ -137,8 +133,6 @@ class CsvController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function doExport(Request $request, Response $response): Response
     {
@@ -240,8 +234,6 @@ class CsvController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function import(Request $request, Response $response): Response
     {
@@ -267,8 +259,6 @@ class CsvController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function doImports(Request $request, Response $response): Response
     {
@@ -330,8 +320,6 @@ class CsvController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function uploadImportFile(Request $request, Response $response): Response
     {
@@ -368,8 +356,6 @@ class CsvController extends AbstractController
      * @param Response $response PSR Response
      * @param string   $file     File name
      * @param string   $type     File type
-     *
-     * @return Response
      */
     public function getFile(Request $request, Response $response, string $file, string $type): Response
     {
@@ -387,8 +373,6 @@ class CsvController extends AbstractController
      * @param Response $response PSR Response
      * @param string   $file     File name
      * @param string   $type     File type
-     *
-     * @return Response
      */
     public function confirmRemoveFile(
         Request $request,
@@ -434,8 +418,6 @@ class CsvController extends AbstractController
      * @param Response $response PSR Response
      * @param string   $file     File name
      * @param string   $type     File type
-     *
-     * @return Response
      */
     public function removeFile(Request $request, Response $response, string $file, string $type): Response
     {
@@ -495,8 +477,6 @@ class CsvController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function importModel(Request $request, Response $response): Response
     {
@@ -562,8 +542,6 @@ class CsvController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function getImportModel(Request $request, Response $response): Response
     {
@@ -607,8 +585,6 @@ class CsvController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function storeModel(Request $request, Response $response): Response
     {
@@ -639,8 +615,6 @@ class CsvController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function membersExport(Request $request, Response $response): Response
     {
@@ -663,8 +637,6 @@ class CsvController extends AbstractController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param string   $type     One of 'contributions' or 'transactions'
-     *
-     * @return Response
      */
     public function contributionsExport(Request $request, Response $response, string $type): Response
     {
@@ -693,8 +665,6 @@ class CsvController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function scheduledPaymentsExport(Request $request, Response $response): Response
     {

--- a/galette/lib/Galette/Controllers/DynamicTranslationsController.php
+++ b/galette/lib/Galette/Controllers/DynamicTranslationsController.php
@@ -44,8 +44,6 @@ class DynamicTranslationsController extends AbstractController
      * @param Request  $request   PSR Request
      * @param Response $response  PSR Response
      * @param ?string  $text_orig Original text
-     *
-     * @return Response
      */
     public function dynamicTranslations(Request $request, Response $response, ?string $text_orig = null): Response
     {
@@ -62,8 +60,6 @@ class DynamicTranslationsController extends AbstractController
      * @param Request  $request       PSR Request
      * @param Response $response      PSR Response
      * @param string   $text_orig_sum Original text MD5 sum
-     *
-     * @return Response
      */
     public function dynamicTranslation(Request $request, Response $response, string $text_orig_sum): Response
     {
@@ -118,8 +114,6 @@ class DynamicTranslationsController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function doDynamicTranslations(Request $request, Response $response): Response
     {

--- a/galette/lib/Galette/Controllers/GaletteController.php
+++ b/galette/lib/Galette/Controllers/GaletteController.php
@@ -60,8 +60,6 @@ class GaletteController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function slash(Request $request, Response $response): Response
     {
@@ -73,8 +71,6 @@ class GaletteController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function systemInformation(Request $request, Response $response): Response
     {
@@ -103,8 +99,6 @@ class GaletteController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function dashboard(Request $request, Response $response): Response
     {
@@ -147,8 +141,6 @@ class GaletteController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function preferences(Request $request, Response $response): Response
     {
@@ -235,8 +227,6 @@ class GaletteController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function storePreferences(Request $request, Response $response): Response
     {
@@ -312,8 +302,6 @@ class GaletteController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function testEmail(Request $request, Response $response): Response
     {
@@ -381,8 +369,6 @@ class GaletteController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function charts(Request $request, Response $response): Response
     {
@@ -414,8 +400,6 @@ class GaletteController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function configureCoreFields(Request $request, Response $response): Response
     {
@@ -445,8 +429,6 @@ class GaletteController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function storeCoreFieldsConfig(Request $request, Response $response): Response
     {
@@ -499,8 +481,6 @@ class GaletteController extends AbstractController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param string   $table    Tbale name
-     *
-     * @return Response
      */
     public function configureListFields(Request $request, Response $response, string $table): Response
     {
@@ -530,8 +510,6 @@ class GaletteController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function storeListFields(Request $request, Response $response): Response
     {
@@ -566,8 +544,6 @@ class GaletteController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function reminders(Request $request, Response $response): Response
     {
@@ -603,8 +579,6 @@ class GaletteController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function doReminders(Request $request, Response $response): Response
     {
@@ -713,8 +687,6 @@ class GaletteController extends AbstractController
      * @param Response $response   PSR Response
      * @param string   $membership Either 'late' or 'nearly'
      * @param string   $mail       Either 'withmail' or 'withoutmail'
-     *
-     * @return Response
      */
     public function filterReminders(Request $request, Response $response, string $membership, string $mail): Response
     {
@@ -743,8 +715,6 @@ class GaletteController extends AbstractController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param string   $hash     Hash
-     *
-     * @return Response
      */
     public function documentLink(Request $request, Response $response, string $hash): Response
     {
@@ -765,8 +735,6 @@ class GaletteController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function empty(Request $request, Response $response): Response
     {

--- a/galette/lib/Galette/Controllers/HistoryController.php
+++ b/galette/lib/Galette/Controllers/HistoryController.php
@@ -45,8 +45,6 @@ class HistoryController extends AbstractController
      * @param Response        $response PSR Response
      * @param string|null     $option   One of 'page' or 'order'
      * @param string|int|null $value    Value of the option
-     *
-     * @return Response
      */
     public function list(
         Request $request,
@@ -101,8 +99,6 @@ class HistoryController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function historyFilter(Request $request, Response $response): Response
     {
@@ -151,8 +147,6 @@ class HistoryController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function flushHistory(Request $request, Response $response): Response
     {
@@ -213,8 +207,6 @@ class HistoryController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function confirmHistoryFlush(Request $request, Response $response): Response
     {
@@ -239,8 +231,6 @@ class HistoryController extends AbstractController
 
     /**
      * Get default filter name
-     *
-     * @return string
      */
     public static function getDefaultFilterName(): string
     {

--- a/galette/lib/Galette/Controllers/ImagesController.php
+++ b/galette/lib/Galette/Controllers/ImagesController.php
@@ -46,8 +46,6 @@ class ImagesController extends AbstractController
      *
      * @param Response $response PSR Response
      * @param Picture  $picture  Picture to output
-     *
-     * @return Response
      */
     protected function sendResponse(Response $response, Picture $picture): Response
     {
@@ -69,8 +67,6 @@ class ImagesController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function logo(Request $request, Response $response): Response
     {
@@ -82,8 +78,6 @@ class ImagesController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function printLogo(Request $request, Response $response): Response
     {
@@ -96,8 +90,6 @@ class ImagesController extends AbstractController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id       Member id
-     *
-     * @return Response
      */
     public function photo(Request $request, Response $response, int $id): Response
     {

--- a/galette/lib/Galette/Controllers/PdfController.php
+++ b/galette/lib/Galette/Controllers/PdfController.php
@@ -57,8 +57,6 @@ class PdfController extends AbstractController
      *
      * @param Response $response PSR Response
      * @param Pdf      $pdf      PDF to output
-     *
-     * @return Response
      */
     protected function sendResponse(Response $response, Pdf $pdf): Response
     {
@@ -75,8 +73,6 @@ class PdfController extends AbstractController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param ?int     $id_adh   Member id
-     *
-     * @return Response
      */
     public function membersCards(Request $request, Response $response, ?int $id_adh = null): Response
     {
@@ -167,8 +163,6 @@ class PdfController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function membersLabels(Request $request, Response $response): Response
     {
@@ -229,8 +223,6 @@ class PdfController extends AbstractController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param ?int     $id_adh   Member id
-     *
-     * @return Response
      */
     public function adhesionForm(Request $request, Response $response, ?int $id_adh = null): Response
     {
@@ -255,8 +247,6 @@ class PdfController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function attendanceSheetConfig(Request $request, Response $response): Response
     {
@@ -304,8 +294,6 @@ class PdfController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function attendanceSheet(Request $request, Response $response): Response
     {
@@ -366,8 +354,6 @@ class PdfController extends AbstractController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param int      $id       Contribution id
-     *
-     * @return Response
      */
     public function contribution(Request $request, Response $response, int $id): Response
     {
@@ -400,8 +386,6 @@ class PdfController extends AbstractController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param ?int     $id       Group id
-     *
-     * @return Response
      */
     public function group(Request $request, Response $response, ?int $id = null): Response
     {
@@ -434,8 +418,6 @@ class PdfController extends AbstractController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param ?int     $id       Model id
-     *
-     * @return Response
      */
     public function models(Request $request, Response $response, ?int $id = null): Response
     {
@@ -492,8 +474,6 @@ class PdfController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function storeModels(Request $request, Response $response): Response
     {
@@ -559,8 +539,6 @@ class PdfController extends AbstractController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param string   $hash     Hash
-     *
-     * @return Response
      */
     public function directlinkDocument(Request $request, Response $response, string $hash): Response
     {

--- a/galette/lib/Galette/Controllers/PluginsController.php
+++ b/galette/lib/Galette/Controllers/PluginsController.php
@@ -47,8 +47,6 @@ class PluginsController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function showPlugins(Request $request, Response $response): Response
     {
@@ -78,8 +76,6 @@ class PluginsController extends AbstractController
      * @param Response $response  PSR Response
      * @param string   $action    Action
      * @param string   $module_id Module id
-     *
-     * @return Response
      */
     public function togglePlugin(Request $request, Response $response, string $action, string $module_id): Response
     {
@@ -133,8 +129,6 @@ class PluginsController extends AbstractController
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
      * @param string   $id       Plugin id
-     *
-     * @return Response
      */
     public function initPluginDb(Request $request, Response $response, string $id): Response
     {

--- a/galette/lib/Galette/Controllers/TextController.php
+++ b/galette/lib/Galette/Controllers/TextController.php
@@ -42,8 +42,6 @@ class TextController extends AbstractController
      * @param Response $response PSR Response
      * @param ?string  $lang     Language
      * @param ?string  $ref      Ref code
-     *
-     * @return Response
      */
     public function list(Request $request, Response $response, ?string $lang = null, ?string $ref = null): Response
     {
@@ -86,8 +84,6 @@ class TextController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function change(Request $request, Response $response): Response
     {
@@ -111,8 +107,6 @@ class TextController extends AbstractController
      *
      * @param Request  $request  PSR Request
      * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function edit(Request $request, Response $response): Response
     {

--- a/galette/lib/Galette/Converter/ImageConverter.php
+++ b/galette/lib/Galette/Converter/ImageConverter.php
@@ -38,8 +38,6 @@ class ImageConverter extends \League\HTMLToMarkdown\Converter\ImageConverter
      * Converts IMG element to markdown.
      *
      * @param ElementInterface $element Element to convert
-     *
-     * @return string
      */
     public function convert(ElementInterface $element): string
     {

--- a/galette/lib/Galette/Core/AbstractPassword.php
+++ b/galette/lib/Galette/Core/AbstractPassword.php
@@ -66,15 +66,11 @@ abstract class AbstractPassword
      * Generates a new password for specified member
      *
      * @param int $id_adh Member identifier
-     *
-     * @return bool
      */
     abstract public function generateNewPassword(int $id_adh): bool;
 
     /**
      * Remove expired passwords queries (older than 24 hours)
-     *
-     * @return bool
      */
     abstract protected function cleanExpired(): bool;
 
@@ -102,8 +98,6 @@ abstract class AbstractPassword
      * Set password
      *
      * @param string $password Password
-     *
-     * @return self
      */
     protected function setPassword(string $password): self
     {
@@ -115,8 +109,6 @@ abstract class AbstractPassword
      * Set hash
      *
      * @param string $hash Hash
-     *
-     * @return self
      */
     protected function setHash(string $hash): self
     {

--- a/galette/lib/Galette/Core/Authentication.php
+++ b/galette/lib/Galette/Core/Authentication.php
@@ -30,12 +30,12 @@ use Galette\Entity\Group;
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>
  *
- * @property  ?string $login
- * @property  ?string $name
- * @property  ?string $surname
- * @property  ?int $id
- * @property  string $lang
- * @property  array<int, Group|int> $managed_groups
+ * @property ?string               $login
+ * @property ?string               $name
+ * @property ?string               $surname
+ * @property ?int                  $id
+ * @property string                $lang
+ * @property array<int, Group|int> $managed_groups
  */
 
 abstract class Authentication
@@ -67,8 +67,6 @@ abstract class Authentication
      *
      * @param string $user  user's login
      * @param string $passe user's password
-     *
-     * @return bool
      */
     abstract public function logIn(string $user, string $passe): bool;
 
@@ -76,8 +74,6 @@ abstract class Authentication
      * Does this login already exist?
      *
      * @param string $user the username
-     *
-     * @return bool
      */
     abstract public function loginExists(string $user): bool;
 
@@ -86,8 +82,6 @@ abstract class Authentication
      *
      * @param string      $login       name
      * @param Preferences $preferences Preferences instance
-     *
-     * @return bool
      */
     public function logAdmin(string $login, Preferences $preferences): bool
     {
@@ -110,15 +104,11 @@ abstract class Authentication
      *
      * @param string      $name        Service name
      * @param Preferences $preferences Preferences instance
-     *
-     * @return bool
      */
     abstract public function logCron(string $name, Preferences $preferences): bool;
 
     /**
      * Log out user and unset variables
-     *
-     * @return bool
      */
     public function logOut(): bool
     {
@@ -137,8 +127,6 @@ abstract class Authentication
 
     /**
      * Is user logged in?
-     *
-     * @return bool
      */
     public function isLogged(): bool
     {
@@ -147,8 +135,6 @@ abstract class Authentication
 
     /**
      * Is user admin?
-     *
-     * @return bool
      */
     public function isAdmin(): bool
     {
@@ -157,8 +143,6 @@ abstract class Authentication
 
     /**
      * Is user super admin?
-     *
-     * @return bool
      */
     public function isSuperAdmin(): bool
     {
@@ -167,8 +151,6 @@ abstract class Authentication
 
     /**
      * Is user active?
-     *
-     * @return bool
      */
     public function isActive(): bool
     {
@@ -177,8 +159,6 @@ abstract class Authentication
 
     /**
      * Is user member of staff?
-     *
-     * @return bool
      */
     public function isStaff(): bool
     {
@@ -187,8 +167,6 @@ abstract class Authentication
 
     /**
      * is user a crontab?
-     *
-     * @return bool
      */
     public function isCron(): bool
     {
@@ -201,8 +179,6 @@ abstract class Authentication
      * least one group.
      *
      * @param array<int>|int $id_group Group(s) identifier(s)
-     *
-     * @return bool
      */
     public function isGroupManager(array|int|null $id_group = null): bool
     {
@@ -238,8 +214,6 @@ abstract class Authentication
 
     /**
      * Get compact menu mode
-     *
-     * @return bool
      */
     public function getCompactMenu(): bool
     {
@@ -248,8 +222,6 @@ abstract class Authentication
 
     /**
      * Is dark mode enabled?
-     *
-     * @return bool
      */
     public function isDarkModeEnabled(): bool
     {
@@ -260,8 +232,6 @@ abstract class Authentication
      * Is user currently up to date?
      * An up-to-date member is active and either due free, or with up-to-date
      * subscription
-     *
-     * @return bool
      */
     public function isUp2Date(): bool
     {
@@ -272,8 +242,6 @@ abstract class Authentication
      * Display logged in member name
      *
      * @param bool $only_name If we want only the name without any additional text
-     *
-     * @return string
      */
     public function loggedInAs(bool $only_name = false): string
     {
@@ -293,8 +261,6 @@ abstract class Authentication
      * Global getter method
      *
      * @param string $name name of the property we want to retrieve
-     *
-     * @return mixed
      */
     public function __get(string $name): mixed
     {
@@ -325,8 +291,6 @@ abstract class Authentication
      * Required for twig to access properties via __get
      *
      * @param string $name name of the property we want to retrieve
-     *
-     * @return bool
      */
     public function __isset(string $name): bool
     {
@@ -337,8 +301,6 @@ abstract class Authentication
 
     /**
      * get user access level
-     *
-     * @return int
      */
     public function getAccessLevel(): int
     {

--- a/galette/lib/Galette/Core/CheckModules.php
+++ b/galette/lib/Galette/Core/CheckModules.php
@@ -72,8 +72,6 @@ class CheckModules
      * - missing: required modules that are missing
      *
      * @param bool $translated Use translations (default to true)
-     *
-     * @return void
      */
     public function doCheck(bool $translated = true): void
     {
@@ -112,8 +110,6 @@ class CheckModules
      * HTML formatted results for checks
      *
      * @param bool $translated Use translations (default to true)
-     *
-     * @return string
      */
     public function toHtml(bool $translated = true): string
     {
@@ -150,8 +146,6 @@ class CheckModules
 
     /**
      * Check if it is ok to use Galette with current modules
-     *
-     * @return bool
      */
     public function isValid(): bool
     {
@@ -162,8 +156,6 @@ class CheckModules
      * Check if a specific module is OK for that instance
      *
      * @param string $module Module name to check
-     *
-     * @return bool
      */
     public function isGood(string $module): bool
     {
@@ -204,8 +196,6 @@ class CheckModules
      * Check if a module is loaded
      *
      * @param string $ext Module name
-     *
-     * @return bool
      */
     protected function isExtensionLoaded(string $ext): bool
     {

--- a/galette/lib/Galette/Core/Db.php
+++ b/galette/lib/Galette/Core/Db.php
@@ -52,13 +52,13 @@ use function Safe\preg_replace;
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>
  *
- * @property Adapter $db
- * @property Sql $sql
- * @property DriverInterface $driver
+ * @property Adapter            $db
+ * @property Sql                $sql
+ * @property DriverInterface    $driver
  * @property AbstractConnection $connection
- * @property PlatformInterface $platform
- * @property string $query_string
- * @property string $type_db
+ * @property PlatformInterface  $platform
+ * @property string             $query_string
+ * @property string             $type_db
  */
 class Db
 {
@@ -141,8 +141,6 @@ class Db
 
     /**
      * Do database connection
-     *
-     * @return void
      */
     private function doConnection(): void
     {
@@ -172,8 +170,6 @@ class Db
      * Connect again to the database on wakeup
      *
      * @param array<string, mixed> $data Date to unserialize
-     *
-     * @return void
      */
     public function __unserialize(array $data): void
     {
@@ -187,9 +183,7 @@ class Db
      *
      * @param bool $check_table Check if table exists, defaults to false
      *
-     * @return string
-     *
-     * @throw LogicException
+     * @throws LogicException
      */
     public function getDbVersion(bool $check_table = false): string
     {
@@ -224,8 +218,6 @@ class Db
 
     /**
      * Check if database version suits our needs
-     *
-     * @return bool
      */
     public function checkDbVersion(): bool
     {
@@ -248,8 +240,6 @@ class Db
      * Perform a select query on the whole table
      *
      * @param string $table Table name
-     *
-     * @return ResultSet
      */
     public function selectAll(string $table): ResultSet
     {
@@ -268,8 +258,6 @@ class Db
      * @param ?string $host which host we want to connect to
      * @param ?string $port which tcp port we want to connect to
      * @param ?string $db   database name
-     *
-     * @return bool
      *
      * @throws Exception|Throwable
      */
@@ -316,8 +304,6 @@ class Db
 
     /**
      * Drop test table if it exists, so we can make all checks.
-     *
-     * @return void
      */
     public function dropTestTable(): void
     {
@@ -528,8 +514,6 @@ class Db
      * Does a given table exists?
      *
      * @param string $name Table name
-     *
-     * @return bool
      */
     public function tableExists(string $name): bool
     {
@@ -565,8 +549,6 @@ class Db
      *
      * @param ?string $prefix       Specified table prefix
      * @param bool    $content_only Proceed only content (no table conversion)
-     *
-     * @return void
      */
     public function convertToUTF(?string $prefix = null, bool $content_only = false): void
     {
@@ -624,8 +606,6 @@ class Db
      *
      * @param string $prefix Specified table prefix
      * @param string $table  the table we want to convert datas from
-     *
-     * @return void
      */
     private function convertContentToUTF(string $prefix, string $table): void
     {
@@ -716,8 +696,6 @@ class Db
 
     /**
      * Is current database using Postgresql?
-     *
-     * @return bool
      */
     public function isPostgres(): bool
     {
@@ -729,8 +707,6 @@ class Db
      *
      * @param string  $table Table name, without prefix
      * @param ?string $alias Tables alias, optional
-     *
-     * @return Select
      */
     public function select(string $table, ?string $alias = null): Select
     {
@@ -752,8 +728,6 @@ class Db
      * Instanciate an insert query
      *
      * @param string $table Table name, without prefix
-     *
-     * @return Insert
      */
     public function insert(string $table): Insert
     {
@@ -766,8 +740,6 @@ class Db
      * Instanciate an update query
      *
      * @param string $table Table name, without prefix
-     *
-     * @return Update
      */
     public function update(string $table): Update
     {
@@ -780,8 +752,6 @@ class Db
      * Instanciate a delete query
      *
      * @param string $table Table name, without prefix
-     *
-     * @return Delete
      */
     public function delete(string $table): Delete
     {
@@ -795,7 +765,6 @@ class Db
      *
      * @param SqlInterface $sql SQL object
      *
-     * @return ResultSet|Result
      * @throws Throwable
      */
     public function execute(SqlInterface $sql): ResultSet|Result
@@ -829,7 +798,6 @@ class Db
      *
      * @param string $name name of the variable we want to retrieve
      *
-     * @return mixed
      * @throws RuntimeException
      */
     public function __get(string $name): mixed
@@ -851,8 +819,6 @@ class Db
      * Required for twig to access properties via __get
      *
      * @param string $name name of the variable we want to retrieve
-     *
-     * @return bool
      */
     public function __isset(string $name): bool
     {
@@ -921,8 +887,6 @@ class Db
      * @param string $table    Table name
      * @param string $pkcol    Primary key column name
      * @param int    $expected Expected sequence value
-     *
-     * @return void
      */
     public function handleSequence(string $table, string $pkcol, int $expected): void
     {
@@ -951,8 +915,6 @@ class Db
      * @param string $table    Table name
      * @param string $pkcol    Primary key column name
      * @param bool   $prefixed Whether to prefix the sequence name
-     *
-     * @return string
      */
     public function getSequenceName(string $table, string $pkcol, bool $prefixed = false): string
     {
@@ -969,8 +931,6 @@ class Db
      *
      * @param SqlInterface $sql       SQL object
      * @param Throwable    $exception Exception to check
-     *
-     * @return bool
      */
     public function isDuplicateException(SqlInterface $sql, Throwable $exception): bool
     {
@@ -986,8 +946,6 @@ class Db
      * Check if current exception is related to a remaining foreign key
      *
      * @param Throwable $exception Exception to check
-     *
-     * @return bool
      */
     public function isForeignKeyException(Throwable $exception): bool
     {
@@ -1004,8 +962,6 @@ class Db
      *
      * @param string $table   Table name, without prefix
      * @param bool   $maymiss Whether the table can be missing, defaults to false
-     *
-     * @return void
      */
     public function drop(string $table, bool $maymiss = false): void
     {
@@ -1024,8 +980,6 @@ class Db
      * Log queries in specific file
      *
      * @param string $query Query to add in logs
-     *
-     * @return void
      */
     protected function log(string $query): void
     {
@@ -1039,8 +993,6 @@ class Db
      * Get last generated value
      *
      * @param object $entity Entity instance
-     *
-     * @return int
      */
     public function getLastGeneratedValue(object $entity): int
     {
@@ -1071,8 +1023,6 @@ class Db
 
     /**
      * Is current database engine supported?
-     *
-     * @return bool
      */
     public function isEngineSUpported(): bool
     {
@@ -1090,8 +1040,6 @@ class Db
 
     /**
      * Get not supported database version message
-     *
-     * @return string
      */
     public function getUnsupportedMessage(): string
     {

--- a/galette/lib/Galette/Core/Galette.php
+++ b/galette/lib/Galette/Core/Galette.php
@@ -52,8 +52,6 @@ class Galette
      * Retrieve Galette version from git, if present.
      *
      * @param bool $time Include time and timezone. Defaults to false.
-     *
-     * @return string
      */
     public static function gitVersion(bool $time = false): string
     {
@@ -1188,8 +1186,6 @@ class Galette
 
     /**
      * Is demonstration mode enabled
-     *
-     * @return bool
      */
     public static function isDemo(): bool
     {
@@ -1198,8 +1194,6 @@ class Galette
 
     /**
      * Is debug mode enabled
-     *
-     * @return bool
      */
     public static function isDebugEnabled(): bool
     {
@@ -1217,8 +1211,6 @@ class Galette
 
     /**
      * Is SQL debug mode enabled
-     *
-     * @return bool
      */
     public static function isSqlDebugEnabled(): bool
     {
@@ -1227,8 +1219,6 @@ class Galette
 
     /**
      * Is a nightly build
-     *
-     * @return bool
      */
     public static function isNightly(): bool
     {
@@ -1239,8 +1229,6 @@ class Galette
      * Check if a string is serialized
      *
      * @param string $string String to check
-     *
-     * @return bool
      */
     public static function isSerialized(string $string): bool
     {
@@ -1270,7 +1258,6 @@ class Galette
      *
      * @param array<string|int, mixed>|object $data Data to encode
      *
-     * @return string
      * @throws RuntimeException
      */
     public static function jsonEncode(array|object $data): string

--- a/galette/lib/Galette/Core/GaletteMail.php
+++ b/galette/lib/Galette/Core/GaletteMail.php
@@ -87,8 +87,6 @@ class GaletteMail
 
     /**
      * Initialize PHPMailer
-     *
-     * @return void
      */
     private function initMailer(): void
     {
@@ -186,8 +184,6 @@ class GaletteMail
      * regular recipient will be the sender.
      *
      * @param array<string, string> $recipients Array (mail=>name) of all recipients
-     *
-     * @return bool
      */
     public function setRecipients(array $recipients): bool
     {
@@ -343,8 +339,6 @@ class GaletteMail
      * Check if an email address is valid
      *
      * @param string $address the email address to check
-     *
-     * @return bool
      */
     public static function isValidEmail(string $address): bool
     {
@@ -362,8 +356,6 @@ class GaletteMail
      * Check if a string is a URL
      *
      * @param string $url the URL to check
-     *
-     * @return bool
      */
     public static function isUrl(string $url): bool
     {
@@ -409,8 +401,6 @@ class GaletteMail
      * Is the email HTML formatted?
      *
      * @param ?bool $set The value to set
-     *
-     * @return bool
      */
     public function isHTML(?bool $set = null): bool
     {
@@ -422,8 +412,6 @@ class GaletteMail
 
     /**
      * Get sender name
-     *
-     * @return string
      */
     public function getSenderName(): string
     {
@@ -432,8 +420,6 @@ class GaletteMail
 
     /**
      * Get sender address
-     *
-     * @return string
      */
     public function getSenderAddress(): string
     {
@@ -495,8 +481,6 @@ class GaletteMail
      * Sets the subject
      *
      * @param string $subject The subject
-     *
-     * @return self
      */
     public function setSubject(string $subject): self
     {
@@ -508,8 +492,6 @@ class GaletteMail
      * Sets the message
      *
      * @param string $message The message
-     *
-     * @return self
      */
     public function setMessage(string $message): self
     {
@@ -522,8 +504,6 @@ class GaletteMail
      *
      * @param string $name    Sender name
      * @param string $address Sender address
-     *
-     * @return self
      */
     public function setSender(string $name, string $address): self
     {
@@ -536,8 +516,6 @@ class GaletteMail
      * Set timeout on SMTP connexion
      *
      * @param int $timeout SMTP timeout
-     *
-     * @return self
      */
     public function setTimeout(int $timeout): self
     {

--- a/galette/lib/Galette/Core/GalettePlugin.php
+++ b/galette/lib/Galette/Core/GalettePlugin.php
@@ -181,8 +181,6 @@ abstract class GalettePlugin
 
     /**
      * Get news for this plugin
-     *
-     * @return ?Entry
      */
     public function getNews(): ?Entry
     {
@@ -192,8 +190,6 @@ abstract class GalettePlugin
 
     /**
      * Is the plugin fully installed (including database, extra configuration, etc)?
-     *
-     * @return bool
      */
     public function isInstalled(): bool
     {

--- a/galette/lib/Galette/Core/Gaptcha.php
+++ b/galette/lib/Galette/Core/Gaptcha.php
@@ -65,8 +65,6 @@ class Gaptcha
 
     /**
      * Get question phrase
-     *
-     * @return string
      */
     public function getQuestion(): string
     {
@@ -89,8 +87,6 @@ class Gaptcha
 
     /**
      * Generate captcha question to display
-     *
-     * @return string
      */
     public function generateQuestion(): string
     {
@@ -106,8 +102,6 @@ class Gaptcha
      * Checks captcha validity
      *
      * @param int $gaptcha User entry
-     *
-     * @return bool
      */
     public function check(int $gaptcha): bool
     {

--- a/galette/lib/Galette/Core/History.php
+++ b/galette/lib/Galette/Core/History.php
@@ -78,8 +78,6 @@ class History
      * X-Forwarded-For, if present and the configuration specifies it.
      * (blindly trusting X-Forwarded-For would make the IP address logging
      * very easy to deveive.
-     *
-     * @return string
      */
     public static function findUserIPAddress(): string
     {
@@ -142,8 +140,6 @@ class History
 
     /**
      * Delete all entries
-     *
-     * @return bool
      */
     public function clean(): bool
     {
@@ -203,8 +199,6 @@ class History
      * Builds users and actions lists
      *
      * @param Select $select Original select
-     *
-     * @return void
      */
     private function buildLists(Select $select): void
     {
@@ -285,8 +279,6 @@ class History
      * Builds where clause, for filtering on simple list mode
      *
      * @param Select $select Original select
-     *
-     * @return void
      */
     private function buildWhereClause(Select $select): void
     {
@@ -338,8 +330,6 @@ class History
      * Count history entries from the query
      *
      * @param Select $select Original select
-     *
-     * @return void
      */
     private function proceedCount(Select $select): void
     {
@@ -386,8 +376,6 @@ class History
      * Required for twig to access properties via __get
      *
      * @param string $name name of the property we want to retrieve
-     *
-     * @return bool
      */
     public function __isset(string $name): bool
     {
@@ -399,8 +387,6 @@ class History
      *
      * @param string $name  name of the property we want to assign a value to
      * @param mixed  $value a relevant value for the property
-     *
-     * @return void
      */
     public function __set(string $name, mixed $value): void
     {
@@ -411,8 +397,6 @@ class History
      * Get table's name
      *
      * @param bool $prefixed Whether table name should be prefixed
-     *
-     * @return string
      */
     protected function getTableName(bool $prefixed = false): string
     {
@@ -425,8 +409,6 @@ class History
 
     /**
      * Get table's PK
-     *
-     * @return string
      */
     protected function getPk(): string
     {
@@ -437,8 +419,6 @@ class History
      * Set filters
      *
      * @param HistoryList $filters Filters
-     *
-     * @return self
      */
     public function setFilters(HistoryList $filters): self
     {
@@ -448,8 +428,6 @@ class History
 
     /**
      * Get count for current query
-     *
-     * @return int
      */
     public function getCount(): int
     {

--- a/galette/lib/Galette/Core/I18n.php
+++ b/galette/lib/Galette/Core/I18n.php
@@ -106,8 +106,6 @@ class I18n
      * Load language parameters
      *
      * @param string $id Identifier for requested language
-     *
-     * @return void
      */
     public function changeLanguage(string $id): void
     {
@@ -119,8 +117,6 @@ class I18n
     /**
      * Update environment according to locale.
      * Mainly used at app initialization or at login
-     *
-     * @return void
      */
     public function updateEnv(): void
     {
@@ -145,8 +141,6 @@ class I18n
      * Load a language
      *
      * @param string $id identifier for the language to load
-     *
-     * @return void
      */
     private function load(string $id): void
     {
@@ -256,8 +250,6 @@ class I18n
      * Does string seem to be encoded as UTF-8?
      *
      * @param string $str string to analyze
-     *
-     * @return  bool
      */
     public static function seemUtf8(string $str): bool
     {
@@ -303,8 +295,6 @@ class I18n
 
     /**
      * Is current language RTL?
-     *
-     * @return bool
      */
     public function isRTL(): bool
     {

--- a/galette/lib/Galette/Core/Install.php
+++ b/galette/lib/Galette/Core/Install.php
@@ -104,8 +104,6 @@ class Install
      * Return current step details
      *
      * @param string $detail Requested detail
-     *
-     * @return string
      */
     public function getStepDetail(string $detail): string
     {
@@ -184,8 +182,6 @@ class Install
 
     /**
      * Get current mode
-     *
-     * @return ?string
      */
     public function getMode(): ?string
     {
@@ -194,8 +190,6 @@ class Install
 
     /**
      * Are we installing?
-     *
-     * @return bool
      */
     public function isInstall(): bool
     {
@@ -204,8 +198,6 @@ class Install
 
     /**
      * Are we upgrading?
-     *
-     * @return bool
      */
     public function isUpgrade(): bool
     {
@@ -216,8 +208,6 @@ class Install
      * Set installation mode
      *
      * @param string $mode Requested mode
-     *
-     * @return self
      */
     public function setMode(string $mode): self
     {
@@ -232,8 +222,6 @@ class Install
 
     /**
      * Go back to previous step
-     *
-     * @return void
      */
     public function atPreviousStep(): void
     {
@@ -265,8 +253,6 @@ class Install
 
     /**
      * Are we at check step?
-     *
-     * @return bool
      */
     public function isCheckStep(): bool
     {
@@ -275,8 +261,6 @@ class Install
 
     /**
      * Set step to type of installation
-     *
-     * @return void
      */
     public function atTypeStep(): void
     {
@@ -285,8 +269,6 @@ class Install
 
     /**
      * Are we at type step?
-     *
-     * @return bool
      */
     public function isTypeStep(): bool
     {
@@ -295,8 +277,6 @@ class Install
 
     /**
      * Set step to database information
-     *
-     * @return void
      */
     public function atDbStep(): void
     {
@@ -305,8 +285,6 @@ class Install
 
     /**
      * Are we at database step?
-     *
-     * @return bool
      */
     public function isDbStep(): bool
     {
@@ -315,8 +293,6 @@ class Install
 
     /**
      * Is DB step passed?
-     *
-     * @return bool
      */
     public function postCheckDb(): bool
     {
@@ -328,8 +304,6 @@ class Install
      *
      * @param string             $type Database type
      * @param array<int, string> $errs Errors array
-     *
-     * @return self
      */
     public function setDbType(string $type, array &$errs): self
     {
@@ -346,8 +320,6 @@ class Install
 
     /**
      * Get database type
-     *
-     * @return ?string
      */
     public function getDbType(): ?string
     {
@@ -362,8 +334,6 @@ class Install
      * @param string  $name Database name
      * @param string  $user Database username
      * @param ?string $pass Database user's password
-     *
-     * @return self
      */
     public function setDsn(string $host, string $port, string $name, string $user, ?string $pass): self
     {
@@ -379,8 +349,6 @@ class Install
      * Set tables prefix
      *
      * @param string $prefix Prefix
-     *
-     * @return self
      */
     public function setTablesPrefix(string $prefix): self
     {
@@ -390,8 +358,6 @@ class Install
 
     /**
      * Retrieve database host
-     *
-     * @return ?string
      */
     public function getDbHost(): ?string
     {
@@ -400,8 +366,6 @@ class Install
 
     /**
      * Retrieve database port
-     *
-     * @return ?string
      */
     public function getDbPort(): ?string
     {
@@ -410,8 +374,6 @@ class Install
 
     /**
      * Retrieve database name
-     *
-     * @return ?string
      */
     public function getDbName(): ?string
     {
@@ -420,8 +382,6 @@ class Install
 
     /**
      * Retrieve database user
-     *
-     * @return ?string
      */
     public function getDbUser(): ?string
     {
@@ -430,8 +390,6 @@ class Install
 
     /**
      * Retrieve database password
-     *
-     * @return string
      */
     public function getDbPass(): string
     {
@@ -440,8 +398,6 @@ class Install
 
     /**
      * Retrieve tables prefix
-     *
-     * @return ?string
      */
     public function getTablesPrefix(): ?string
     {
@@ -450,8 +406,6 @@ class Install
 
     /**
      * Set step to database checks
-     *
-     * @return void
      */
     public function atDbCheckStep(): void
     {
@@ -460,8 +414,6 @@ class Install
 
     /**
      * Are we at database check step?
-     *
-     * @return bool
      */
     public function isDbCheckStep(): bool
     {
@@ -470,8 +422,6 @@ class Install
 
     /**
      * Test database connection
-     *
-     * @return bool
      *
      * @throws Throwable
      */
@@ -489,8 +439,6 @@ class Install
 
     /**
      * Set step to version selection
-     *
-     * @return void
      */
     public function atVersionSelection(): void
     {
@@ -499,8 +447,6 @@ class Install
 
     /**
      * Are we at version selection step?
-     *
-     * @return bool
      */
     public function isVersionSelectionStep(): bool
     {
@@ -509,8 +455,6 @@ class Install
 
     /**
      * Set step to database installation
-     *
-     * @return void
      */
     public function atDbInstallStep(): void
     {
@@ -519,8 +463,6 @@ class Install
 
     /**
      * Are we at db installation step?
-     *
-     * @return bool
      */
     public function isDbinstallStep(): bool
     {
@@ -529,8 +471,6 @@ class Install
 
     /**
      * Set step to database upgrade
-     *
-     * @return void
      */
     public function atDbUpgradeStep(): void
     {
@@ -539,8 +479,6 @@ class Install
 
     /**
      * Are we at db upgrade step?
-     *
-     * @return bool
      */
     public function isDbUpgradeStep(): bool
     {
@@ -633,8 +571,6 @@ class Install
      *
      * @param Db      $zdb   Database instance
      * @param ?string $spath Path to scripts
-     *
-     * @return bool
      */
     public function executeScripts(Db $zdb, ?string $spath = null): bool
     {
@@ -724,8 +660,6 @@ class Install
      *
      * @param Db     $zdb       Database instance
      * @param string $sql_query SQL instructions
-     *
-     * @return bool
      */
     public function executeSql(Db $zdb, string $sql_query): bool
     {
@@ -821,8 +755,6 @@ class Install
 
     /**
      * Reinitialize report array
-     *
-     * @return void
      */
     public function reinitReport(): void
     {
@@ -831,8 +763,6 @@ class Install
 
     /**
      * Set step to super admin information
-     *
-     * @return void
      */
     public function atAdminStep(): void
     {
@@ -841,8 +771,6 @@ class Install
 
     /**
      * Are we at super admin information step?
-     *
-     * @return bool
      */
     public function isAdminStep(): bool
     {
@@ -854,8 +782,6 @@ class Install
      *
      * @param string $login Login
      * @param string $pass  Password
-     *
-     * @return self
      */
     public function setAdminInfos(string $login, string $pass): self
     {
@@ -866,8 +792,6 @@ class Install
 
     /**
      * Retrieve super admin login
-     *
-     * @return string
      */
     public function getAdminLogin(): string
     {
@@ -876,8 +800,6 @@ class Install
 
     /**
      * Retrieve super admin password
-     *
-     * @return string
      */
     public function getAdminPass(): string
     {
@@ -886,8 +808,6 @@ class Install
 
     /**
      * Set step to telemetry
-     *
-     * @return void
      */
     public function atTelemetryStep(): void
     {
@@ -896,8 +816,6 @@ class Install
 
     /**
      * Are we at telemetry step?
-     *
-     * @return bool
      */
     public function isTelemetryStep(): bool
     {
@@ -906,8 +824,6 @@ class Install
 
     /**
      * Set step to Galette initialization
-     *
-     * @return void
      */
     public function atGaletteInitStep(): void
     {
@@ -916,8 +832,6 @@ class Install
 
     /**
      * Are we at Galette initialization step?
-     *
-     * @return bool
      */
     public function isGaletteInitStep(): bool
     {
@@ -929,8 +843,6 @@ class Install
      *
      * @param array<string, string> $post_data      Data posted
      * @param array<int, string>    $error_detected Errors array
-     *
-     * @return void
      */
     public function loadExistingConfig(array $post_data, array &$error_detected): void
     {
@@ -1068,8 +980,6 @@ class Install
 
     /**
      * Write configuration file to disk
-     *
-     * @return bool
      */
     public function writeConfFile(): bool
     {
@@ -1137,8 +1047,6 @@ class Install
 
     /**
      * Get configuration file contents
-     *
-     * @return string
      */
     public function getConfigFileContents(): string
     {
@@ -1159,8 +1067,6 @@ define('PREFIX_DB', '" . $this->db_prefix . "');
      * @param I18n  $i18n  I18n
      * @param Db    $zdb   Database instance
      * @param Login $login Logged in instance
-     *
-     * @return bool
      */
     public function initObjects(I18n $i18n, Db $zdb, Login $login): bool
     {
@@ -1243,8 +1149,6 @@ define('PREFIX_DB', '" . $this->db_prefix . "');
      *
      * @param string         $msg Report message title
      * @param bool|Throwable $res Initialization result
-     *
-     * @return void
      */
     private function proceedReport(string $msg, bool|Throwable $res): void
     {
@@ -1273,8 +1177,6 @@ define('PREFIX_DB', '" . $this->db_prefix . "');
 
     /**
      * Set step to database installation
-     *
-     * @return void
      */
     public function atEndStep(): void
     {
@@ -1283,8 +1185,6 @@ define('PREFIX_DB', '" . $this->db_prefix . "');
 
     /**
      * Are we at end step?
-     *
-     * @return bool
      */
     public function isEndStep(): bool
     {
@@ -1295,8 +1195,6 @@ define('PREFIX_DB', '" . $this->db_prefix . "');
      * Set installed version if we're upgrading
      *
      * @param ?string $version Installed version
-     *
-     * @return self
      */
     public function setInstalledVersion(?string $version): self
     {
@@ -1308,8 +1206,6 @@ define('PREFIX_DB', '" . $this->db_prefix . "');
      * Current Galette installed version, according to database
      *
      * @param Db $zdb Database instance
-     *
-     * @return string|false
      */
     public function getCurrentVersion(Db $zdb): string|false
     {
@@ -1329,8 +1225,6 @@ define('PREFIX_DB', '" . $this->db_prefix . "');
      * Check if step is passed
      *
      * @param int $step Step
-     *
-     * @return bool
      */
     public function isStepPassed(int $step): bool
     {
@@ -1339,8 +1233,6 @@ define('PREFIX_DB', '" . $this->db_prefix . "');
 
     /**
      *  Initialize database constants to connect
-     *
-     * @return void
      */
     public function initDbConstants(): void
     {

--- a/galette/lib/Galette/Core/L10n.php
+++ b/galette/lib/Galette/Core/L10n.php
@@ -51,8 +51,6 @@ class L10n
      * Add a translation stored in the database
      *
      * @param string $text_orig Text to translate
-     *
-     * @return bool
      */
     public function addDynamicTranslation(string $text_orig): bool
     {
@@ -125,8 +123,6 @@ class L10n
      * Delete a translation stored in the database
      *
      * @param string $text_orig Text to translate
-     *
-     * @return bool
      */
     public function deleteDynamicTranslation(string $text_orig): bool
     {
@@ -156,8 +152,6 @@ class L10n
      * @param string $text_orig   Text to translate
      * @param string $text_locale The locale
      * @param string $text_trans  Translated text
-     *
-     * @return bool
      */
     public function updateDynamicTranslation(string $text_orig, string $text_locale, string $text_trans): bool
     {
@@ -215,8 +209,6 @@ class L10n
      *
      * @param string $text_orig   Text to translate
      * @param string $text_locale The locale
-     *
-     * @return string
      */
     public function getDynamicTranslation(string $text_orig, string $text_locale): string
     {

--- a/galette/lib/Galette/Core/Links.php
+++ b/galette/lib/Galette/Core/Links.php
@@ -66,8 +66,6 @@ class Links
      *
      * @param int $target Target (one of self::TARGET_* constants)
      * @param int $id     Target identifier
-     *
-     * @return bool
      */
     private function removeOldEntry(int $target, int $id): bool
     {
@@ -99,8 +97,6 @@ class Links
      *
      * @param int $target Target (one of self::TARGET_* constants)
      * @param int $id     Target identifier
-     *
-     * @return string
      */
     public function generateNewLink(int $target, int $id): string
     {
@@ -157,8 +153,6 @@ class Links
 
     /**
      * Get expiration date
-     *
-     * @return DateTime
      */
     private function getExpirationDate(): DateTime
     {
@@ -169,8 +163,6 @@ class Links
 
     /**
      * Remove expired links queries (older than 1 week)
-     *
-     * @return bool
      */
     protected function cleanExpired(): bool
     {

--- a/galette/lib/Galette/Core/Login.php
+++ b/galette/lib/Galette/Core/Login.php
@@ -60,8 +60,6 @@ class Login extends Authentication
      *
      * @param string      $login       name
      * @param Preferences $preferences Preferences instance
-     *
-     * @return bool
      */
     public function logAdmin(string $login, Preferences $preferences): bool
     {
@@ -75,8 +73,6 @@ class Login extends Authentication
      *
      * @param string      $name        Service name
      * @param Preferences $preferences Preferences instance
-     *
-     * @return bool
      */
     public function logCron(string $name, Preferences $preferences): bool
     {
@@ -98,8 +94,6 @@ class Login extends Authentication
 
     /**
      * Log out user and unset variables
-     *
-     * @return bool
      */
     public function logOut(): bool
     {
@@ -113,8 +107,6 @@ class Login extends Authentication
      *
      * @param string $user  user's login
      * @param string $passe user's password
-     *
-     * @return bool
      */
     public function logIn(string $user, string $passe): bool
     {
@@ -185,8 +177,6 @@ class Login extends Authentication
 
     /**
      * Get select query without where clause
-     *
-     * @return Select
      */
     private function select(): Select
     {
@@ -216,8 +206,6 @@ class Login extends Authentication
      * Populate object after successful login
      *
      * @param ArrayObject<string, int|string> $row User information
-     *
-     * @return void
      */
     private function logUser(ArrayObject $row): void
     {
@@ -265,8 +253,6 @@ class Login extends Authentication
      * Impersonate user
      *
      * @param int $id Member ID
-     *
-     * @return bool
      */
     public function impersonate(int $id): bool
     {
@@ -309,8 +295,6 @@ class Login extends Authentication
      * Does this login already exist?
      *
      * @param string $user the username
-     *
-     * @return bool
      */
     public function loginExists(string $user): bool
     {
@@ -332,8 +316,6 @@ class Login extends Authentication
 
     /**
      * Is impersonated
-     *
-     * @return bool
      */
     public function isImpersonated(): bool
     {

--- a/galette/lib/Galette/Core/Logo.php
+++ b/galette/lib/Galette/Core/Logo.php
@@ -54,8 +54,6 @@ class Logo extends Picture
      * Gets the default picture to show, anyway
      *
      * @see Picture::getDefaultPicture()
-     *
-     * @return void
      */
     protected function getDefaultPicture(): void
     {
@@ -112,8 +110,6 @@ class Logo extends Picture
 
     /**
      * Returns custom state
-     *
-     * @return bool
      */
     public function isCustom(): bool
     {

--- a/galette/lib/Galette/Core/Logs.php
+++ b/galette/lib/Galette/Core/Logs.php
@@ -38,8 +38,6 @@ class Logs
 {
     /**
      * Clean old logs (older than one month per default)
-     *
-     * @return void
      */
     public static function cleanup(): void
     {

--- a/galette/lib/Galette/Core/Mailing.php
+++ b/galette/lib/Galette/Core/Mailing.php
@@ -42,23 +42,23 @@ use function Safe\unlink;
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>
  *
- * @property string $subject
- * @property string $message
- * @property bool $html
- * @property int $current_step
- * @property-read  int $step
- * @property int|string $id
- * @property-read string $alt_message
- * @property-read string $wrapped_message
- * @property-read PHPMailer $mail
- * @property-read string[] $errors
- * @property-read Adherent[] $recipients
- * @property-read Adherent[] $unreachables
+ * @property      string            $subject
+ * @property      string            $message
+ * @property      bool              $html
+ * @property      int               $current_step
+ * @property-read int               $step
+ * @property      int|string        $id
+ * @property-read string            $alt_message
+ * @property-read string            $wrapped_message
+ * @property-read PHPMailer         $mail
+ * @property-read string[]          $errors
+ * @property-read Adherent[]        $recipients
+ * @property-read Adherent[]        $unreachables
  * @property-read string|false|null $tmp_path
- * @property File[] $attachments
- * @property-read string $sender_name
- * @property-read string $sender_address
- * @property int $history_id
+ * @property      File[]            $attachments
+ * @property-read string            $sender_name
+ * @property-read string            $sender_address
+ * @property      int               $history_id
  */
 class Mailing extends GaletteMail
 {
@@ -111,8 +111,6 @@ class Mailing extends GaletteMail
 
     /**
      * Generate new mailing id and temporary path
-     *
-     * @return string
      */
     private function generateNewId(): string
     {
@@ -135,8 +133,6 @@ class Mailing extends GaletteMail
      * Generate temporary path
      *
      * @param ?string $id Random id, defaults to null
-     *
-     * @return void
      */
     private function generateTmpPath(?string $id = null): void
     {
@@ -148,8 +144,6 @@ class Mailing extends GaletteMail
 
     /**
      * Load mailing attachments
-     *
-     * @return void
      */
     private function loadAttachments(): void
     {
@@ -177,8 +171,6 @@ class Mailing extends GaletteMail
      * @param bool                       $new True if we create a 'new' mailing,
      *                                        false otherwise (from preview for
      *                                        example)
-     *
-     * @return bool
      */
     public function loadFromHistory(ArrayObject $rs, bool $new = true): bool
     {
@@ -233,8 +225,6 @@ class Mailing extends GaletteMail
      * Copy attachments from another mailing
      *
      * @param int $id Original mailing id
-     *
-     * @return void
      */
     private function copyAttachments(int $id): void
     {
@@ -273,8 +263,6 @@ class Mailing extends GaletteMail
 
     /**
      * Apply final header to email and send it :-)
-     *
-     * @return int
      */
     public function send(): int
     {
@@ -356,8 +344,6 @@ class Mailing extends GaletteMail
      * Move attachments with final id once mailing has been stored
      *
      * @param int $id Mailing history id
-     *
-     * @return void
      */
     public function moveAttachments(int $id): void
     {
@@ -385,8 +371,6 @@ class Mailing extends GaletteMail
      * Remove specified attachment
      *
      * @param string $name Filename
-     *
-     * @return void
      */
     public function removeAttachment(string $name): void
     {
@@ -439,8 +423,6 @@ class Mailing extends GaletteMail
      *
      * @param bool $temp Remove only temporary attachments,
      *                   to avoid history breaking
-     *
-     * @return bool
      */
     public function removeAttachments(bool $temp = false): bool
     {
@@ -494,8 +476,6 @@ class Mailing extends GaletteMail
 
     /**
      * Does mailing already exists in history?
-     *
-     * @return bool
      */
     public function existsInHistory(): bool
     {
@@ -569,8 +549,6 @@ class Mailing extends GaletteMail
      * Required for twig to access properties via __get
      *
      * @param string $name name of the property we want to retrieve
-     *
-     * @return bool
      */
     public function __isset(string $name): bool
     {
@@ -590,8 +568,6 @@ class Mailing extends GaletteMail
      *
      * @param string $name  name of the property we want to assign a value to
      * @param mixed  $value a relevant value for the property
-     *
-     * @return void
      */
     public function __set(string $name, mixed $value): void
     {

--- a/galette/lib/Galette/Core/MailingHistory.php
+++ b/galette/lib/Galette/Core/MailingHistory.php
@@ -173,8 +173,6 @@ class MailingHistory extends History
      * Builds where clause, for filtering on simple list mode
      *
      * @param Select $select Original select
-     *
-     * @return void
      */
     private function buildWhereClause(Select $select): void
     {
@@ -243,8 +241,6 @@ class MailingHistory extends History
      * Count history entries from the query
      *
      * @param Select $select Original select
-     *
-     * @return void
      */
     private function proceedCount(Select $select): void
     {
@@ -283,8 +279,6 @@ class MailingHistory extends History
      * @param bool    $new     True if we create a 'new' mailing,
      *                         false otherwise (from preview for
      *                         example)
-     *
-     * @return bool
      */
     public static function loadFrom(Db $zdb, int $id, Mailing $mailing, bool $new = true): bool
     {
@@ -311,8 +305,6 @@ class MailingHistory extends History
      * Store a mailing in the history
      *
      * @param bool $sent Defaults to false
-     *
-     * @return bool
      */
     public function storeMailing(bool $sent = false): bool
     {
@@ -385,8 +377,6 @@ class MailingHistory extends History
 
     /**
      * Update in the database
-     *
-     * @return bool
      */
     public function update(): bool
     {
@@ -407,8 +397,6 @@ class MailingHistory extends History
 
     /**
      * Store in the database
-     *
-     * @return bool
      */
     public function store(): bool
     {
@@ -433,8 +421,6 @@ class MailingHistory extends History
      *
      * @param int|array<int> $ids  Mailing history entries identifiers
      * @param History        $hist History instance
-     *
-     * @return bool
      */
     public function removeEntries(int|array $ids, History $hist): bool
     {
@@ -477,8 +463,6 @@ class MailingHistory extends History
      * Get table's name
      *
      * @param bool $prefixed Whether table name should be prefixed
-     *
-     * @return string
      */
     protected function getTableName(bool $prefixed = false): string
     {
@@ -491,8 +475,6 @@ class MailingHistory extends History
 
     /**
      * Get table's PK
-     *
-     * @return string
      */
     protected function getPk(): string
     {
@@ -501,8 +483,6 @@ class MailingHistory extends History
 
     /**
      * Get count for current query
-     *
-     * @return int
      */
     public function getCount(): int
     {
@@ -513,7 +493,6 @@ class MailingHistory extends History
      * Handle mailing recipients
      *
      * @param ArrayObject<string, string> $row ResultSet row
-     * @return void
      */
     private function handleRecipients(ArrayObject &$row): void
     {

--- a/galette/lib/Galette/Core/Pagination.php
+++ b/galette/lib/Galette/Core/Pagination.php
@@ -36,12 +36,12 @@ use function Safe\preg_match;
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>
  *
- * @property int $current_page
- * @property string $orderby
+ * @property int      $current_page
+ * @property string   $orderby
  * @property SQLOrder $ordered
- * @property int $show
- * @property int $pages
- * @property int $counter
+ * @property int      $show
+ * @property int      $pages
+ * @property int      $counter
  */
 
 abstract class Pagination
@@ -77,15 +77,11 @@ abstract class Pagination
 
     /**
      * Returns the field we want to default set order to
-     *
-     * @return int|string
      */
     abstract protected function getDefaultOrder(): int|string;
 
     /**
      * Return the default direction for ordering
-     *
-     * @return SQLOrder
      */
     protected function getDefaultDirection(): SQLOrder
     {
@@ -94,8 +90,6 @@ abstract class Pagination
 
     /**
      * Reinit default parameters
-     *
-     * @return void
      */
     public function reinit(): void
     {
@@ -109,8 +103,6 @@ abstract class Pagination
 
     /**
      * Invert sort order
-     *
-     * @return void
      */
     public function invertorder(): void
     {
@@ -125,8 +117,6 @@ abstract class Pagination
 
     /**
      * Get current sort direction
-     *
-     * @return string
      */
     public function getDirection(): string
     {
@@ -137,8 +127,6 @@ abstract class Pagination
      * Set sort direction
      *
      * @param SQLOrder|string|null $direction Order direction
-     *
-     * @return self
      */
     public function setDirection(SQLOrder|string|null $direction): self
     {
@@ -165,8 +153,6 @@ abstract class Pagination
      * Add limits so we retrieve only relavant rows
      *
      * @param Select $select Original select
-     *
-     * @return void
      */
     public function setLimits(Select $select): void
     {
@@ -182,8 +168,6 @@ abstract class Pagination
      * Set counter
      *
      * @param int $c Count
-     *
-     * @return void
      */
     public function setCounter(int $c): void
     {
@@ -193,8 +177,6 @@ abstract class Pagination
 
     /**
      * Update or set pages count
-     *
-     * @return void
      */
     protected function countPages(): void
     {
@@ -221,8 +203,6 @@ abstract class Pagination
      * @param RouteParser $routeparser Application instance
      * @param Twig        $view        View instance
      * @param bool        $restricted  Do not permit displaying all
-     *
-     * @return void
      */
     public function setViewPagination(RouteParser $routeparser, Twig $view, bool $restricted = true): void
     {
@@ -317,8 +297,6 @@ abstract class Pagination
      * @param string $url     URL the link to point on
      * @param string $title   Link's title
      * @param bool   $current Is current page
-     *
-     * @return string
      */
     private function getLink(string $content, string $url, string $title, bool $current = false): string
     {
@@ -332,8 +310,6 @@ abstract class Pagination
      * Build href
      *
      * @param int $page Page
-     *
-     * @return string
      */
     protected function getHref(int $page): string
     {
@@ -389,8 +365,6 @@ abstract class Pagination
      * Required for twig to access properties via __get
      *
      * @param string $name name of the property we want to retrieve
-     *
-     * @return bool
      */
     public function __isset(string $name): bool
     {
@@ -405,8 +379,6 @@ abstract class Pagination
      *
      * @param string $name  name of the property we want to assign a value to
      * @param mixed  $value a relevant value for the property
-     *
-     * @return void
      */
     public function __set(string $name, mixed $value): void
     {

--- a/galette/lib/Galette/Core/Password.php
+++ b/galette/lib/Galette/Core/Password.php
@@ -64,8 +64,6 @@ class Password extends AbstractPassword
      * Remove all old password entries
      *
      * @param int $id_adh Member identifier
-     *
-     * @return bool
      */
     private function removeOldEntries(int $id_adh): bool
     {
@@ -93,8 +91,6 @@ class Password extends AbstractPassword
      * Generates a new password for specified member
      *
      * @param int $id_adh Member identifier
-     *
-     * @return bool
      */
     public function generateNewPassword(int $id_adh): bool
     {
@@ -135,8 +131,6 @@ class Password extends AbstractPassword
 
     /**
      * Remove expired passwords queries (older than 24 hours)
-     *
-     * @return bool
      */
     public function cleanExpired(): bool
     {
@@ -202,8 +196,6 @@ class Password extends AbstractPassword
      * Remove a hash that has been used (ie. once password has been updated)
      *
      * @param string $hash hash
-     *
-     * @return bool
      */
     public function removeHash(string $hash): bool
     {

--- a/galette/lib/Galette/Core/Picture.php
+++ b/galette/lib/Galette/Core/Picture.php
@@ -146,8 +146,6 @@ class Picture
      * "Magic" function called on unserialize
      *
      * @param array<string, mixed> $data Data to unserialize
-     *
-     * @return void
      */
     public function __unserialize(array $data): void
     {
@@ -277,8 +275,6 @@ class Picture
 
     /**
      * Gets the default picture to show, anyway
-     *
-     * @return void
      */
     protected function getDefaultPicture(): void
     {
@@ -290,8 +286,6 @@ class Picture
 
     /**
      * Set picture sizes
-     *
-     * @return void
      */
     private function setSizes(): void
     {
@@ -316,8 +310,6 @@ class Picture
 
     /**
      * Get image file contents in stdOut
-     *
-     * @return void
      */
     public function getContents(): void
     {
@@ -437,8 +429,6 @@ class Picture
      * @param string                  $key           Key to look for in uploaded files
      * @param callable|null           $callback      Callback to use for storing the file. If null, will use $this->storeFile()
      * @param ?array<string,mixed>    $cropping      Cropping properties
-     *
-     * @return bool
      */
     public function upload(array $request_files, string $key, ?callable $callback = null, ?array $cropping = null): bool
     {
@@ -471,8 +461,6 @@ class Picture
 
     /**
      * Build destination path
-     *
-     * @return string
      */
     protected function buildDestPath(): string
     {
@@ -483,8 +471,6 @@ class Picture
      * Get file mime type
      *
      * @param string $file File
-     *
-     * @return string
      */
     public static function getMimeType(string $file): string
     {
@@ -615,8 +601,6 @@ class Picture
      * Check for missing images in database
      *
      * @param Db $zdb Database instance
-     *
-     * @return void
      */
     public function missingInDb(Db $zdb): void
     {
@@ -705,8 +689,6 @@ class Picture
      * @param ?string               $dest     The destination image.
      *                                        If null, we'll use the source image. Defaults to null
      * @param ?array<string, mixed> $cropping Cropping properties
-     *
-     * @return bool
      */
     private function resizeImage(string $source, string $ext, ?string $dest = null, ?array $cropping = null): bool
     {
@@ -934,8 +916,6 @@ class Picture
 
     /**
      * Returns current file format
-     *
-     * @return string
      */
     public function getFormat(): string
     {
@@ -964,8 +944,6 @@ class Picture
 
     /**
      * Returns current mime type
-     *
-     * @return string
      */
     public function getMime(): string
     {

--- a/galette/lib/Galette/Core/PluginControllerTrait.php
+++ b/galette/lib/Galette/Core/PluginControllerTrait.php
@@ -43,8 +43,6 @@ trait PluginControllerTrait
 
     /**
      * Get plugin module ID
-     *
-     * @return string
      */
     protected function getModuleId(): string
     {
@@ -53,8 +51,6 @@ trait PluginControllerTrait
 
     /**
      * Get plugin module route namespace
-     *
-     * @return string
      */
     protected function getModuleRoute(): string
     {
@@ -65,8 +61,6 @@ trait PluginControllerTrait
      * Get plugin template name for Twig
      *
      * @param string $name Template name
-     *
-     * @return string
      */
     protected function getTemplate(string $name): string
     {
@@ -78,8 +72,6 @@ trait PluginControllerTrait
      *
      * @param string                   $filter_name Filter name
      * @param array<string,mixed>|null $args        Arguments
-     *
-     * @return string
      */
     public function getFilterName(string $filter_name, ?array $args = null): string
     {

--- a/galette/lib/Galette/Core/PluginInstall.php
+++ b/galette/lib/Galette/Core/PluginInstall.php
@@ -41,8 +41,6 @@ class PluginInstall extends Install
 
     /**
      * Test database connection
-     *
-     * @return bool
      */
     public function testDbConnexion(): bool
     {
@@ -56,8 +54,6 @@ class PluginInstall extends Install
      * @param I18n  $i18n  I18n
      * @param Db    $zdb   Database instance
      * @param Login $login Logged in instance
-     *
-     * @return bool
      */
     public function initObjects(I18n $i18n, Db $zdb, Login $login): bool
     {

--- a/galette/lib/Galette/Core/Plugins.php
+++ b/galette/lib/Galette/Core/Plugins.php
@@ -71,8 +71,6 @@ class Plugins
      *
      * @param string $path could be a separated list of paths
      *                     (path separator depends on your OS).
-     *
-     * @return void
      */
     public function autoload(string $path): void
     {
@@ -83,8 +81,6 @@ class Plugins
 
     /**
      * Parse modules in current path
-     *
-     * @return void
      */
     protected function parseModules(): void
     {
@@ -153,8 +149,6 @@ class Plugins
      *                                 (path separator depends on your OS).
      * @param ?string     $lang        Indicates if we need to load a lang file on plugin
      *                                 loading.
-     *
-     * @return void
      */
     public function loadModules(Preferences $preferences, string $path, ?string $lang = null): void
     {
@@ -196,8 +190,6 @@ class Plugins
      * @param ?string               $date     Module release date
      * @param ?array<string,string> $acls     Module routes ACLs
      * @param ?int                  $priority Module priority
-     *
-     * @return void
      */
     public function register(
         string $name,
@@ -244,8 +236,6 @@ class Plugins
 
     /**
      * Reset modules list
-     *
-     * @return void
      */
     public function resetModulesList(): void
     {
@@ -257,7 +247,6 @@ class Plugins
      *
      * @param string $id Module's ID
      *
-     * @return void
      * @throws Exception
      */
     public function deactivateModule(string $id): void
@@ -278,7 +267,6 @@ class Plugins
      *
      * @param string $id Module's ID
      *
-     * @return void
      * @throws Exception
      */
     protected function createDisabledFile(string $id): void
@@ -295,7 +283,6 @@ class Plugins
      *
      * @param string $id Module's ID
      *
-     * @return void
      * @throws Exception
      */
     protected function removeDisabledFile(string $id): void
@@ -324,7 +311,6 @@ class Plugins
      *
      * @param string $id Module's ID
      *
-     * @return void
      * @throws Exception
      */
     public function activateModule(string $id): void
@@ -347,8 +333,6 @@ class Plugins
      *
      * @param string $id       Module ID
      * @param string $language Language code
-     *
-     * @return void
      */
     public function loadModuleL10N(string $id, string $language): void
     {
@@ -382,8 +366,6 @@ class Plugins
      * Loads event provider
      *
      * @param string $id Module ID
-     *
-     * @return void
      */
     public function loadEventProviders(string $id): void
     {
@@ -416,8 +398,6 @@ class Plugins
      * Returns true if the module with ID <var>$id</var> exists.
      *
      * @param string $id Module ID
-     *
-     * @return bool
      */
     public function moduleExists(string $id): bool
     {
@@ -438,8 +418,6 @@ class Plugins
      * Returns root path for module with ID <var>$id</var>.
      *
      * @param string $id Module ID
-     *
-     * @return ?string
      */
     public function moduleRoot(string $id): ?string
     {
@@ -552,8 +530,6 @@ class Plugins
      * Does module need a database?
      *
      * @param string $id Module's ID
-     *
-     * @return bool
      */
     public function needsDatabase(string $id): bool
     {
@@ -569,8 +545,6 @@ class Plugins
      * Override preferences from plugin
      *
      * @param string $id Module ID
-     *
-     * @return void
      */
     public function overridePrefs(string $id): void
     {
@@ -608,8 +582,6 @@ class Plugins
      *
      * @param string $id   Module id
      * @param string $path File path
-     *
-     * @return string
      */
     public function getFile(string $id, string $path): string
     {
@@ -629,8 +601,6 @@ class Plugins
      * Set a module as disabled
      *
      * @param int $cause Cause (one of Plugins::DISABLED_* constants)
-     *
-     * @return void
      */
     private function setDisabled(int $cause): void
     {
@@ -646,8 +616,6 @@ class Plugins
      * Get module namespace
      *
      * @param string $id Module ID
-     *
-     * @return string
      */
     public function getNamespace(string $id): string
     {
@@ -659,8 +627,6 @@ class Plugins
      *
      * @param string $id   Module ID
      * @param bool   $full Include namespace, defaults to false
-     *
-     * @return string
      */
     public function getClassName(string $id, bool $full = false): string
     {
@@ -675,8 +641,6 @@ class Plugins
      * Set CRSF excluded routes for one plugin
      *
      * @param array<string> $exclusions Array of regular expressions patterns to be excluded
-     *
-     * @return self
      */
     public function setCsrfExclusions(array $exclusions): self
     {
@@ -696,8 +660,6 @@ class Plugins
 
     /**
      * Is the current module explicitly disabled?
-     *
-     * @return bool
      */
     public function isExplicitlyDisabled(): bool
     {
@@ -736,8 +698,6 @@ class Plugins
      * Get path for disabled file
      *
      * @param string $id Module ID
-     *
-     * @return string
      */
     public function getDisabledPath(string $id): string
     {
@@ -752,8 +712,6 @@ class Plugins
      * Set translator
      *
      * @param Translator $translator Translator instance
-     *
-     * @return self
      */
     public function setTranslator(Translator $translator): self
     {
@@ -765,8 +723,6 @@ class Plugins
      * Set event dispatcher
      *
      * @param EventDispatcher $dispatcher Event dispatcher instance
-     *
-     * @return self
      */
     public function setEventDispatcher(EventDispatcher $dispatcher): self
     {

--- a/galette/lib/Galette/Core/Preferences.php
+++ b/galette/lib/Galette/Core/Preferences.php
@@ -50,123 +50,123 @@ use function Safe\unlink;
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>
  *
- * @property string $pref_admin_login Super admin login
- * @property string $pref_admin_pass Super admin password
- * @property string $pref_nom Association name
- * @property string $pref_slogan Association slogan
- * @property string $pref_adresse Address
- * @property string $pref_adresse2 Address continuation
- * @property string $pref_cp Association zipcode
- * @property string $pref_ville Association
- * @property string $pref_region Region
- * @property string $pref_pays Country
- * @property int $pref_postal_address Postal address to use, one of self::POSTAL_ADDRESS*
- * @property int $pref_postal_staff_member Staff member ID from which retrieve postal address
- * @property string $pref_org_phone_number Phone number
- * @property int $pref_org_phone Phone number to use, one of self::PHONE_NUMBER*
- * @property int $pref_org_phone_staff_member Staff member ID from which retrieve phone number
- * @property string $pref_org_email Email address
- * @property bool $pref_disable_members_socials Disable social networks for members
- * @property string $pref_lang Default instance language
- * @property int $pref_numrows Default number of rows in lists
- * @property int $pref_statut Default status for new members
- * @property string $pref_email_nom
- * @property string $pref_email
- * @property string $pref_email_newadh
- * @property bool $pref_bool_mailadh
- * @property bool $pref_bool_mailowner
- * @property bool $pref_editor_enabled
- * @property int $pref_mail_method Mail method, see GaletteMail::METHOD_*
- * @property string $pref_mail_smtp
- * @property string $pref_mail_smtp_host
- * @property bool $pref_mail_smtp_auth
- * @property bool $pref_mail_smtp_secure
- * @property int $pref_mail_smtp_port
- * @property string $pref_mail_smtp_user
- * @property string $pref_mail_smtp_password
- * @property int $pref_membership_ext
- * @property string $pref_beg_membership
- * @property int $pref_membership_offermonths
- * @property string $pref_email_reply_to
- * @property string $pref_website
- * @property int $pref_etiq_marges_v
- * @property int $pref_etiq_marges_h
- * @property int $pref_etiq_hspace
- * @property int $pref_etiq_vspace
- * @property int $pref_etiq_hsize
- * @property int $pref_etiq_vsize
- * @property int $pref_etiq_cols
- * @property int $pref_etiq_rows
- * @property int $pref_etiq_corps
- * @property bool $pref_etiq_border
- * @property bool $pref_force_picture_ratio
- * @property string $pref_member_picture_ratio
- * @property string $pref_card_abrev
- * @property string $pref_card_strip
- * @property string $pref_card_tcol
- * @property string $pref_card_scol
- * @property string $pref_card_bcol
- * @property string $pref_card_hcol
- * @property string $pref_bool_display_title
- * @property int $pref_card_address
- * @property string $pref_card_year
- * @property int $pref_card_marges_v
- * @property int $pref_card_marges_h
- * @property int $pref_card_vspace
- * @property int $pref_card_hspace
- * @property string $pref_card_self
- * @property int $pref_card_hsize
- * @property int $pref_card_vsize
- * @property int $pref_card_cols
- * @property int $pref_card_rows
- * @property string $pref_theme Preferred theme
- * @property bool $pref_hide_bg_image
- * @property bool $pref_enable_custom_colors
- * @property string $pref_cc_primary
- * @property string $pref_cc_primary_text
- * @property string $pref_cc_secondary
- * @property string $pref_cc_secondary_text
- * @property bool $pref_bool_publicpages
- * @property int $pref_publicpages_visibility_generic
- * @property int $pref_publicpages_visibility_documents
- * @property int $pref_publicpages_visibility_memberslist
- * @property int $pref_publicpages_visibility_membersgallery
- * @property int $pref_publicpages_visibility_stafflist
- * @property int $pref_publicpages_visibility_staffgallery
- * @property bool $pref_bool_groupsmanagers_are_staff
- * @property bool $pref_bool_selfsubscribe
- * @property bool $pref_bool_empty_form_link
- * @property string $pref_member_form_grid
- * @property string $pref_mail_sign
- * @property string $pref_new_contrib_script
- * @property bool $pref_bool_wrap_mails
- * @property string $pref_rss_url
- * @property string $pref_adhesion_form
- * @property bool $pref_mail_allow_unsecure
- * @property string $pref_instance_uuid
- * @property string $pref_registration_uuid
- * @property string $pref_telemetry_date
- * @property string $pref_registration_date
- * @property string $pref_footer
- * @property int $pref_filter_account
- * @property string $pref_galette_url
- * @property int $pref_redirect_on_create
- * @property int $pref_password_length
- * @property bool $pref_password_blacklist
- * @property int $pref_password_strength
- * @property int $pref_default_paymenttype
- * @property bool $pref_bool_create_member
- * @property bool $pref_bool_groupsmanagers_create_member
- * @property bool $pref_bool_groupsmanagers_edit_member
- * @property bool $pref_bool_groupsmanagers_edit_groups
- * @property bool $pref_bool_groupsmanagers_mailings
- * @property bool $pref_bool_groupsmanagers_exports
- * @property bool $pref_bool_groupsmanagers_create_contributions
- * @property bool $pref_bool_groupsmanagers_create_transactions
- * @property bool $pref_bool_groupsmanagers_see_contributions
- * @property bool $pref_bool_groupsmanagers_see_transactions
- * @property-read string[] $vpref_email_newadh list of mail senders
- * @property bool $pref_noindex
+ * @property      string   $pref_admin_login                              Super admin login
+ * @property      string   $pref_admin_pass                               Super admin password
+ * @property      string   $pref_nom                                      Association name
+ * @property      string   $pref_slogan                                   Association slogan
+ * @property      string   $pref_adresse                                  Address
+ * @property      string   $pref_adresse2                                 Address continuation
+ * @property      string   $pref_cp                                       Association zipcode
+ * @property      string   $pref_ville                                    Association
+ * @property      string   $pref_region                                   Region
+ * @property      string   $pref_pays                                     Country
+ * @property      int      $pref_postal_address                           Postal address to use, one of self::POSTAL_ADDRESS*
+ * @property      int      $pref_postal_staff_member                      Staff member ID from which retrieve postal address
+ * @property      string   $pref_org_phone_number                         Phone number
+ * @property      int      $pref_org_phone                                Phone number to use, one of self::PHONE_NUMBER*
+ * @property      int      $pref_org_phone_staff_member                   Staff member ID from which retrieve phone number
+ * @property      string   $pref_org_email                                Email address
+ * @property      bool     $pref_disable_members_socials                  Disable social networks for members
+ * @property      string   $pref_lang                                     Default instance language
+ * @property      int      $pref_numrows                                  Default number of rows in lists
+ * @property      int      $pref_statut                                   Default status for new members
+ * @property      string   $pref_email_nom
+ * @property      string   $pref_email
+ * @property      string   $pref_email_newadh
+ * @property      bool     $pref_bool_mailadh
+ * @property      bool     $pref_bool_mailowner
+ * @property      bool     $pref_editor_enabled
+ * @property      int      $pref_mail_method                              Mail method, see GaletteMail::METHOD_*
+ * @property      string   $pref_mail_smtp
+ * @property      string   $pref_mail_smtp_host
+ * @property      bool     $pref_mail_smtp_auth
+ * @property      bool     $pref_mail_smtp_secure
+ * @property      int      $pref_mail_smtp_port
+ * @property      string   $pref_mail_smtp_user
+ * @property      string   $pref_mail_smtp_password
+ * @property      int      $pref_membership_ext
+ * @property      string   $pref_beg_membership
+ * @property      int      $pref_membership_offermonths
+ * @property      string   $pref_email_reply_to
+ * @property      string   $pref_website
+ * @property      int      $pref_etiq_marges_v
+ * @property      int      $pref_etiq_marges_h
+ * @property      int      $pref_etiq_hspace
+ * @property      int      $pref_etiq_vspace
+ * @property      int      $pref_etiq_hsize
+ * @property      int      $pref_etiq_vsize
+ * @property      int      $pref_etiq_cols
+ * @property      int      $pref_etiq_rows
+ * @property      int      $pref_etiq_corps
+ * @property      bool     $pref_etiq_border
+ * @property      bool     $pref_force_picture_ratio
+ * @property      string   $pref_member_picture_ratio
+ * @property      string   $pref_card_abrev
+ * @property      string   $pref_card_strip
+ * @property      string   $pref_card_tcol
+ * @property      string   $pref_card_scol
+ * @property      string   $pref_card_bcol
+ * @property      string   $pref_card_hcol
+ * @property      string   $pref_bool_display_title
+ * @property      int      $pref_card_address
+ * @property      string   $pref_card_year
+ * @property      int      $pref_card_marges_v
+ * @property      int      $pref_card_marges_h
+ * @property      int      $pref_card_vspace
+ * @property      int      $pref_card_hspace
+ * @property      string   $pref_card_self
+ * @property      int      $pref_card_hsize
+ * @property      int      $pref_card_vsize
+ * @property      int      $pref_card_cols
+ * @property      int      $pref_card_rows
+ * @property      string   $pref_theme                                    Preferred theme
+ * @property      bool     $pref_hide_bg_image
+ * @property      bool     $pref_enable_custom_colors
+ * @property      string   $pref_cc_primary
+ * @property      string   $pref_cc_primary_text
+ * @property      string   $pref_cc_secondary
+ * @property      string   $pref_cc_secondary_text
+ * @property      bool     $pref_bool_publicpages
+ * @property      int      $pref_publicpages_visibility_generic
+ * @property      int      $pref_publicpages_visibility_documents
+ * @property      int      $pref_publicpages_visibility_memberslist
+ * @property      int      $pref_publicpages_visibility_membersgallery
+ * @property      int      $pref_publicpages_visibility_stafflist
+ * @property      int      $pref_publicpages_visibility_staffgallery
+ * @property      bool     $pref_bool_groupsmanagers_are_staff
+ * @property      bool     $pref_bool_selfsubscribe
+ * @property      bool     $pref_bool_empty_form_link
+ * @property      string   $pref_member_form_grid
+ * @property      string   $pref_mail_sign
+ * @property      string   $pref_new_contrib_script
+ * @property      bool     $pref_bool_wrap_mails
+ * @property      string   $pref_rss_url
+ * @property      string   $pref_adhesion_form
+ * @property      bool     $pref_mail_allow_unsecure
+ * @property      string   $pref_instance_uuid
+ * @property      string   $pref_registration_uuid
+ * @property      string   $pref_telemetry_date
+ * @property      string   $pref_registration_date
+ * @property      string   $pref_footer
+ * @property      int      $pref_filter_account
+ * @property      string   $pref_galette_url
+ * @property      int      $pref_redirect_on_create
+ * @property      int      $pref_password_length
+ * @property      bool     $pref_password_blacklist
+ * @property      int      $pref_password_strength
+ * @property      int      $pref_default_paymenttype
+ * @property      bool     $pref_bool_create_member
+ * @property      bool     $pref_bool_groupsmanagers_create_member
+ * @property      bool     $pref_bool_groupsmanagers_edit_member
+ * @property      bool     $pref_bool_groupsmanagers_edit_groups
+ * @property      bool     $pref_bool_groupsmanagers_mailings
+ * @property      bool     $pref_bool_groupsmanagers_exports
+ * @property      bool     $pref_bool_groupsmanagers_create_contributions
+ * @property      bool     $pref_bool_groupsmanagers_create_transactions
+ * @property      bool     $pref_bool_groupsmanagers_see_contributions
+ * @property      bool     $pref_bool_groupsmanagers_see_transactions
+ * @property-read string[] $vpref_email_newadh                            list of mail senders
+ * @property      bool     $pref_noindex
  */
 class Preferences
 {
@@ -395,8 +395,6 @@ class Preferences
     /**
      * Check if all fields referenced in the default array do exist,
      * create them if not
-     *
-     * @return bool
      */
     private function checkUpdate(): bool
     {
@@ -457,8 +455,6 @@ class Preferences
 
     /**
      * Load current preferences from database.
-     *
-     * @return bool
      */
     public function load(): bool
     {
@@ -488,7 +484,6 @@ class Preferences
      * @param string $adm_login admin login entered at install time
      * @param string $adm_pass  admin password entered at install time
      *
-     * @return bool
      * @throws Throwable
      */
     public function installInit(string $lang, string $adm_login, string $adm_pass): bool
@@ -552,8 +547,6 @@ class Preferences
      *
      * @param array<string, mixed> $values Values
      * @param Login                $login  Logged in user
-     *
-     * @return bool
      */
     public function check(array $values, Login $login): bool
     {
@@ -717,8 +710,6 @@ class Preferences
      *
      * @param string $fieldname Field name
      * @param mixed  $value     Value to be set
-     *
-     * @return mixed
      */
     public function validateValue(string $fieldname, mixed $value): mixed
     {
@@ -857,8 +848,6 @@ class Preferences
      * Will store all preferences in the database
      *
      * @param bool $updating True if we're updating instance
-     *
-     * @return bool
      */
     public function store(bool $updating = false): bool
     {
@@ -1014,8 +1003,6 @@ class Preferences
 
     /**
      * Are public pages visible?
-     *
-     * @return bool
      */
     public function arePublicPagesEnabled(): bool
     {
@@ -1026,8 +1013,6 @@ class Preferences
      * Are public pages visible?
      *
      * @param Authentication $login Authentication instance
-     *
-     * @return bool
      *
      * @deprecated 1.2.0
      */
@@ -1046,8 +1031,6 @@ class Preferences
      *
      * @param Authentication $login Authentication instance
      * @param string         $right Right to check
-     *
-     * @return bool
      */
     public function showPublicPage(Authentication $login, string $right): bool
     {
@@ -1231,8 +1214,6 @@ class Preferences
      * Required for twig to access properties via __get
      *
      * @param string $name name of the property we want to retrieve
-     *
-     * @return bool
      */
     public function __isset(string $name): bool
     {
@@ -1269,8 +1250,6 @@ class Preferences
      *
      * @param string $name  name of the property we want to assign a value to
      * @param mixed  $value a relevant value for the property
-     *
-     * @return void
      */
     public function __set(string $name, mixed $value): void
     {
@@ -1308,8 +1287,6 @@ class Preferences
 
     /**
      * Get instance URL from configuration (if set) or guessed if not
-     *
-     * @return string
      */
     public function getURL(): string
     {
@@ -1323,8 +1300,6 @@ class Preferences
 
     /**
      * Get default URL (when not set by user in preferences)
-     *
-     * @return string
      */
     public function getDefaultURL(): string
     {
@@ -1345,8 +1320,6 @@ class Preferences
 
     /**
      * Get last telemetry date
-     *
-     * @return string
      */
     public function getTelemetryDate(): string
     {
@@ -1361,8 +1334,6 @@ class Preferences
 
     /**
      * Get last telemetry registration date
-     *
-     * @return string|null
      */
     public function getRegistrationDate(): ?string
     {
@@ -1450,8 +1421,6 @@ class Preferences
      *
      * @param PHPMailer $mail    PHPMailer instance
      * @param bool      $as_text Whether to return signature as text or HTML (default)
-     *
-     * @return string
      */
     public function getMailSignature(PHPMailer $mail, bool $as_text = false): string
     {
@@ -1570,8 +1539,6 @@ class Preferences
      * Purify HTML value
      *
      * @param string $value Value to clean
-     *
-     * @return string
      */
     public function cleanHtmlValue(string $value): string
     {
@@ -1590,8 +1557,6 @@ class Preferences
      *
      * @param string $field Field name
      * @param mixed  $value Field value
-     *
-     * @return bool
      */
     protected function updateOneField(
         string $field,
@@ -1625,8 +1590,6 @@ class Preferences
 
     /**
      * Update telemetry date only
-     *
-     * @return bool
      */
     public function updateTelemetryDate(): bool
     {
@@ -1638,8 +1601,6 @@ class Preferences
 
     /**
      * Update registration date only
-     *
-     * @return bool
      */
     public function updateRegistrationDate(): bool
     {
@@ -1653,8 +1614,6 @@ class Preferences
      * Generate and store UUID of specified type
      *
      * @param string $type UUID type to generate
-     *
-     * @return string
      */
     public function generateUUID(string $type): string
     {
@@ -1687,8 +1646,6 @@ class Preferences
      * Check if CSS is impacted when storing preferences
      *
      * @param array<string, mixed> $values Values to check
-     *
-     * @return void
      */
     protected function checkCssImpacted(array $values): void
     {
@@ -1714,8 +1671,6 @@ class Preferences
      * Reset dark mode CSS file
      *
      * @param \Slim\Flash\Messages $flash Flash messages instance
-     *
-     * @return void
      */
     public function resetDarkCss(\Slim\Flash\Messages $flash): void
     {
@@ -1795,8 +1750,6 @@ class Preferences
 
     /**
      * Get ID
-     *
-     * @return ?int
      */
     public function getID(): ?int
     {

--- a/galette/lib/Galette/Core/PrintLogo.php
+++ b/galette/lib/Galette/Core/PrintLogo.php
@@ -44,8 +44,6 @@ class PrintLogo extends Logo
      * Gets the default picture to show, anyway
      *
      * @see Logo::getDefaultPicture()
-     *
-     * @return void
      */
     protected function getDefaultPicture(): void
     {

--- a/galette/lib/Galette/Core/SysInfos.php
+++ b/galette/lib/Galette/Core/SysInfos.php
@@ -40,8 +40,6 @@ class SysInfos
      * @param Db          $zdb     Database instance
      * @param Preferences $prefs   Preferences instance
      * @param Plugins     $plugins Plugins
-     *
-     * @return string
      */
     public function getRawData(Db $zdb, Preferences $prefs, Plugins $plugins): string
     {
@@ -112,8 +110,6 @@ class SysInfos
      * Get plugins information
      *
      * @param Plugins $plugins Plugins
-     *
-     * @return string
      */
     private function getPluginsInfo(Plugins $plugins): string
     {

--- a/galette/lib/Galette/Core/Translator.php
+++ b/galette/lib/Galette/Core/Translator.php
@@ -39,8 +39,6 @@ class Translator extends ZTranslator //@phpstan-ignore class.extendsFinalByPhpDo
      * @param string  $message    String to check for
      * @param string  $textDomain Translation domain, defaults to "default"
      * @param ?string $locale     Locale, defaults to null
-     *
-     * @return bool
      */
     public function translationExists(string $message, string $textDomain = 'default', ?string $locale = null): bool
     {

--- a/galette/lib/Galette/DynamicFields/Boolean.php
+++ b/galette/lib/Galette/DynamicFields/Boolean.php
@@ -48,8 +48,6 @@ class Boolean extends DynamicField
 
     /**
      * Get field type
-     *
-     * @return int
      */
     public function getType(): int
     {
@@ -60,8 +58,6 @@ class Boolean extends DynamicField
      * Get value to display for a field
      *
      * @param mixed $value Raw value to get displayed
-     *
-     * @return string
      */
     public function getDisplayValue(mixed $value): string
     {

--- a/galette/lib/Galette/DynamicFields/Choice.php
+++ b/galette/lib/Galette/DynamicFields/Choice.php
@@ -48,8 +48,6 @@ class Choice extends DynamicField
 
     /**
      * Get field type
-     *
-     * @return int
      */
     public function getType(): int
     {
@@ -60,8 +58,6 @@ class Choice extends DynamicField
      * Get value to display for a field
      *
      * @param mixed $value Raw value to get displayed
-     *
-     * @return string
      */
     public function getDisplayValue(mixed $value): string
     {

--- a/galette/lib/Galette/DynamicFields/Date.php
+++ b/galette/lib/Galette/DynamicFields/Date.php
@@ -51,8 +51,6 @@ class Date extends DynamicField
 
     /**
      * Get field type
-     *
-     * @return int
      */
     public function getType(): int
     {
@@ -64,8 +62,6 @@ class Date extends DynamicField
      * This method *tries* to fix that.
      *
      * @param Db $zdb Database instance
-     *
-     * @return bool
      */
     public static function resetLocalizedFormats(Db $zdb): bool
     {
@@ -174,8 +170,6 @@ class Date extends DynamicField
      * Get value to display for a field
      *
      * @param mixed $value Raw value to get displayed
-     *
-     * @return string
      */
     public function getDisplayValue(mixed $value): string
     {

--- a/galette/lib/Galette/DynamicFields/DynamicField.php
+++ b/galette/lib/Galette/DynamicFields/DynamicField.php
@@ -120,8 +120,6 @@ abstract class DynamicField
      *
      * @param Db  $zdb Database instance
      * @param int $id  Field id
-     *
-     * @return DynamicField|false
      */
     public static function loadFieldType(Db $zdb, int $id): DynamicField|false
     {
@@ -155,8 +153,6 @@ abstract class DynamicField
      * @param Db       $zdb Database instance
      * @param int      $t   Field type
      * @param int|null $id  Optional dynamic field id (to load data)
-     *
-     * @return DynamicField
      */
     public static function getFieldType(Db $zdb, int $t, ?int $id = null): DynamicField
     {
@@ -176,8 +172,6 @@ abstract class DynamicField
      * Load field
      *
      * @param int $id Id
-     *
-     * @return void
      */
     public function load(int $id): void
     {
@@ -206,8 +200,6 @@ abstract class DynamicField
      *
      * @param ArrayObject<string, int|string> $rs     ResultSet
      * @param bool                            $values Whether to load values. Defaults to true
-     *
-     * @return void
      */
     public function loadFromRS(ArrayObject $rs, bool $values = true): void
     {
@@ -245,8 +237,6 @@ abstract class DynamicField
      *
      * @param int  $id       Field ID
      * @param bool $prefixed Whether table name should be prefixed
-     *
-     * @return string
      */
     public static function getFixedValuesTableName(int $id, bool $prefixed = false): string
     {
@@ -259,8 +249,6 @@ abstract class DynamicField
 
     /**
      * Returns an array of fixed valued for a field of type 'choice'.
-     *
-     * @return void
      */
     private function loadFixedValues(): void
     {
@@ -292,15 +280,11 @@ abstract class DynamicField
 
     /**
      * Get field type
-     *
-     * @return int
      */
     abstract public function getType(): int;
 
     /**
      * Get field type name
-     *
-     * @return String
      */
     public function getTypeName(): string
     {
@@ -316,8 +300,6 @@ abstract class DynamicField
 
     /**
      * Does the field handle data?
-     *
-     * @return bool
      */
     public function hasData(): bool
     {
@@ -326,8 +308,6 @@ abstract class DynamicField
 
     /**
      * Does the field has width?
-     *
-     * @return bool
      */
     public function hasWidth(): bool
     {
@@ -336,8 +316,6 @@ abstract class DynamicField
 
     /**
      * Does the field has height?
-     *
-     * @return bool
      */
     public function hasHeight(): bool
     {
@@ -346,8 +324,6 @@ abstract class DynamicField
 
     /**
      * Does the field has min size?
-     *
-     * @return bool
      */
     public function hasMinSize(): bool
     {
@@ -356,8 +332,6 @@ abstract class DynamicField
 
     /**
      * Does the field has a size?
-     *
-     * @return bool
      */
     public function hasSize(): bool
     {
@@ -366,8 +340,6 @@ abstract class DynamicField
 
     /**
      * Is the field multivalued?
-     *
-     * @return bool
      */
     public function isMultiValued(): bool
     {
@@ -376,8 +348,6 @@ abstract class DynamicField
 
     /**
      * Does the field has fixed values?
-     *
-     * @return bool
      */
     public function hasFixedValues(): bool
     {
@@ -386,8 +356,6 @@ abstract class DynamicField
 
     /**
      * Does the field require permissions?
-     *
-     * @return bool
      */
     public function hasPermissions(): bool
     {
@@ -396,8 +364,6 @@ abstract class DynamicField
 
     /**
      * Get field id
-     *
-     * @return int|null
      */
     public function getId(): ?int
     {
@@ -406,8 +372,6 @@ abstract class DynamicField
 
     /**
      * Is field required?
-     *
-     * @return bool
      */
     public function isRequired(): bool
     {
@@ -416,8 +380,6 @@ abstract class DynamicField
 
     /**
      * Get field's width in forms
-     *
-     * @return int|null
      */
     public function getWidthInForms(): ?int
     {
@@ -426,8 +388,6 @@ abstract class DynamicField
 
     /**
      * Get field width
-     *
-     * @return int|null
      */
     public function getWidth(): ?int
     {
@@ -436,8 +396,6 @@ abstract class DynamicField
 
     /**
      * Get field height
-     *
-     * @return int|null
      */
     public function getHeight(): ?int
     {
@@ -446,8 +404,6 @@ abstract class DynamicField
 
     /**
      * Is current field repeatable?
-     *
-     * @return bool
      */
     public function isRepeatable(): bool
     {
@@ -456,8 +412,6 @@ abstract class DynamicField
 
     /**
      * Get fields repetitions
-     *
-     * @return int|null
      */
     public function getRepeat(): ?int
     {
@@ -466,8 +420,6 @@ abstract class DynamicField
 
     /**
      * Get field min size
-     *
-     * @return int|null
      */
     public function getMinSize(): ?int
     {
@@ -476,8 +428,6 @@ abstract class DynamicField
 
     /**
      * Get field size
-     *
-     * @return int|null
      */
     public function getSize(): ?int
     {
@@ -486,8 +436,6 @@ abstract class DynamicField
 
     /**
      * Get field index
-     *
-     * @return int|null
      */
     public function getIndex(): ?int
     {
@@ -496,8 +444,6 @@ abstract class DynamicField
 
     /**
      * Get field information
-     *
-     * @return string
      */
     public function getInformation(): string
     {
@@ -506,8 +452,6 @@ abstract class DynamicField
 
     /**
      * Does the field information have to be displayed above input?
-     *
-     * @return bool
      */
     public function hasInformationAbove(): bool
     {
@@ -533,8 +477,6 @@ abstract class DynamicField
      * Retrieve form name
      *
      * @param string $form_name Form name
-     *
-     * @return string
      */
     public static function getFormTitle(string $form_name): string
     {
@@ -544,8 +486,6 @@ abstract class DynamicField
 
     /**
      * Get form
-     *
-     * @return string
      */
     public function getForm(): string
     {
@@ -576,8 +516,6 @@ abstract class DynamicField
      *
      * @param array<string,mixed> $values All values to check, basically the $_POST array
      *                                    after sending the form
-     *
-     * @return bool
      */
     public function check(array $values): bool
     {
@@ -714,8 +652,6 @@ abstract class DynamicField
      *
      * @param array<string,mixed> $values All values to check, basically the $_POST array
      *                                    after sending the form
-     *
-     * @return bool
      */
     public function store(array $values): bool
     {
@@ -842,8 +778,6 @@ abstract class DynamicField
 
     /**
      * Get new index
-     *
-     * @return int
      */
     protected function getNewIndex(): int
     {
@@ -862,8 +796,6 @@ abstract class DynamicField
 
     /**
      * Is field duplicated?
-     *
-     * @return bool
      */
     public function isDuplicate(): bool
     {
@@ -911,8 +843,6 @@ abstract class DynamicField
      * Move a dynamic field
      *
      * @param string $action What to do (one of self::MOVE_*)
-     *
-     * @return bool
      */
     public function move(string $action): bool
     {
@@ -963,8 +893,6 @@ abstract class DynamicField
 
     /**
      * Delete a dynamic field
-     *
-     * @return bool
      */
     public function remove(): bool
     {
@@ -1075,8 +1003,6 @@ abstract class DynamicField
      * Get value to display for a field
      *
      * @param mixed $value Raw value to get displayed
-     *
-     * @return string
      */
     public function getDisplayValue(mixed $value): string
     {

--- a/galette/lib/Galette/DynamicFields/File.php
+++ b/galette/lib/Galette/DynamicFields/File.php
@@ -49,8 +49,6 @@ class File extends DynamicField
 
     /**
      * Get field type
-     *
-     * @return int
      */
     public function getType(): int
     {
@@ -63,8 +61,6 @@ class File extends DynamicField
      * @param int         $id     Object (member, contribution, ...) ID
      * @param int         $pos    Position in the list of values  (0-based)
      * @param string|null $prefix Forced file prefix; if null (defaults) form_name wil be used verbatim
-     *
-     * @return string
      */
     public function getFileName(int $id, int $pos, ?string $prefix = null): string
     {

--- a/galette/lib/Galette/DynamicFields/Line.php
+++ b/galette/lib/Galette/DynamicFields/Line.php
@@ -51,8 +51,6 @@ class Line extends DynamicField
 
     /**
      * Get field type
-     *
-     * @return int
      */
     public function getType(): int
     {

--- a/galette/lib/Galette/DynamicFields/Separator.php
+++ b/galette/lib/Galette/DynamicFields/Separator.php
@@ -47,8 +47,6 @@ class Separator extends DynamicField
 
     /**
      * Get field type
-     *
-     * @return int
      */
     public function getType(): int
     {

--- a/galette/lib/Galette/DynamicFields/Text.php
+++ b/galette/lib/Galette/DynamicFields/Text.php
@@ -50,8 +50,6 @@ class Text extends DynamicField
 
     /**
      * Get field type
-     *
-     * @return int
      */
     public function getType(): int
     {
@@ -62,8 +60,6 @@ class Text extends DynamicField
      * Get value to display for a field
      *
      * @param mixed $value Raw value to get displayed
-     *
-     * @return string
      */
     public function getDisplayValue(mixed $value): string
     {

--- a/galette/lib/Galette/Entity/Adherent.php
+++ b/galette/lib/Galette/Entity/Adherent.php
@@ -53,65 +53,65 @@ use Galette\Features\Dynamics;
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>
  *
- * @property ?int $id
- * @property int|Title|null $title Either a title id or an instance of Title
- * @property ?string $stitle Title label
- * @property string $company_name
- * @property string $name
- * @property ?string $surname
- * @property string $nickname
- * @property ?string $birthdate Localized birthdate
- * @property ?string $rbirthdate Raw birthdate
- * @property string $birth_place
- * @property int $gender
- * @property string $sgender Gender label
- * @property ?string $job
- * @property string $language
- * @property int $status
- * @property string $sstatus Status label
- * @property ?string $address
- * @property ?string $zipcode
- * @property ?string $town
- * @property ?string $country
- * @property ?string $phone
- * @property ?string $gsm
- * @property ?string $email
- * @property string $gnupgid
- * @property string $fingerprint
- * @property ?string $login
- * @property ?string $password Encrypted password
- * @property string $creation_date Localized creation date
- * @property string $modification_date Localized modification date
- * @property ?string $due_date Localized due date
- * @property ?string $rdue_date Due date
- * @property ?string $others_infos
- * @property ?string $others_infos_admin
- * @property Picture $picture
- * @property Group[] $groups
- * @property Group[] $managed_groups
- * @property int|Adherent|null $parent Parent id if parent dep is not loaded, Adherent instance otherwise
- * @property Adherent[] $children
- * @property bool $admin better to rely on isAdmin()
- * @property bool $staff better to rely on isStaff()
- * @property bool $due_free better to rely on isDueFree()
- * @property bool $appears_in_list better to rely on appearsInMembersList()
- * @property bool $active better to rely on isActive()
- * @property bool $duplicate better to rely on isDuplicate()
- * @property string $sadmin yes/no
- * @property string $sstaff yes/no
- * @property string $sdue_free yes/no
- * @property string $sappears_in_list yes/no
- * @property string $sactive yes/no
- * @property string $sfullname
- * @property string $sname
- * @property string $saddress
- * @property string $contribstatus State of member contributions
- * @property int $days_remaining
- * @property-read int $parent_id
- * @property Social $social Social networks/Contact
- * @property string $number Member number
- * @property-read bool $self_adh
- * @property ?string $region
+ * @property      ?int              $id
+ * @property      int|Title|null    $title              Either a title id or an instance of Title
+ * @property      ?string           $stitle             Title label
+ * @property      string            $company_name
+ * @property      string            $name
+ * @property      ?string           $surname
+ * @property      string            $nickname
+ * @property      ?string           $birthdate          Localized birthdate
+ * @property      ?string           $rbirthdate         Raw birthdate
+ * @property      string            $birth_place
+ * @property      int               $gender
+ * @property      string            $sgender            Gender label
+ * @property      ?string           $job
+ * @property      string            $language
+ * @property      int               $status
+ * @property      string            $sstatus            Status label
+ * @property      ?string           $address
+ * @property      ?string           $zipcode
+ * @property      ?string           $town
+ * @property      ?string           $country
+ * @property      ?string           $phone
+ * @property      ?string           $gsm
+ * @property      ?string           $email
+ * @property      string            $gnupgid
+ * @property      string            $fingerprint
+ * @property      ?string           $login
+ * @property      ?string           $password           Encrypted password
+ * @property      string            $creation_date      Localized creation date
+ * @property      string            $modification_date  Localized modification date
+ * @property      ?string           $due_date           Localized due date
+ * @property      ?string           $rdue_date          Due date
+ * @property      ?string           $others_infos
+ * @property      ?string           $others_infos_admin
+ * @property      Picture           $picture
+ * @property      Group[]           $groups
+ * @property      Group[]           $managed_groups
+ * @property      int|Adherent|null $parent             Parent id if parent dep is not loaded, Adherent instance otherwise
+ * @property      Adherent[]        $children
+ * @property      bool              $admin              better to rely on isAdmin()
+ * @property      bool              $staff              better to rely on isStaff()
+ * @property      bool              $due_free           better to rely on isDueFree()
+ * @property      bool              $appears_in_list    better to rely on appearsInMembersList()
+ * @property      bool              $active             better to rely on isActive()
+ * @property      bool              $duplicate          better to rely on isDuplicate()
+ * @property      string            $sadmin             yes/no
+ * @property      string            $sstaff             yes/no
+ * @property      string            $sdue_free          yes/no
+ * @property      string            $sappears_in_list   yes/no
+ * @property      string            $sactive            yes/no
+ * @property      string            $sfullname
+ * @property      string            $sname
+ * @property      string            $saddress
+ * @property      string            $contribstatus      State of member contributions
+ * @property      int               $days_remaining
+ * @property-read int               $parent_id
+ * @property      Social            $social             Social networks/Contact
+ * @property      string            $number             Member number
+ * @property-read bool              $self_adh
+ * @property      ?string           $region
  */
 class Adherent implements AccessManagementInterface
 {
@@ -302,8 +302,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Apply default values
-     *
-     * @return void
      */
     public function applyDefaultValues(): void
     {
@@ -351,8 +349,6 @@ class Adherent implements AccessManagementInterface
      * Loads a member from its login
      *
      * @param string $login login for the member to load
-     *
-     * @return bool
      */
     public function loadFromLoginOrMail(string $login): bool
     {
@@ -380,8 +376,6 @@ class Adherent implements AccessManagementInterface
      * Populate object from a resultset row
      *
      * @param ArrayObject<string, int|string> $r the resultset row
-     *
-     * @return void
      */
     private function loadFromRS(ArrayObject $r): void
     {
@@ -469,8 +463,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Load member parent
-     *
-     * @return void
      */
     private function loadParent(): void
     {
@@ -482,8 +474,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Load member children
-     *
-     * @return void
      */
     private function loadChildren(): void
     {
@@ -508,8 +498,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Load member groups
-     *
-     * @return void
      */
     public function loadGroups(): void
     {
@@ -519,8 +507,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Load member social network/contact information
-     *
-     * @return void
      */
     public function loadSocials(): void
     {
@@ -529,9 +515,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Retrieve status from preferences
-     *
-     * @return int
-     *
      */
     private function getDefaultStatus(): int
     {
@@ -541,8 +524,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Check for dues status
-     *
-     * @return void
      */
     private function checkDues(): void
     {
@@ -609,8 +590,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Is member admin?
-     *
-     * @return bool
      */
     public function isAdmin(): bool
     {
@@ -619,8 +598,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Is user member of staff?
-     *
-     * @return bool
      */
     public function isStaff(): bool
     {
@@ -629,8 +606,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Is member freed of dues?
-     *
-     * @return bool
      */
     public function isDueFree(): bool
     {
@@ -641,8 +616,6 @@ class Adherent implements AccessManagementInterface
      * Is member in specified group?
      *
      * @param string $group_name Group name
-     *
-     * @return bool
      */
     public function isGroupMember(string $group_name): bool
     {
@@ -662,8 +635,6 @@ class Adherent implements AccessManagementInterface
      * Is member manager of specified group?
      *
      * @param ?string $group_name Group name
-     *
-     * @return bool
      */
     public function isGroupManager(?string $group_name): bool
     {
@@ -687,8 +658,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Does current member represents a company?
-     *
-     * @return bool
      */
     public function isCompany(): bool
     {
@@ -697,8 +666,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Is current member a man?
-     *
-     * @return bool
      */
     public function isMan(): bool
     {
@@ -707,8 +674,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Is current member a woman?
-     *
-     * @return bool
      */
     public function isWoman(): bool
     {
@@ -718,8 +683,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Can member appear in public members list?
-     *
-     * @return bool
      */
     public function appearsInMembersList(): bool
     {
@@ -728,8 +691,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Is member active?
-     *
-     * @return bool
      */
     public function isActive(): bool
     {
@@ -738,8 +699,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Does member have uploaded a picture?
-     *
-     * @return bool
      */
     public function hasPicture(): bool
     {
@@ -748,8 +707,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Does member have a parent?
-     *
-     * @return bool
      */
     public function hasParent(): bool
     {
@@ -758,8 +715,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Does member have children?
-     *
-     * @return bool
      */
     public function hasChildren(): bool
     {
@@ -860,8 +815,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Is member a sponsor for current period?
-     *
-     * @return bool
      */
     public function isSponsor(): bool
     {
@@ -947,8 +900,6 @@ class Adherent implements AccessManagementInterface
      * @param false|Title  $title   Member title to show or false
      * @param false|int    $id      Member id to display or false
      * @param false|string $nick    Member nickname to display or false
-     *
-     * @return string
      */
     public static function getNameWithCase(
         ?string $name,
@@ -990,8 +941,6 @@ class Adherent implements AccessManagementInterface
      * @param Db     $zdb    Database instance
      * @param int    $id_adh Member identifier
      * @param string $pass   New password
-     *
-     * @return bool
      */
     public static function updatePassword(Db $zdb, int $id_adh, string $pass): bool
     {
@@ -1013,8 +962,6 @@ class Adherent implements AccessManagementInterface
      * Get field label
      *
      * @param string $field Field name
-     *
-     * @return string
      */
     private function getFieldLabel(string $field): string
     {
@@ -1057,8 +1004,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Mark as self membership
-     *
-     * @return void
      */
     public function setSelfMembership(): void
     {
@@ -1067,8 +1012,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Is member up to date?
-     *
-     * @return bool
      */
     public function isUp2Date(): bool
     {
@@ -1096,8 +1039,6 @@ class Adherent implements AccessManagementInterface
      * @param Preferences         $preferences Preferences instance
      * @param array<string,mixed> $fields      Members fields configuration
      * @param History             $history     History instance
-     *
-     * @return void
      */
     public function setDependencies(
         Preferences $preferences,
@@ -1282,8 +1223,6 @@ class Adherent implements AccessManagementInterface
      * @param string              $field  Field name
      * @param mixed               $value  Value we want to set
      * @param array<string,mixed> $values All values, for some references
-     *
-     * @return void
      */
     public function validate(string $field, mixed $value, array $values): void
     {
@@ -1599,8 +1538,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Store the member
-     *
-     * @return bool
      */
     public function store(): bool
     {
@@ -1767,8 +1704,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Update member modification date
-     *
-     * @return void
      */
     private function updateModificationDate(): void
     {
@@ -1833,8 +1768,6 @@ class Adherent implements AccessManagementInterface
      * Global getter method
      *
      * @param string $name name of the property we want to retrieve
-     *
-     * @return mixed
      */
     public function __get(string $name): mixed
     {
@@ -1957,8 +1890,6 @@ class Adherent implements AccessManagementInterface
      * Required for twig to access properties via __get
      *
      * @param string $name name of the property we want to retrieve
-     *
-     * @return bool
      */
     public function __isset(string $name): bool
     {
@@ -1991,8 +1922,6 @@ class Adherent implements AccessManagementInterface
      * Get member email
      * If member does not have an email address but is attached to
      * another member, we'll take information from its parent.
-     *
-     * @return string
      */
     public function getEmail(): string
     {
@@ -2008,8 +1937,6 @@ class Adherent implements AccessManagementInterface
     /**
      * Get member address.
      * If member does not have an address but is attached to another member, we'll take information from its parent.
-     *
-     * @return string
      */
     public function getAddress(): string
     {
@@ -2025,8 +1952,6 @@ class Adherent implements AccessManagementInterface
     /**
      * Get member zipcode.
      * If member does not have an address but is attached to another member, we'll take information from its parent.
-     *
-     * @return string
      */
     public function getZipcode(): string
     {
@@ -2043,8 +1968,6 @@ class Adherent implements AccessManagementInterface
     /**
      * Get member town.
      * If member does not have an address but is attached to another member, we'll take information from its parent.
-     *
-     * @return string
      */
     public function getTown(): string
     {
@@ -2061,8 +1984,6 @@ class Adherent implements AccessManagementInterface
     /**
      * Get member region.
      * If member does not have an address but is attached to another member, we'll take information from its parent.
-     *
-     * @return string
      */
     public function getRegion(): string
     {
@@ -2079,8 +2000,6 @@ class Adherent implements AccessManagementInterface
     /**
      * Get member country.
      * If member does not have an address but is attached to another member, we'll take information from its parent.
-     *
-     * @return string
      */
     public function getCountry(): string
     {
@@ -2096,8 +2015,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Get member age
-     *
-     * @return string
      */
     public function getAge(): string
     {
@@ -2170,8 +2087,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Set member as duplicate
-     *
-     * @return void
      */
     public function setDuplicate(): void
     {
@@ -2247,8 +2162,6 @@ class Adherent implements AccessManagementInterface
      * Can current logged-in user create member
      *
      * @param Login $login Login instance
-     *
-     * @return bool
      */
     public function canCreate(Login $login): bool
     {
@@ -2268,8 +2181,6 @@ class Adherent implements AccessManagementInterface
      * Can current logged-in user display member
      *
      * @param Login $login Login instance
-     *
-     * @return bool
      */
     public function canShow(Login $login): bool
     {
@@ -2289,8 +2200,6 @@ class Adherent implements AccessManagementInterface
      * Can current logged-in user edit member
      *
      * @param Login $login Login instance
-     *
-     * @return bool
      */
     public function canEdit(Login $login): bool
     {
@@ -2322,8 +2231,6 @@ class Adherent implements AccessManagementInterface
      * Can current logged-in user delete member
      *
      * @param Login $login Login instance
-     *
-     * @return bool
      */
     public function canDelete(Login $login): bool
     {
@@ -2333,8 +2240,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Are we currently duplicated a member?
-     *
-     * @return bool
      */
     public function isDuplicate(): bool
     {
@@ -2345,8 +2250,6 @@ class Adherent implements AccessManagementInterface
      * Flag creation mail sending
      *
      * @param bool $send True (default) to send creation email
-     *
-     * @return Adherent
      */
     public function setSendmail(bool $send = true): self
     {
@@ -2356,8 +2259,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Should we send administrative emails to member?
-     *
-     * @return bool
      */
     public function sendEMail(): bool
     {
@@ -2380,8 +2281,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Get current due status
-     *
-     * @return int
      */
     public function getDueStatus(): int
     {
@@ -2390,8 +2289,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Get prefix for events
-     *
-     * @return string
      */
     protected function getEventsPrefix(): string
     {
@@ -2454,8 +2351,6 @@ class Adherent implements AccessManagementInterface
 
     /**
      * Get member vCard
-     *
-     * @return VCard
      */
     public function getVCard(): VCard
     {

--- a/galette/lib/Galette/Entity/Contribution.php
+++ b/galette/lib/Galette/Entity/Contribution.php
@@ -49,23 +49,23 @@ use function Safe\mkdir;
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>
  *
- * @property int $id
- * @property ?string $date
- * @property ?DateTime $raw_date
- * @property ?int $member
- * @property ?ContributionsTypes $type
- * @property ?double $amount
- * @property ?int $payment_type
- * @property ?double $orig_amount
- * @property ?string $info
- * @property ?string $begin_date
- * @property ?DateTime $raw_begin_date
- * @property ?string $end_date
- * @property ?DateTime $raw_end_date
- * @property ?Transaction $transaction
- * @property ?int $extension
- * @property int $duration
- * @property ?int $model
+ * @property int                                  $id
+ * @property ?string                              $date
+ * @property ?DateTime                            $raw_date
+ * @property ?int                                 $member
+ * @property ?ContributionsTypes                  $type
+ * @property ?float                               $amount
+ * @property ?int                                 $payment_type
+ * @property ?float                               $orig_amount
+ * @property ?string                              $info
+ * @property ?string                              $begin_date
+ * @property ?DateTime                            $raw_begin_date
+ * @property ?string                              $end_date
+ * @property ?DateTime                            $raw_end_date
+ * @property ?Transaction                         $transaction
+ * @property ?int                                 $extension
+ * @property int                                  $duration
+ * @property ?int                                 $model
  * @property array<string, array<string, string>> $fields
  */
 class Contribution implements AccessManagementInterface
@@ -163,8 +163,6 @@ class Contribution implements AccessManagementInterface
 
     /**
      * Set fields, must populate $this->fields
-     *
-     * @return self
      */
     protected function setFields(): self
     {
@@ -223,8 +221,6 @@ class Contribution implements AccessManagementInterface
 
     /**
      * Sets end contribution date
-     *
-     * @return void
      */
     private function retrieveEndDate(): void
     {
@@ -364,8 +360,6 @@ class Contribution implements AccessManagementInterface
      * Populate object from a resultset row
      *
      * @param ArrayObject<string, int|string> $r the resultset row
-     *
-     * @return void
      */
     private function loadFromRS(ArrayObject $r): void
     {
@@ -407,8 +401,6 @@ class Contribution implements AccessManagementInterface
      * Populate object from an array
      *
      * @param array<string,mixed> $args Instanciation arguments
-     *
-     * @return void
      */
     private function loadFromArray(array $args): void
     {
@@ -450,8 +442,6 @@ class Contribution implements AccessManagementInterface
 
     /**
      * Contribution created with a membership extension
-     *
-     * @return void
      */
     private function loadWithMembershipExt(): void
     {
@@ -474,8 +464,6 @@ class Contribution implements AccessManagementInterface
 
     /**
      * Contribution created with an en date of membership
-     *
-     * @return void
      */
     private function loadWithEndofMembershipDate(): void
     {
@@ -715,8 +703,6 @@ class Contribution implements AccessManagementInterface
 
     /**
      * Store the contribution
-     *
-     * @return bool
      */
     public function store(): bool
     {
@@ -816,8 +802,6 @@ class Contribution implements AccessManagementInterface
 
     /**
      * Update member deadline
-     *
-     * @return bool
      */
     private function updateDeadline(): bool
     {
@@ -849,8 +833,6 @@ class Contribution implements AccessManagementInterface
      * Remove contribution from database
      *
      * @param bool $transaction Activate transaction mode (defaults to true)
-     *
-     * @return bool
      */
     public function remove(bool $transaction = true): bool
     {
@@ -897,8 +879,6 @@ class Contribution implements AccessManagementInterface
      *
      * @param string $field Field name
      * @param string $entry Array entry to use (defaults to "label")
-     *
-     * @return string
      */
     public function getFieldLabel(string $field, string $entry = 'label'): string
     {
@@ -941,8 +921,6 @@ class Contribution implements AccessManagementInterface
      *
      * @param Db   $zdb       Database instance
      * @param ?int $member_id Member identifier
-     *
-     * @return string|null
      */
     public static function getDueDate(Db $zdb, ?int $member_id): ?string
     {
@@ -986,8 +964,6 @@ class Contribution implements AccessManagementInterface
      * Detach a contribution from a transaction
      *
      * @param int $trans_id Transaction identifier
-     *
-     * @return bool
      */
     public function unsetTransactionPart(int $trans_id): bool
     {
@@ -1025,8 +1001,6 @@ class Contribution implements AccessManagementInterface
      * Set a contribution as a transaction part
      *
      * @param int $trans_id Transaction identifier
-     *
-     * @return bool
      */
     public function setTransactionPart(int $trans_id): bool
     {
@@ -1050,8 +1024,6 @@ class Contribution implements AccessManagementInterface
 
     /**
      * Is current contribution a membership fee
-     *
-     * @return bool
      */
     public function isFee(): bool
     {
@@ -1062,8 +1034,6 @@ class Contribution implements AccessManagementInterface
      * Is current contribution part of specified transaction
      *
      * @param int $id Transaction identifier
-     *
-     * @return bool
      */
     public function isTransactionPartOf(int $id): bool
     {
@@ -1076,8 +1046,6 @@ class Contribution implements AccessManagementInterface
 
     /**
      * Is current contribution part of transaction
-     *
-     * @return bool
      */
     public function isTransactionPart(): bool
     {
@@ -1180,8 +1148,6 @@ class Contribution implements AccessManagementInterface
     }
     /**
      * Get raw contribution type
-     *
-     * @return string
      */
     public function getRawType(): string
     {
@@ -1194,8 +1160,6 @@ class Contribution implements AccessManagementInterface
 
     /**
      * Get contribution type label
-     *
-     * @return string
      */
     public function getTypeLabel(): string
     {
@@ -1208,8 +1172,6 @@ class Contribution implements AccessManagementInterface
 
     /**
      * Get payment type id
-     *
-     * @return int
      */
     public function getPaymentTypeId(): int
     {
@@ -1223,8 +1185,6 @@ class Contribution implements AccessManagementInterface
 
     /**
      * Get payment type label
-     *
-     * @return string
      */
     public function getPaymentType(): string
     {
@@ -1314,8 +1274,6 @@ class Contribution implements AccessManagementInterface
      *
      * @param string $name  name of the property we want to assign a value to
      * @param mixed  $value a relevant value for the property
-     *
-     * @return void
      */
     public function __set(string $name, mixed $value): void
     {
@@ -1374,8 +1332,6 @@ class Contribution implements AccessManagementInterface
      * Flag creation mail sending
      *
      * @param bool $send True (default) to send creation email
-     *
-     * @return self
      */
     public function setSendmail(bool $send = true): self
     {
@@ -1385,8 +1341,6 @@ class Contribution implements AccessManagementInterface
 
     /**
      * Should we send administrative emails to member?
-     *
-     * @return bool
      */
     public function sendEMail(): bool
     {
@@ -1439,8 +1393,6 @@ class Contribution implements AccessManagementInterface
      * Can current logged-in user create a contribution?
      *
      * @param Login $login Login instance
-     *
-     * @return bool
      */
     public function canCreate(Login $login): bool
     {
@@ -1460,8 +1412,6 @@ class Contribution implements AccessManagementInterface
      * Can current logged-in user display contribution?
      *
      * @param Login $login Login instance
-     *
-     * @return bool
      */
     public function canShow(Login $login): bool
     {
@@ -1505,8 +1455,6 @@ class Contribution implements AccessManagementInterface
      * Can current logged-in user edit a contribution?
      *
      * @param Login $login Login instance
-     *
-     * @return bool
      */
     public function canEdit(Login $login): bool
     {
@@ -1520,8 +1468,6 @@ class Contribution implements AccessManagementInterface
      * Can current logged-in user delete a contribution?
      *
      * @param Login $login Login instance
-     *
-     * @return bool
      */
     public function canDelete(Login $login): bool
     {
@@ -1532,8 +1478,6 @@ class Contribution implements AccessManagementInterface
      * Set contribution type and determine if it is a contribution or a donation
      *
      * @param int $type Type
-     *
-     * @return self
      */
     public function setContributionType(int $type): self
     {
@@ -1547,8 +1491,6 @@ class Contribution implements AccessManagementInterface
 
     /**
      * Get prefix for events
-     *
-     * @return string
      */
     protected function getEventsPrefix(): string
     {
@@ -1558,7 +1500,6 @@ class Contribution implements AccessManagementInterface
     /**
      * Does contribution have attached scheduled payment?
      *
-     * @return bool
      * @throws Throwable
      */
     public function hasSchedule(): bool
@@ -1570,7 +1511,6 @@ class Contribution implements AccessManagementInterface
     /**
      * Is schedule fully allocated
      *
-     * @return bool
      * @throws Throwable
      */
     public function isScheduleFullyAllocated(): bool
@@ -1584,7 +1524,6 @@ class Contribution implements AccessManagementInterface
      *
      * @param int $value Payment type to set
      *
-     * @return void
      * @throws Throwable
      */
     public function setPaymentType(int $value): void
@@ -1616,8 +1555,6 @@ class Contribution implements AccessManagementInterface
 
     /**
      * Disable login on checks
-     *
-     * @return self
      */
     public function setNoCheckLogin(): self
     {

--- a/galette/lib/Galette/Entity/ContributionsTypes.php
+++ b/galette/lib/Galette/Entity/ContributionsTypes.php
@@ -35,11 +35,11 @@ use Throwable;
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>
  *
- * @property int $id
+ * @property int    $id
  * @property string $label
  * @property string $libelle
  * @property ?float $amount
- * @property int $extension
+ * @property int    $extension
  */
 
 class ContributionsTypes
@@ -132,8 +132,6 @@ class ContributionsTypes
      * Populate object from a resultset row
      *
      * @param ArrayObject<string, int|string> $r the resultset row
-     *
-     * @return void
      */
     private function loadFromRS(ArrayObject $r): void
     {
@@ -147,8 +145,6 @@ class ContributionsTypes
 
     /**
      * Does current type give membership extension?
-     *
-     * @return bool
      */
     public function isExtension(): bool
     {
@@ -157,8 +153,6 @@ class ContributionsTypes
 
     /**
      * Get the amount
-     *
-     * @return float
      */
     public function getAmount(): float
     {
@@ -168,7 +162,6 @@ class ContributionsTypes
     /**
      * Set defaults at install time
      *
-     * @return bool
      * @throws Throwable
      */
     public function installInit(): bool
@@ -343,8 +336,6 @@ class ContributionsTypes
      * @param int  $id         Id
      * @param bool $translated Do we want translated or original label?
      *                         Defaults to true.
-     *
-     * @return string|int
      */
     public function getLabel(int $id, bool $translated = true): string|int
     {
@@ -555,8 +546,6 @@ class ContributionsTypes
      * Check if this entry is used.
      *
      * @param int $id Entry ID
-     *
-     * @return bool
      */
     public function isUsed(int $id): bool
     {
@@ -609,8 +598,6 @@ class ContributionsTypes
      * Required for twig to access properties via __get
      *
      * @param string $name name of the property we want to retrieve
-     *
-     * @return bool
      */
     public function __isset(string $name): bool
     {

--- a/galette/lib/Galette/Entity/Document.php
+++ b/galette/lib/Galette/Entity/Document.php
@@ -91,8 +91,6 @@ class Document
      * Load a document from its identifier
      *
      * @param int $id Identifier
-     *
-     * @return void
      */
     private function load(int $id): void
     {
@@ -201,8 +199,6 @@ class Document
      * Check if a document can be shown
      *
      * @param Login $login Login
-     *
-     * @return bool
      */
     public function canShow(Login $login): bool
     {
@@ -222,8 +218,6 @@ class Document
      * Load document from a db ResultSet
      *
      * @param ArrayObject<string, int|string> $rs ResultSet
-     *
-     * @return void
      */
     private function loadFromRS(ArrayObject $rs): void
     {
@@ -240,8 +234,6 @@ class Document
      *
      * @param array<string,mixed>          $post  POST data
      * @param array<UploadedFileInterface> $files Uploaded files
-     *
-     * @return bool
      */
     public function store(array $post, array $files): bool
     {
@@ -296,8 +288,6 @@ class Document
      * Remove document
      *
      * @param array<int>|null $ids IDs to remove, default to current id
-     *
-     * @return bool
      */
     public function remove(?array $ids = null): bool
     {
@@ -332,8 +322,6 @@ class Document
 
     /**
      * Remove document file
-     *
-     * @return bool
      */
     protected function removeFile(): bool
     {
@@ -348,8 +336,6 @@ class Document
 
     /**
      * Get file URL
-     *
-     * @return string
      */
     public function getURL(): string
     {
@@ -358,8 +344,6 @@ class Document
 
     /**
      * Get document ID
-     *
-     * @return ?int
      */
     public function getId(): ?int
     {
@@ -368,8 +352,6 @@ class Document
 
     /**
      * Get document file name
-     *
-     * @return string
      */
     public function getDocumentFilename(): string
     {
@@ -379,8 +361,6 @@ class Document
     /**
      * Set comment
      * @param ?string $comment Comment to set
-     *
-     * @return self
      */
     public function setComment(?string $comment): self
     {
@@ -390,8 +370,6 @@ class Document
 
     /**
      * Get comment
-     *
-     * @return ?string
      */
     public function getComment(): ?string
     {
@@ -402,8 +380,6 @@ class Document
      * Set type
      *
      * @param string $type Type
-     *
-     * @return self
      */
     public function setType(string $type): self
     {
@@ -413,8 +389,6 @@ class Document
 
     /**
      * Get type
-     *
-     * @return string
      */
     public function getType(): string
     {
@@ -425,8 +399,6 @@ class Document
      * Get creation date
      *
      * @param bool $formatted Return formatted date (default) or not
-     *
-     * @return string|DateTime
      */
     public function getCreationDate(bool $formatted = true): string|DateTime
     {
@@ -470,8 +442,6 @@ class Document
      *
      * @param string $type       Document type
      * @param bool   $translated Return translated types (default) or not
-     *
-     * @return string
      */
     public function getSystemType(string $type, bool $translated = true): string
     {

--- a/galette/lib/Galette/Entity/DynamicFieldsHandle.php
+++ b/galette/lib/Galette/Entity/DynamicFieldsHandle.php
@@ -83,8 +83,6 @@ class DynamicFieldsHandle
      * Load dynamic fields values for specified object
      *
      * @param object $object Object instance
-     *
-     * @return bool
      */
     public function load(object $object): bool
     {
@@ -212,8 +210,6 @@ class DynamicFieldsHandle
      * @param int        $field Field ID
      * @param int        $index Value index
      * @param string|int $value Value
-     *
-     * @return void
      */
     public function setValue(?int $item, int $field, int $index, string|int $value): void
     {
@@ -237,8 +233,6 @@ class DynamicFieldsHandle
      *
      * @param int $field Field ID
      * @param int $index Value index
-     *
-     * @return void
      */
     public function unsetValue(int $field, int $index): void
     {
@@ -253,8 +247,6 @@ class DynamicFieldsHandle
      *
      * @param ?int $item_id     Current item id to use (will be used if current item_id is 0)
      * @param bool $transaction True if a transaction already exists
-     *
-     * @return bool
      */
     public function storeValues(?int $item_id = null, bool $transaction = false): bool
     {
@@ -318,8 +310,6 @@ class DynamicFieldsHandle
 
     /**
      * Get (and prepare if not done yet) insert statement
-     *
-     * @return StatementInterface
      */
     private function getInsertStatement(): StatementInterface
     {
@@ -339,8 +329,6 @@ class DynamicFieldsHandle
 
     /**
      * Get (and prepare if not done yet) update statement
-     *
-     * @return StatementInterface
      */
     private function getUpdateStatement(): StatementInterface
     {
@@ -362,8 +350,6 @@ class DynamicFieldsHandle
 
     /**
      * Handle values that have been removed
-     *
-     * @return void
      */
     private function handleRemovals(): void
     {
@@ -433,8 +419,6 @@ class DynamicFieldsHandle
 
     /**
      * Is there any change in dynamic fields?
-     *
-     * @return bool
      */
     public function hasChanged(): bool
     {
@@ -446,8 +430,6 @@ class DynamicFieldsHandle
      *
      * @param ?int $item_id     Current item id to use (will be used if current item_id is 0)
      * @param bool $transaction True if a transaction already exists
-     *
-     * @return bool
      */
     public function removeValues(?int $item_id = null, bool $transaction = false): bool
     {
@@ -487,8 +469,6 @@ class DynamicFieldsHandle
 
     /**
      * Get current fields resultset
-     *
-     * @return ResultSet
      */
     protected function getCurrentFields(): ResultSet
     {

--- a/galette/lib/Galette/Entity/FieldsCategories.php
+++ b/galette/lib/Galette/Entity/FieldsCategories.php
@@ -87,8 +87,6 @@ class FieldsCategories
      *
      * @param Db                $zdb        Database
      * @param array<int,string> $categories Categories
-     *
-     * @return bool
      */
     public static function setCategories(Db $zdb, array $categories): bool
     {
@@ -125,7 +123,6 @@ class FieldsCategories
     /**
      * Set default fields categories at install time
      *
-     * @return bool
      * @throws Throwable
      */
     public function installInit(): bool

--- a/galette/lib/Galette/Entity/FieldsConfig.php
+++ b/galette/lib/Galette/Entity/FieldsConfig.php
@@ -144,8 +144,6 @@ class FieldsConfig
 
     /**
      * Load current fields configuration from database.
-     *
-     * @return bool
      */
     public function load(): bool
     {
@@ -217,8 +215,6 @@ class FieldsConfig
     /**
      * Create field array configuration,
      * Several lists of fields are kept (visible, requireds, etc), build them.
-     *
-     * @return void
      */
     protected function buildLists(): void
     {
@@ -235,8 +231,6 @@ class FieldsConfig
      * Adds a field to lists
      *
      * @param array<string,mixed> $field Field values
-     *
-     * @return void
      */
     protected function addToLists(array $field): void
     {
@@ -257,8 +251,6 @@ class FieldsConfig
      * Is a field set as required?
      *
      * @param string $field Field name
-     *
-     * @return bool
      */
     public function isRequired(string $field): bool
     {
@@ -270,8 +262,6 @@ class FieldsConfig
      * (password for existing members for example)
      *
      * @param string $field Field name
-     *
-     * @return void
      */
     public function setNotRequired(string $field): void
     {
@@ -293,8 +283,6 @@ class FieldsConfig
      * Checks if all fields are present in the database.
      *
      * For now, this function only checks if count matches.
-     *
-     * @return void
      */
     private function checkUpdate(): void
     {
@@ -371,7 +359,6 @@ class FieldsConfig
      * Set default fields configuration at install time. All previous
      * existing values will be dropped first, including fields categories.
      *
-     * @return bool
      * @throws Throwable
      */
     public function installInit(): bool
@@ -713,8 +700,6 @@ class FieldsConfig
      * Get visibility for specified field
      *
      * @param string $field The requested field
-     *
-     * @return int
      */
     public function getVisibility(string $field): int
     {
@@ -735,8 +720,6 @@ class FieldsConfig
      * Set fields
      *
      * @param array<int, array<int, array<string, mixed>>> $fields categorized fields array
-     *
-     * @return bool
      */
     public function setFields(array $fields): bool
     {
@@ -746,8 +729,6 @@ class FieldsConfig
 
     /**
      * Store config in database
-     *
-     * @return bool
      */
     private function store(): bool
     {
@@ -828,8 +809,6 @@ class FieldsConfig
      * Migrate old required fields configuration
      * Only needed for 0.7.4 upgrade
      * (should have been 0.7.3 - but I missed that.)
-     *
-     * @return bool
      */
     public function migrateRequired(): bool
     {
@@ -907,8 +886,6 @@ class FieldsConfig
      * Insert values in database
      *
      * @param array<int,mixed> $values Values to insert
-     *
-     * @return void
      */
     private function insert(array $values): void
     {
@@ -958,8 +935,6 @@ class FieldsConfig
      * Does field should be displayed in self subscription page
      *
      * @param string $name Field name
-     *
-     * @return bool
      */
     public function isSelfExcluded(string $name): bool
     {
@@ -977,8 +952,6 @@ class FieldsConfig
      *
      * @param Login               $login  Login instance
      * @param array<string,mixed> $fields Fields list
-     *
-     * @return void
      */
     public function filterVisible(Login $login, array &$fields): void
     {

--- a/galette/lib/Galette/Entity/Group.php
+++ b/galette/lib/Galette/Entity/Group.php
@@ -118,8 +118,6 @@ class Group
      * Load group from its name
      *
      * @param string $group_name Group name
-     *
-     * @return bool
      */
     public function loadFromName(string $group_name): bool
     {
@@ -150,8 +148,6 @@ class Group
      * Populate object from a resultset row
      *
      * @param ArrayObject<string, int|string> $r the resultset row
-     *
-     * @return void
      */
     private function loadFromRS(ArrayObject $r): void
     {
@@ -171,8 +167,6 @@ class Group
      * Loads members for the current group
      *
      * @param int $type Either self::MEMBER_TYPE or self::MANAGER_TYPE
-     *
-     * @return void
      */
     private function loadPersons(int $type): void
     {
@@ -237,8 +231,6 @@ class Group
 
     /**
      * Load sub-groups
-     *
-     * @return void
      */
     private function loadSubGroups(): void
     {
@@ -278,8 +270,6 @@ class Group
      * Remove specified group
      *
      * @param bool $cascade Also remove members and managers
-     *
-     * @return bool
      */
     public function remove(bool $cascade = false): bool
     {
@@ -360,8 +350,6 @@ class Group
 
     /**
      * Is group empty? (after first deletion try)
-     *
-     * @return bool
      */
     public function isEmpty(): bool
     {
@@ -370,8 +358,6 @@ class Group
 
     /**
      * Detach a group from its parent
-     *
-     * @return bool
      */
     public function detach(): bool
     {
@@ -412,8 +398,6 @@ class Group
 
     /**
      * Store the group
-     *
-     * @return bool
      */
     public function store(): bool
     {
@@ -496,8 +480,6 @@ class Group
      * Is current logged-in user manager of the group?
      *
      * @param Login $login Login instance
-     *
-     * @return bool
      */
     public function isManager(Login $login): bool
     {
@@ -521,8 +503,6 @@ class Group
 
     /**
      * Get group id
-     *
-     * @return int
      */
     public function getId(): ?int
     {
@@ -531,8 +511,6 @@ class Group
 
     /**
      * Get Level of the group
-     *
-     * @return int
      */
     public function getLevel(): int
     {
@@ -544,8 +522,6 @@ class Group
 
     /**
      * Get the full name of the group "foo / bar"
-     *
-     * @return ?string
      */
     public function getFullName(): ?string
     {
@@ -573,8 +549,6 @@ class Group
 
     /**
      * Get the indented short name of the group "  >> bar"
-     *
-     * @return ?string
      */
     public function getIndentName(): ?string
     {
@@ -586,8 +560,6 @@ class Group
 
     /**
      * Get group name
-     *
-     * @return ?string
      */
     public function getName(): ?string
     {
@@ -635,8 +607,6 @@ class Group
 
     /**
      * Get parent group
-     *
-     * @return Group|null
      */
     public function getParentGroup(): ?Group
     {
@@ -647,8 +617,6 @@ class Group
      * Get group creation date
      *
      * @param bool $formatted Return date formatted, raw if false
-     *
-     * @return string
      */
     public function getCreationDate(bool $formatted = true): string
     {
@@ -664,8 +632,6 @@ class Group
      * Get member count
      *
      * @param bool $force Force members load, defaults to false
-     *
-     * @return int
      */
     public function getMemberCount(bool $force = false): int
     {
@@ -684,8 +650,6 @@ class Group
      * Set name
      *
      * @param string $name Group name
-     *
-     * @return self
      */
     public function setName(string $name): self
     {
@@ -697,8 +661,6 @@ class Group
      * check if can Set parent group
      *
      * @param Group $group Parent group
-     *
-     * @return bool
      */
     public function canSetParentGroup(Group $group): bool
     {
@@ -715,8 +677,6 @@ class Group
      * Set parent group
      *
      * @param int $id Parent group identifier
-     *
-     * @return self
      */
     public function setParentGroup(int $id): self
     {
@@ -740,8 +700,6 @@ class Group
      * Add member to group
      *
      * @param Adherent $member Member to add
-     *
-     * @return void
      */
     public function addMember(Adherent $member): void
     {
@@ -779,7 +737,6 @@ class Group
      *
      * @param Adherent[] $members Members list
      *
-     * @return bool
      * @throws Throwable
      */
     public function setMembers(array $members = []): bool
@@ -868,7 +825,6 @@ class Group
      *
      * @param Adherent[] $members Managers list
      *
-     * @return bool
      * @throws Throwable
      */
     public function setManagers(array $members = []): bool
@@ -956,8 +912,6 @@ class Group
      * Set login instance
      *
      * @param Login $login Login instance
-     *
-     * @return self
      */
     public function setLogin(Login $login): self
     {
@@ -969,8 +923,6 @@ class Group
      * Can current logged-in user edit group
      *
      * @param Login $login Login instance
-     *
-     * @return bool
      */
     public function canEdit(Login $login): bool
     {

--- a/galette/lib/Galette/Entity/ImportModel.php
+++ b/galette/lib/Galette/Entity/ImportModel.php
@@ -83,8 +83,6 @@ class ImportModel
      * Populate object from a resultset row
      *
      * @param ArrayObject<string, int|string> $r the resultset row
-     *
-     * @return void
      */
     private function loadFromRS(ArrayObject $r): void
     {
@@ -101,8 +99,6 @@ class ImportModel
      * Remove model
      *
      * @param Db $zdb Database instance
-     *
-     * @return bool
      */
     public function remove(Db $zdb): bool
     {
@@ -129,8 +125,6 @@ class ImportModel
      * Store the model
      *
      * @param Db $zdb Database instance
-     *
-     * @return bool
      */
     public function store(Db $zdb): bool
     {
@@ -188,8 +182,6 @@ class ImportModel
      * Get creation date
      *
      * @param bool $formatted Return date formatted, raw if false
-     *
-     * @return string
      */
     public function getCreationDate(bool $formatted = true): string
     {
@@ -205,8 +197,6 @@ class ImportModel
      * Set fields
      *
      * @param array<string> $fields Fields list
-     *
-     * @return self
      */
     public function setFields(array $fields): self
     {

--- a/galette/lib/Galette/Entity/ListsConfig.php
+++ b/galette/lib/Galette/Entity/ListsConfig.php
@@ -84,8 +84,6 @@ class ListsConfig extends FieldsConfig
     /**
      * Create field array configuration
      * Several lists of fields are kept (visible, required, etc), build them.
-     *
-     * @return void
      */
     protected function buildLists(): void
     {
@@ -109,8 +107,6 @@ class ListsConfig extends FieldsConfig
      * Adds a field to lists
      *
      * @param array<string,mixed> $field Field values
-     *
-     * @return void
      */
     protected function addToLists(array $field): void
     {
@@ -182,8 +178,6 @@ class ListsConfig extends FieldsConfig
      * Handle list labels
      *
      * @param object $field Field data
-     *
-     * @return void
      */
     private function handleLabel(object $field): void
     {
@@ -247,8 +241,6 @@ class ListsConfig extends FieldsConfig
      * Set fields
      *
      * @param array<int,array<string,mixed>> $fields categorized fields array
-     *
-     * @return bool
      */
     public function setListFields(array $fields): bool
     {
@@ -258,8 +250,6 @@ class ListsConfig extends FieldsConfig
 
     /**
      * Store list config in database
-     *
-     * @return bool
      */
     private function storeList(): bool
     {
@@ -345,8 +335,6 @@ class ListsConfig extends FieldsConfig
      * Get visibility for specified field
      *
      * @param string $field The requested field
-     *
-     * @return int
      */
     public function getVisibility(string $field): int
     {

--- a/galette/lib/Galette/Entity/PaymentType.php
+++ b/galette/lib/Galette/Entity/PaymentType.php
@@ -35,7 +35,7 @@ use Galette\Features\Translatable;
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>
  *
- * @property int $id
+ * @property int    $id
  * @property string $name
  */
 
@@ -80,8 +80,6 @@ class PaymentType implements \Stringable
      * Load a payment type from its identifier
      *
      * @param int $id Identifier
-     *
-     * @return bool
      */
     public function load(int $id): bool
     {
@@ -109,8 +107,6 @@ class PaymentType implements \Stringable
      * Load payment type from a db ResultSet
      *
      * @param ArrayObject<string, int|string> $rs ResultSet
-     *
-     * @return void
      */
     private function loadFromRS(ArrayObject $rs): void
     {
@@ -121,8 +117,6 @@ class PaymentType implements \Stringable
 
     /**
      * Store payment type in database
-     *
-     * @return bool
      */
     public function store(): bool
     {
@@ -165,8 +159,6 @@ class PaymentType implements \Stringable
 
     /**
      * Remove current title
-     *
-     * @return bool
      */
     public function remove(): bool
     {
@@ -199,8 +191,6 @@ class PaymentType implements \Stringable
      * Getter
      *
      * @param string $name Property name
-     *
-     * @return mixed
      */
     public function __get(string $name): mixed
     {
@@ -221,8 +211,6 @@ class PaymentType implements \Stringable
      * Required for twig to access properties via __get
      *
      * @param string $name Property name
-     *
-     * @return bool
      */
     public function __isset(string $name): bool
     {
@@ -237,8 +225,6 @@ class PaymentType implements \Stringable
      *
      * @param string $name  Property name
      * @param mixed  $value Property value
-     *
-     * @return void
      */
     public function __set(string $name, mixed $value): void
     {
@@ -302,9 +288,6 @@ class PaymentType implements \Stringable
 
     /**
      * Is current payment a system one
-     *
-     * @return bool
-     *
      */
     public function isSystemType(): bool
     {
@@ -313,8 +296,6 @@ class PaymentType implements \Stringable
 
     /**
      * Simple text representation
-     *
-     * @return string
      */
     public function __toString(): string
     {

--- a/galette/lib/Galette/Entity/PdfModel.php
+++ b/galette/lib/Galette/Entity/PdfModel.php
@@ -40,22 +40,22 @@ use function Safe\preg_replace_callback;
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>
  *
- * @property ?int $id
- * @property string $name
- * @property int $type
- * @property ?string $header
- * @property-read string $hheader
- * @property ?string $footer
- * @property-read string $hfooter
- * @property ?string $title
- * @property-read string $htitle
- * @property ?string $subtitle
- * @property-read string $hsubtitle
- * @property ?string $body
- * @property-read string $hbody
- * @property ?string $styles
- * @property string $hstyles
- * @property ?PdfMain $parent
+ * @property      ?int     $id
+ * @property      string   $name
+ * @property      int      $type
+ * @property      ?string  $header
+ * @property-read string   $hheader
+ * @property      ?string  $footer
+ * @property-read string   $hfooter
+ * @property      ?string  $title
+ * @property-read string   $htitle
+ * @property      ?string  $subtitle
+ * @property-read string   $hsubtitle
+ * @property      ?string  $body
+ * @property-read string   $hbody
+ * @property      ?string  $styles
+ * @property      string   $hstyles
+ * @property      ?PdfMain $parent
  */
 
 abstract class PdfModel
@@ -114,8 +114,6 @@ abstract class PdfModel
      *
      * @param int  $id   Identifier
      * @param bool $init Init data if required model is missing
-     *
-     * @return void
      */
     protected function load(int $id, bool $init = true): void
     {
@@ -156,8 +154,6 @@ abstract class PdfModel
      * Load model from a db ResultSet
      *
      * @param ArrayObject<string, int|string> $rs ResultSet
-     *
-     * @return void
      */
     protected function loadFromRS(ArrayObject $rs): void
     {
@@ -189,8 +185,6 @@ abstract class PdfModel
 
     /**
      * Store model in database
-     *
-     * @return bool
      */
     public function store(): bool
     {
@@ -246,8 +240,6 @@ abstract class PdfModel
      * Get object class for specified type
      *
      * @param int $type Type
-     *
-     * @return string
      */
     public static function getTypeClass(int $type): string
     {
@@ -268,8 +260,6 @@ abstract class PdfModel
      * @param int    $chars Length
      * @param string $field Field name
      * @param bool   $empty Can value be empty
-     *
-     * @return void
      */
     protected function checkChars(string $value, int $chars, string $field, bool $empty = false): void
     {
@@ -299,8 +289,6 @@ abstract class PdfModel
      * Getter
      *
      * @param string $name Property name
-     *
-     * @return mixed
      */
     public function __get(string $name): mixed
     {
@@ -367,8 +355,6 @@ abstract class PdfModel
      * Required for twig to access properties via __get
      *
      * @param string $name Property name
-     *
-     * @return bool
      */
     public function __isset(string $name): bool
     {
@@ -383,8 +369,6 @@ abstract class PdfModel
      *
      * @param string $name  Property name
      * @param mixed  $value Property value
-     *
-     * @return void
      */
     public function __set(string $name, mixed $value): void
     {

--- a/galette/lib/Galette/Entity/Reminder.php
+++ b/galette/lib/Galette/Entity/Reminder.php
@@ -39,10 +39,10 @@ use UnexpectedValueException;
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>
  *
- * @property-read int $member_id
- * @property int $type
- * @property Adherent $dest
- * @property string $date
+ * @property-read int      $member_id
+ * @property      int      $type
+ * @property      Adherent $dest
+ * @property      string   $date
  */
 
 class Reminder
@@ -84,8 +84,6 @@ class Reminder
      * Load a reminder from its id
      *
      * @param int $id Identifier
-     *
-     * @return void
      */
     private function load(int $id): void
     {
@@ -111,8 +109,6 @@ class Reminder
      * Load reminder from a db ResultSet
      *
      * @param ArrayObject<string, int|string> $rs ResultSet
-     *
-     * @return void
      */
     private function loadFromRS(ArrayObject $rs): void
     {
@@ -140,8 +136,6 @@ class Reminder
      * Store reminder in database and history
      *
      * @param Db $zdb Database instance
-     *
-     * @return bool
      */
     private function store(Db $zdb): bool
     {
@@ -179,8 +173,6 @@ class Reminder
 
     /**
      * Was reminder sent successfully?
-     *
-     * @return bool
      */
     public function isSuccess(): bool
     {
@@ -189,8 +181,6 @@ class Reminder
 
     /**
      * Did member had an email when reminder was sent?
-     *
-     * @return bool
      */
     public function hasMail(): bool
     {
@@ -203,8 +193,6 @@ class Reminder
      * @param Texts   $texts Text object
      * @param History $hist  History
      * @param Db      $zdb   Database instance
-     *
-     * @return bool
      */
     public function send(Texts $texts, History $hist, Db $zdb): bool
     {
@@ -290,8 +278,6 @@ class Reminder
 
     /**
      * Retrieve message
-     *
-     * @return string
      */
     public function getMessage(): string
     {
@@ -302,8 +288,6 @@ class Reminder
      * Getter
      *
      * @param string $name Property name
-     *
-     * @return mixed
      */
     public function __get(string $name): mixed
     {
@@ -326,8 +310,6 @@ class Reminder
      * Required for twig to access properties via __get
      *
      * @param string $name Property name
-     *
-     * @return bool
      */
     public function __isset(string $name): bool
     {
@@ -342,8 +324,6 @@ class Reminder
      *
      * @param string $name  Property name
      * @param mixed  $value Property value
-     *
-     * @return void
      */
     public function __set(string $name, mixed $value): void
     {

--- a/galette/lib/Galette/Entity/SavedSearch.php
+++ b/galette/lib/Galette/Entity/SavedSearch.php
@@ -39,12 +39,12 @@ use function Safe\json_encode;
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>
  *
- * @property int $id
- * @property string $name
+ * @property int                  $id
+ * @property string               $name
  * @property array<string, mixed> $parameters
- * @property int $author_id
- * @property string $creation_date
- * @property string $form
+ * @property int                  $author_id
+ * @property string               $creation_date
+ * @property string               $form
  */
 
 class SavedSearch
@@ -88,8 +88,6 @@ class SavedSearch
      * Load a saved search from its identifier
      *
      * @param int $id Identifier
-     *
-     * @return void
      */
     private function load(int $id): void
     {
@@ -121,8 +119,6 @@ class SavedSearch
      * Load a saved search from a db ResultSet
      *
      * @param ArrayObject<string, int|string> $rs ResultSet
-     *
-     * @return void
      */
     private function loadFromRS(ArrayObject $rs): void
     {
@@ -150,8 +146,6 @@ class SavedSearch
      * Check and set values
      *
      * @param array<string, mixed> $values Values to set
-     *
-     * @return bool
      */
     public function check(array $values): bool
     {
@@ -185,8 +179,6 @@ class SavedSearch
 
     /**
      * Store saved search in database
-     *
-     * @return bool
      */
     public function store(): bool
     {
@@ -221,8 +213,6 @@ class SavedSearch
 
     /**
      * Remove current saved search
-     *
-     * @return bool
      */
     public function remove(): bool
     {
@@ -252,8 +242,6 @@ class SavedSearch
      * Getter
      *
      * @param string $name Property name
-     *
-     * @return mixed
      */
     public function __get(string $name): mixed
     {
@@ -315,8 +303,6 @@ class SavedSearch
      * Required for twig to access properties via __get
      *
      * @param string $name Property name
-     *
-     * @return bool
      */
     public function __isset(string $name): bool
     {
@@ -340,8 +326,6 @@ class SavedSearch
      *
      * @param string $name  Property name
      * @param mixed  $value Property value
-     *
-     * @return void
      */
     public function __set(string $name, mixed $value): void
     {

--- a/galette/lib/Galette/Entity/ScheduledPayment.php
+++ b/galette/lib/Galette/Entity/ScheduledPayment.php
@@ -84,8 +84,6 @@ class ScheduledPayment
      * Load a scheduled payment from its identifier
      *
      * @param int $id Identifier
-     *
-     * @return bool
      */
     public function load(int $id): bool
     {
@@ -115,8 +113,6 @@ class ScheduledPayment
      * Load scheduled payment from a db ResultSet
      *
      * @param ArrayObject<string, int|string> $rs ResultSet
-     *
-     * @return void
      */
     private function loadFromRS(ArrayObject $rs): void
     {
@@ -137,8 +133,6 @@ class ScheduledPayment
      * Check data
      *
      * @param array<string,mixed> $data Data
-     *
-     * @return bool
      */
     public function check(array $data): bool
     {
@@ -202,8 +196,6 @@ class ScheduledPayment
 
     /**
      * Store scheduled payment in database
-     *
-     * @return bool
      */
     public function store(): bool
     {
@@ -245,8 +237,6 @@ class ScheduledPayment
 
     /**
      * Remove current
-     *
-     * @return bool
      */
     public function remove(): bool
     {
@@ -272,8 +262,6 @@ class ScheduledPayment
 
     /**
      * Get identifier
-     *
-     * @return ?int
      */
     public function getId(): ?int
     {
@@ -282,8 +270,6 @@ class ScheduledPayment
 
     /**
      * Get contribution
-     *
-     * @return Contribution
      */
     public function getContribution(): Contribution
     {
@@ -294,8 +280,6 @@ class ScheduledPayment
      * Set contribution
      *
      * @param int|Contribution $contribution Contribution instance or id
-     *
-     * @return self
      */
     public function setContribution(int|Contribution $contribution): self
     {
@@ -323,8 +307,6 @@ class ScheduledPayment
 
     /**
      * Get payment type
-     *
-     * @return PaymentType
      */
     public function getPaymentType(): PaymentType
     {
@@ -337,8 +319,6 @@ class ScheduledPayment
      * Set payment type
      *
      * @param int|PaymentType $payment_type Payment type instance or id
-     *
-     * @return self
      */
     public function setPaymentType(int|PaymentType $payment_type): self
     {
@@ -368,8 +348,6 @@ class ScheduledPayment
      * Get creation date
      *
      * @param bool $formatted Get formatted date, or DateTime object
-     *
-     * @return string|DateTime|null
      */
     public function getCreationDate(bool $formatted = true): string|DateTime|null
     {
@@ -380,8 +358,6 @@ class ScheduledPayment
      * Set creation date
      *
      * @param string $creation_date Creation date
-     *
-     * @return self
      */
     public function setCreationDate(string $creation_date): self
     {
@@ -393,8 +369,6 @@ class ScheduledPayment
      * Get scheduled date
      *
      * @param bool $formatted Get formatted date, or DateTime object
-     *
-     * @return string|DateTime|null
      */
     public function getScheduledDate(bool $formatted = true): string|DateTime|null
     {
@@ -405,8 +379,6 @@ class ScheduledPayment
      * Set scheduled date
      *
      * @param string $scheduled_date Scheduled date
-     *
-     * @return self
      */
     public function setScheduledDate(string $scheduled_date): self
     {
@@ -416,8 +388,6 @@ class ScheduledPayment
 
     /**
      * Get amount
-     *
-     * @return float
      */
     public function getAmount(): ?float
     {
@@ -428,8 +398,6 @@ class ScheduledPayment
      * Set amount
      *
      * @param float $amount Amount
-     *
-     * @return self
      */
     public function setAmount(float $amount): self
     {
@@ -439,8 +407,6 @@ class ScheduledPayment
 
     /**
      * Is payment done?
-     *
-     * @return bool
      */
     public function isPaid(): bool
     {
@@ -451,8 +417,6 @@ class ScheduledPayment
      * Set paid
      *
      * @param bool $is_paid Paid status
-     *
-     * @return self
      */
     public function setPaid(bool $is_paid = true): self
     {
@@ -462,8 +426,6 @@ class ScheduledPayment
 
     /**
      * Is payment due?
-     *
-     * @return bool
      */
     public function isDue(): bool
     {
@@ -474,8 +436,6 @@ class ScheduledPayment
 
     /**
      * Get comment
-     *
-     * @return ?string
      */
     public function getComment(): ?string
     {
@@ -486,8 +446,6 @@ class ScheduledPayment
      * Set comment
      *
      * @param ?string $comment Comment
-     *
-     * @return self
      */
     public function setComment(?string $comment): self
     {
@@ -500,7 +458,6 @@ class ScheduledPayment
      *
      * @param int $id_cotis Contribution identifier
      *
-     * @return bool
      * @throws Throwable
      */
     public function isContributionHandled(int $id_cotis): bool
@@ -517,7 +474,6 @@ class ScheduledPayment
      *
      * @param int $id_cotis Contribution identifier
      *
-     * @return float
      * @throws Throwable
      */
     public function getAllocation(int $id_cotis): float
@@ -534,7 +490,6 @@ class ScheduledPayment
     /**
      * Get allocated amount for current contribution
      *
-     * @return float
      * @throws Throwable
      */
     public function getAllocated(): float
@@ -544,8 +499,6 @@ class ScheduledPayment
 
     /**
      * Get missing amount
-     *
-     * @return float
      */
     public function getMissingAmount(): float
     {
@@ -556,8 +509,6 @@ class ScheduledPayment
      * Is scheduled payment fully allocated?
      *
      * @param Contribution $contrib Contribution
-     *
-     * @return bool
      */
     public function isFullyAllocated(Contribution $contrib): bool
     {
@@ -618,8 +569,6 @@ class ScheduledPayment
 
     /**
      * Set fields, must populate $this->fields
-     *
-     * @return self
      */
     protected function setFields(): self
     {

--- a/galette/lib/Galette/Entity/Social.php
+++ b/galette/lib/Galette/Entity/Social.php
@@ -38,7 +38,7 @@ use Analog\Analog;
  *
  * @property string $url
  * @property string $type
- * @property int $id
+ * @property int    $id
  */
 
 class Social
@@ -86,8 +86,6 @@ class Social
      * Load a social from its identifier
      *
      * @param int $id Identifier
-     *
-     * @return void
      */
     private function load(int $id): void
     {
@@ -157,8 +155,6 @@ class Social
      * Load social from a db ResultSet
      *
      * @param ArrayObject<string, int|string> $rs ResultSet
-     *
-     * @return void
      */
     private function loadFromRS(ArrayObject $rs): void
     {
@@ -170,8 +166,6 @@ class Social
 
     /**
      * Store social in database
-     *
-     * @return bool
      */
     public function store(): bool
     {
@@ -215,8 +209,6 @@ class Social
      * Remove current social
      *
      * @param array<int>|null $ids IDs to remove, default to current id
-     *
-     * @return bool
      */
     public function remove(?array $ids = null): bool
     {
@@ -246,8 +238,6 @@ class Social
      * Getter
      *
      * @param string $name Property name
-     *
-     * @return mixed
      */
     public function __get(string $name): mixed
     {
@@ -259,8 +249,6 @@ class Social
      * Required for twig to access properties via __get
      *
      * @param string $name Property name
-     *
-     * @return bool
      */
     public function __isset(string $name): bool
     {
@@ -269,8 +257,6 @@ class Social
 
     /**
      * Display URL the best way
-     *
-     * @return string
      */
     public function displayUrl(): string
     {
@@ -289,8 +275,6 @@ class Social
      * Set type
      *
      * @param string $type Type
-     *
-     * @return self
      */
     public function setType(string $type): self
     {
@@ -302,8 +286,6 @@ class Social
      * Set linked member
      *
      * @param int|null $id Member id
-     *
-     * @return self
      */
     public function setLinkedMember(?int $id = null): self
     {
@@ -318,8 +300,6 @@ class Social
      * Set URL
      *
      * @param string $url Value to set
-     *
-     * @return self
      */
     public function setUrl(string $url): self
     {
@@ -371,8 +351,6 @@ class Social
      *
      * @param string $type       Social type
      * @param bool   $translated Return translated types (default) or not
-     *
-     * @return string
      */
     public function getSystemType(string $type, bool $translated = true): string
     {

--- a/galette/lib/Galette/Entity/Status.php
+++ b/galette/lib/Galette/Entity/Status.php
@@ -129,8 +129,6 @@ class Status
      * Populate object from a resultset row
      *
      * @param ArrayObject<string, int|string> $r the resultset row
-     *
-     * @return void
      */
     private function loadFromRS(ArrayObject $r): void
     {
@@ -142,7 +140,6 @@ class Status
     /**
      * Set defaults at install time
      *
-     * @return bool
      * @throws Throwable
      */
     public function installInit(): bool
@@ -311,8 +308,6 @@ class Status
      * @param int  $id         Id
      * @param bool $translated Do we want translated or original label?
      *                         Defaults to true.
-     *
-     * @return string|int
      */
     public function getLabel(int $id, bool $translated = true): string|int
     {
@@ -527,8 +522,6 @@ class Status
      * Check if this entry is used.
      *
      * @param int $id Entry ID
-     *
-     * @return bool
      */
     public function isUsed(int $id): bool
     {
@@ -581,8 +574,6 @@ class Status
      * Required for twig to access properties via __get
      *
      * @param string $name name of the property we want to retrieve
-     *
-     * @return bool
      */
     public function __isset(string $name): bool
     {

--- a/galette/lib/Galette/Entity/Texts.php
+++ b/galette/lib/Galette/Entity/Texts.php
@@ -152,8 +152,6 @@ class Texts
 
     /**
      * Set emails replacements
-     *
-     * @return self
      */
     public function setMail(): self
     {
@@ -172,8 +170,6 @@ class Texts
      * Set change password URL
      *
      * @param Password $password Password instance
-     *
-     * @return self
      */
     public function setChangePasswordURI(Password $password): self
     {
@@ -189,8 +185,6 @@ class Texts
 
     /**
      * Set validity link
-     *
-     * @return self
      */
     public function setLinkValidity(): self
     {
@@ -204,8 +198,6 @@ class Texts
      * Set member card PDF link
      *
      * @param string $link Link
-     *
-     * @return self
      */
     public function setMemberCardLink(string $link): self
     {
@@ -217,8 +209,6 @@ class Texts
      * Set contribution PDF link
      *
      * @param string $link Link
-     *
-     * @return self
      */
     public function setContribLink(string $link): self
     {
@@ -337,8 +327,6 @@ class Texts
      * @param string $lang    Texte language to locate
      * @param string $subject Subject to set
      * @param string $body    Body text to set
-     *
-     * @return bool
      */
     public function setTexts(string $ref, string $lang, string $subject, string $body): bool
     {
@@ -457,8 +445,6 @@ class Texts
 
     /**
      * Checks for missing texts in the database
-     *
-     * @return bool
      */
     private function checkUpdate(): bool
     {
@@ -517,8 +503,6 @@ class Texts
 
     /**
      * Get the subject, with all replacements done
-     *
-     * @return string
      */
     public function getSubject(): string
     {
@@ -527,8 +511,6 @@ class Texts
 
     /**
      * Get the body, with all replacements done
-     *
-     * @return string
      */
     public function getBody(): string
     {
@@ -539,8 +521,6 @@ class Texts
      * Insert values in database
      *
      * @param array<int, mixed> $values Values to insert
-     *
-     * @return void
      */
     private function insert(array $values): void
     {
@@ -643,8 +623,6 @@ class Texts
      * Set replacements
      *
      * @param array<string,?mixed> $replaces Replacements to add
-     *
-     * @return void
      */
     public function setReplacements(array $replaces): void
     {
@@ -661,8 +639,6 @@ class Texts
      * Set current text reference
      *
      * @param string $ref Reference
-     *
-     * @return self
      */
     public function setCurrent(string $ref): self
     {

--- a/galette/lib/Galette/Entity/Title.php
+++ b/galette/lib/Galette/Entity/Title.php
@@ -33,11 +33,11 @@ use Analog\Analog;
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>
  *
- * @property int $id
- * @property string $short
- * @property ?string $long
- * @property-read string $tshort
- * @property-read string $tlong
+ * @property      int     $id
+ * @property      string  $short
+ * @property      ?string $long
+ * @property-read string  $tshort
+ * @property-read string  $tlong
  */
 
 class Title
@@ -71,8 +71,6 @@ class Title
      * Load a title from its identifier
      *
      * @param int $id Identifier
-     *
-     * @return void
      */
     private function load(int $id): void
     {
@@ -101,8 +99,6 @@ class Title
      * Load title from a db ResultSet
      *
      * @param ArrayObject<string, int|string> $rs ResultSet
-     *
-     * @return void
      */
     private function loadFromRS(ArrayObject $rs): void
     {
@@ -121,8 +117,6 @@ class Title
      * Store title in database
      *
      * @param Db $zdb Database instance
-     *
-     * @return bool
      */
     public function store(Db $zdb): bool
     {
@@ -161,8 +155,6 @@ class Title
      * Remove current title
      *
      * @param Db $zdb Database instance
-     *
-     * @return bool
      */
     public function remove(Db $zdb): bool
     {
@@ -196,8 +188,6 @@ class Title
      * Getter
      *
      * @param string $name Property name
-     *
-     * @return mixed
      */
     public function __get(string $name): mixed
     {
@@ -247,8 +237,6 @@ class Title
      * Required for twig to access properties via __get
      *
      * @param string $name Property name
-     *
-     * @return bool
      */
     public function __isset(string $name): bool
     {
@@ -263,8 +251,6 @@ class Title
      *
      * @param string $name  Property name
      * @param mixed  $value Property value
-     *
-     * @return void
      */
     public function __set(string $name, mixed $value): void
     {

--- a/galette/lib/Galette/Entity/Transaction.php
+++ b/galette/lib/Galette/Entity/Transaction.php
@@ -43,12 +43,12 @@ use Galette\Helpers\EntityHelper;
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>
  *
- * @property int $id
- * @property string $date
- * @property float $amount
+ * @property int     $id
+ * @property string  $date
+ * @property float   $amount
  * @property ?string $description
- * @property ?int $member
- * @property ?int $payment_type
+ * @property ?int    $member
+ * @property ?int    $payment_type
  */
 class Transaction implements AccessManagementInterface
 {
@@ -102,8 +102,6 @@ class Transaction implements AccessManagementInterface
 
     /**
      * Set fields, must populate $this->fields
-     *
-     * @return self
      */
     protected function setFields(): self
     {
@@ -205,8 +203,6 @@ class Transaction implements AccessManagementInterface
      *
      * @param History $hist        History
      * @param bool    $transaction Activate transaction mode (defaults to true)
-     *
-     * @return bool
      */
     public function remove(History $hist, bool $transaction = true): bool
     {
@@ -265,8 +261,6 @@ class Transaction implements AccessManagementInterface
      * Populate object from a resultset row
      *
      * @param ArrayObject<string,int|string> $r the resultset row
-     *
-     * @return void
      */
     private function loadFromRS(ArrayObject $r): void
     {
@@ -416,8 +410,6 @@ class Transaction implements AccessManagementInterface
      * Store the transaction
      *
      * @param History $hist History
-     *
-     * @return bool
      */
     public function store(History $hist): bool
     {
@@ -493,8 +485,6 @@ class Transaction implements AccessManagementInterface
 
     /**
      * Retrieve amount that has already been dispatched into contributions
-     *
-     * @return double
      */
     public function getDispatchedAmount(): float
     {
@@ -526,8 +516,6 @@ class Transaction implements AccessManagementInterface
 
     /**
      * Retrieve amount that has not yet been dispatched into contributions
-     *
-     * @return double
      */
     public function getMissingAmount(): float
     {
@@ -559,8 +547,6 @@ class Transaction implements AccessManagementInterface
 
     /**
      * Get payment type label
-     *
-     * @return string
      */
     public function getPaymentType(): string
     {
@@ -669,8 +655,6 @@ class Transaction implements AccessManagementInterface
      * Can current logged-in user create a transaction?
      *
      * @param Login $login Login instance
-     *
-     * @return bool
      */
     public function canCreate(Login $login): bool
     {
@@ -690,8 +674,6 @@ class Transaction implements AccessManagementInterface
      * Can current logged-in user display transactions?
      *
      * @param Login $login Login instance
-     *
-     * @return bool
      */
     public function canShow(Login $login): bool
     {
@@ -734,8 +716,6 @@ class Transaction implements AccessManagementInterface
      * Can current logged-in user edit a transaction?
      *
      * @param Login $login Login instance
-     *
-     * @return bool
      */
     public function canEdit(Login $login): bool
     {
@@ -747,8 +727,6 @@ class Transaction implements AccessManagementInterface
      * Specific right for groups managers to attach/detach contributions from a transaction -_-
      *
      * @param Login $login Login instance
-     *
-     * @return bool
      */
     public function canAttachAndDetach(Login $login): bool
     {
@@ -764,8 +742,6 @@ class Transaction implements AccessManagementInterface
      * Can current logged-in user delete a transaction?
      *
      * @param Login $login Login instance
-     *
-     * @return bool
      */
     public function canDelete(Login $login): bool
     {

--- a/galette/lib/Galette/Events/ContribListener.php
+++ b/galette/lib/Galette/Events/ContribListener.php
@@ -71,8 +71,6 @@ class ContribListener implements ListenerSubscriber
      * Set up contribution listeners
      *
      * @param ListenerRegistry $acceptor Listener
-     *
-     * @return void
      */
     public function subscribeListeners(ListenerRegistry $acceptor): void
     {
@@ -88,8 +86,6 @@ class ContribListener implements ListenerSubscriber
      * Contribution added listener
      *
      * @param Contribution $contrib Added contribution
-     *
-     * @return void
      */
     public function contributionAdded(Contribution $contrib): void
     {
@@ -111,8 +107,6 @@ class ContribListener implements ListenerSubscriber
      *
      * @param Contribution $contrib Contribution
      * @param bool         $new     New contribution or editing existing one
-     *
-     * @return void
      */
     private function sendContribEmail(Contribution $contrib, bool $new): void
     {
@@ -216,8 +210,6 @@ class ContribListener implements ListenerSubscriber
      *
      * @param Contribution $contrib Contribution
      * @param bool         $new     New contribution or editing existing one
-     *
-     * @return void
      */
     private function sendAdminEmail(Contribution $contrib, bool $new): void
     {
@@ -289,8 +281,6 @@ class ContribListener implements ListenerSubscriber
      * Call post contribution script from Preferences
      *
      * @param Contribution $contrib Added contribution
-     *
-     * @return void
      */
     private function callPostContributionScript(Contribution $contrib): void
     {

--- a/galette/lib/Galette/Events/GaletteEvent.php
+++ b/galette/lib/Galette/Events/GaletteEvent.php
@@ -46,8 +46,6 @@ class GaletteEvent implements HasEventName
 
     /**
      * Get event name
-     *
-     * @return string
      */
     public function eventName(): string
     {
@@ -56,8 +54,6 @@ class GaletteEvent implements HasEventName
 
     /**
      * Get event object
-     *
-     * @return object
      */
     public function getObject(): object
     {

--- a/galette/lib/Galette/Events/MemberListener.php
+++ b/galette/lib/Galette/Events/MemberListener.php
@@ -68,8 +68,6 @@ class MemberListener implements ListenerSubscriber
      * Set up member listeners
      *
      * @param ListenerRegistry $acceptor Listener
-     *
-     * @return void
      */
     public function subscribeListeners(ListenerRegistry $acceptor): void
     {
@@ -92,8 +90,6 @@ class MemberListener implements ListenerSubscriber
      * Member added listener
      *
      * @param Adherent $member Added member
-     *
-     * @return void
      */
     public function memberAdded(Adherent $member): void
     {
@@ -113,8 +109,6 @@ class MemberListener implements ListenerSubscriber
      * Member edited listener
      *
      * @param Adherent $member Added member
-     *
-     * @return void
      */
     public function memberEdited(Adherent $member): void
     {
@@ -135,8 +129,6 @@ class MemberListener implements ListenerSubscriber
      *
      * @param Adherent $member Member
      * @param bool     $new    New member or editing existing one
-     *
-     * @return void
      */
     private function sendMemberEmail(Adherent $member, bool $new): void
     {
@@ -229,8 +221,6 @@ class MemberListener implements ListenerSubscriber
      *
      * @param Adherent $member Member
      * @param bool     $new    New member or editing existing one
-     *
-     * @return void
      */
     private function sendAdminEmail(Adherent $member, bool $new): void
     {

--- a/galette/lib/Galette/Features/Cacheable.php
+++ b/galette/lib/Galette/Features/Cacheable.php
@@ -53,8 +53,6 @@ trait Cacheable
      * Handle cache
      *
      * @param bool $nocache Do not try to cache
-     *
-     * @return void
      */
     protected function handleCache(bool $nocache = false): void
     {
@@ -69,8 +67,6 @@ trait Cacheable
 
     /**
      * Check if cache is valid
-     *
-     * @return bool
      */
     private function checkCache(): bool
     {
@@ -106,22 +102,16 @@ trait Cacheable
 
     /**
      * Complete path to cache file
-     *
-     * @return string
      */
     abstract protected function getCacheFilename(): string;
 
     /**
      * Ensure data to cache are present
-     *
-     * @return void
      */
     abstract protected function prepareForCache(): void;
 
     /**
      * Creates/update the cache
-     *
-     * @return void
      */
     protected function makeCache(): void
     {
@@ -145,8 +135,6 @@ trait Cacheable
 
     /**
      * Get data to cache
-     *
-     * @return string
      */
     protected function getDataTocache(): string
     {
@@ -155,8 +143,6 @@ trait Cacheable
 
     /**
      * Loads entries from cache
-     *
-     * @return void
      */
     protected function loadCache(): void
     {
@@ -172,8 +158,6 @@ trait Cacheable
      * Called once cache has been loaded.
      *
      * @param mixed $content Content from cache
-     *
-     * @return bool
      */
     abstract protected function cacheLoaded(mixed $content): bool;
 }

--- a/galette/lib/Galette/Features/Dependencies.php
+++ b/galette/lib/Galette/Features/Dependencies.php
@@ -48,8 +48,6 @@ trait Dependencies
      * Set dependencies
      *
      * @param array<string, bool> $deps Dependencies to set
-     *
-     * @return self
      */
     public function setDeps(array $deps): self
     {
@@ -62,8 +60,6 @@ trait Dependencies
 
     /**
      * Reset dependencies to load
-     *
-     * @return self
      */
     public function disableAllDeps(): self
     {
@@ -76,8 +72,6 @@ trait Dependencies
 
     /**
      * Enable all dependencies to load
-     *
-     * @return self
      */
     public function enableAllDeps(): self
     {
@@ -91,8 +85,6 @@ trait Dependencies
      * Enable a load dependency
      *
      * @param string $name Dependency name
-     *
-     * @return self
      */
     public function enableDep(string $name): self
     {
@@ -112,8 +104,6 @@ trait Dependencies
      * Enable a load dependency
      *
      * @param string $name Dependency name
-     *
-     * @return self
      */
     public function disableDep(string $name): self
     {
@@ -133,8 +123,6 @@ trait Dependencies
      * Is load dependency enabled?
      *
      * @param string $name Dependency name
-     *
-     * @return bool
      */
     protected function isDepEnabled(string $name): bool
     {

--- a/galette/lib/Galette/Features/Dynamics.php
+++ b/galette/lib/Galette/Features/Dynamics.php
@@ -53,8 +53,6 @@ trait Dynamics
 
     /**
      * Load dynamic fields for member
-     *
-     * @return void
      */
     private function loadDynamicFields(): void
     {
@@ -69,8 +67,6 @@ trait Dynamics
 
     /**
      * Get dynamic fields
-     *
-     * @return DynamicFieldsHandle
      */
     public function getDynamicFields(): DynamicFieldsHandle
     {
@@ -86,8 +82,6 @@ trait Dynamics
      * @param array<string, mixed>   $post     Posted values
      * @param array<string,int|bool> $required Array of required fields
      * @param array<string>          $disabled Array of disabled fields
-     *
-     * @return bool
      */
     protected function dynamicsCheck(array $post, array $required, array $disabled): bool
     {
@@ -206,8 +200,6 @@ trait Dynamics
      * Stores dynamic fields
      *
      * @param bool $transaction True if a transaction already exists
-     *
-     * @return bool
      */
     protected function dynamicsStore(bool $transaction = false): bool
     {
@@ -226,8 +218,6 @@ trait Dynamics
      * Store dynamic Files
      *
      * @param array<UploadedFileInterface> $files Posted files
-     *
-     * @return void
      */
     protected function dynamicsFiles(array $files): void
     {
@@ -298,8 +288,6 @@ trait Dynamics
      * Remove dynamic fields values
      *
      * @param bool $transaction True if a transaction already exists
-     *
-     * @return bool
      */
     protected function dynamicsRemove(bool $transaction = false): bool
     {
@@ -325,8 +313,6 @@ trait Dynamics
      *
      * @param array<string> $values Dynamic fields values
      * @param string        $prefix Prefix to replace, default to 'dynfield_'
-     *
-     * @return bool
      */
     public function dynamicsValidate(array $values, string $prefix = 'dynfield_'): bool
     {
@@ -339,8 +325,6 @@ trait Dynamics
 
     /**
      * Get form name
-     *
-     * @return string
      */
     public function getFormName(): string
     {
@@ -349,8 +333,6 @@ trait Dynamics
 
     /**
      * Get ID
-     *
-     * @return ?int
      */
     public function getID(): ?int
     {

--- a/galette/lib/Galette/Features/HasEvent.php
+++ b/galette/lib/Galette/Features/HasEvent.php
@@ -38,15 +38,11 @@ trait HasEvent
 
     /**
      * Get prefix for events
-     *
-     * @return string
      */
     abstract protected function getEventsPrefix(): string;
 
     /**
      * Activate events
-     *
-     * @return self
      */
     public function activateEvents(): self
     {
@@ -56,8 +52,6 @@ trait HasEvent
 
     /**
      * Disable events
-     *
-     * @return self
      */
     public function disableEvents(): self
     {
@@ -67,8 +61,6 @@ trait HasEvent
 
     /**
      * Are events enabled
-     *
-     * @return bool
      */
     public function areEventsEnabled(): bool
     {
@@ -77,8 +69,6 @@ trait HasEvent
 
     /**
      * Activate add event
-     *
-     * @return self
      */
     public function withAddEvent(): self
     {
@@ -88,8 +78,6 @@ trait HasEvent
 
     /**
      * Disable add event
-     *
-     * @return self
      */
     public function withoutAddEvent(): self
     {
@@ -99,8 +87,6 @@ trait HasEvent
 
     /**
      * Get add event name
-     *
-     * @return ?string
      */
     public function getAddEventName(): ?string
     {
@@ -115,8 +101,6 @@ trait HasEvent
 
     /**
      * Has add event
-     *
-     * @return bool
      */
     public function hasAddEvent(): bool
     {
@@ -125,8 +109,6 @@ trait HasEvent
 
     /**
      * Activate edit event
-     *
-     * @return self
      */
     public function withEditEvent(): self
     {
@@ -136,8 +118,6 @@ trait HasEvent
 
     /**
      * Disable edit event
-     *
-     * @return self
      */
     public function withoutEditEvent(): self
     {
@@ -147,8 +127,6 @@ trait HasEvent
 
     /**
      * Get edit event name
-     *
-     * @return ?string
      */
     public function getEditEventName(): ?string
     {
@@ -163,8 +141,6 @@ trait HasEvent
 
     /**
      * Has edit event
-     *
-     * @return bool
      */
     public function hasEditEvent(): bool
     {
@@ -173,8 +149,6 @@ trait HasEvent
 
     /**
      * Activate add event
-     *
-     * @return self
      */
     public function withDeleteEvent(): self
     {
@@ -184,8 +158,6 @@ trait HasEvent
 
     /**
      * Disable delete event
-     *
-     * @return self
      */
     public function withoutDeleteEvent(): self
     {
@@ -195,8 +167,6 @@ trait HasEvent
 
     /**
      * Get edit event name
-     *
-     * @return ?string
      */
     public function getDeleteEventName(): ?string
     {
@@ -211,8 +181,6 @@ trait HasEvent
 
     /**
      * Has delete event
-     *
-     * @return bool
      */
     public function hasDeleteEvent(): bool
     {

--- a/galette/lib/Galette/Features/I18n.php
+++ b/galette/lib/Galette/Features/I18n.php
@@ -40,8 +40,6 @@ trait I18n
      * Add a translation stored in the database
      *
      * @param string $text_orig Text to translate
-     *
-     * @return bool
      */
     protected function addTranslation(string $text_orig): bool
     {
@@ -66,8 +64,6 @@ trait I18n
      * @param string $text_orig   Text to translate
      * @param string $text_locale The locale
      * @param string $text_trans  Translated text
-     *
-     * @return bool
      */
     protected function updateTranslation(string $text_orig, string $text_locale, string $text_trans): bool
     {
@@ -90,8 +86,6 @@ trait I18n
      * Delete a translation stored in the database
      *
      * @param string $text_orig Text to translate
-     *
-     * @return bool
      */
     protected function deleteTranslation(string $text_orig): bool
     {

--- a/galette/lib/Galette/Features/Permissions.php
+++ b/galette/lib/Galette/Features/Permissions.php
@@ -72,8 +72,6 @@ trait Permissions
 
     /**
      * Get permission name
-     *
-     * @return string
      */
     public function getPermissionName(): string
     {
@@ -83,8 +81,6 @@ trait Permissions
 
     /**
      * Get current permissions
-     *
-     * @return int|null
      */
     public function getPermission(): ?int
     {

--- a/galette/lib/Galette/Features/Replacements.php
+++ b/galette/lib/Galette/Features/Replacements.php
@@ -141,8 +141,6 @@ trait Replacements
      * Set patterns
      *
      * @param array<string,array<string,string>> $patterns Patterns to add
-     *
-     * @return self
      */
     protected function setPatterns(array $patterns): self
     {
@@ -163,8 +161,6 @@ trait Replacements
      * Set replacements
      *
      * @param array<string,?mixed> $replaces Replacements to add
-     *
-     * @return void
      */
     public function setReplacements(array $replaces): void
     {
@@ -465,8 +461,6 @@ trait Replacements
      * Set mail instance
      *
      * @param PHPMailer $mail PHPMailer instance
-     *
-     * @return self
      */
     public function setMail(PHPMailer $mail): self
     {
@@ -476,8 +470,6 @@ trait Replacements
 
     /**
      * Set main replacements
-     *
-     * @return self
      */
     public function setMain(): self
     {
@@ -548,8 +540,6 @@ trait Replacements
 
     /**
      * Set contribution and proceed related replacements
-     *
-     * @return self
      */
     public function setNoContribution(): self
     {
@@ -596,8 +586,6 @@ trait Replacements
      * Set contribution and proceed related replacements
      *
      * @param Contribution $contrib Contribution
-     *
-     * @return self
      */
     public function setContribution(Contribution $contrib): self
     {
@@ -646,8 +634,6 @@ trait Replacements
      * Set member and proceed related replacements
      *
      * @param Adherent $member Member
-     *
-     * @return self
      */
     public function setMember(Adherent $member): self
     {
@@ -733,8 +719,6 @@ trait Replacements
      * @param string                  $form_name      Form name
      * @param array<string|int,mixed> $dynamic_fields Dynamic fields
      * @param ?object                 $object         Related object (Adherent, Contribution, ...)
-     *
-     * @return self
      */
     private function setDynamicFields(string $form_name, array $dynamic_fields, ?object $object): self
     {
@@ -864,8 +848,6 @@ trait Replacements
      * Set Db dependency
      *
      * @param Db $db Db instance
-     *
-     * @return self
      */
     public function setDb(Db $db): self
     {
@@ -877,8 +859,6 @@ trait Replacements
      * Set Login dependency
      *
      * @param Login $login Login instance
-     *
-     * @return self
      */
     public function setLogin(Login $login): self
     {
@@ -890,8 +870,6 @@ trait Replacements
      * Set Preferences dependency
      *
      * @param Preferences $preferences Preferences instance
-     *
-     * @return self
      */
     public function setPreferences(Preferences $preferences): self
     {
@@ -903,8 +881,6 @@ trait Replacements
      * Set RouteParser dependency
      *
      * @param RouteParser $routeparser RouteParser instance
-     *
-     * @return self
      */
     public function setRouteparser(RouteParser $routeparser): self
     {
@@ -916,8 +892,6 @@ trait Replacements
      * Set I18n dependency
      *
      * @param I18n $i18n I18n instance
-     *
-     * @return self
      */
     public function setI18n(I18n $i18n): self
     {
@@ -929,8 +903,6 @@ trait Replacements
      * Proceed replacement on given entry
      *
      * @param string $source Source string
-     *
-     * @return string
      */
     protected function proceedReplacements(string $source): string
     {
@@ -984,8 +956,6 @@ trait Replacements
 
     /**
      * Set legacy mode
-     *
-     * @return self
      */
     protected function setLegacy(): self
     {

--- a/galette/lib/Galette/Features/Socials.php
+++ b/galette/lib/Galette/Features/Socials.php
@@ -41,8 +41,6 @@ trait Socials
      * Check socials
      *
      * @param array<string,mixed> $post User input
-     *
-     * @return void
      */
     protected function checkSocials(array $post): void
     {
@@ -58,8 +56,6 @@ trait Socials
      * Store social networks/contacts
      *
      * @param int|null $id ID
-     *
-     * @return bool
      */
     protected function storeSocials(?int $id = null): bool
     {

--- a/galette/lib/Galette/Features/Translatable.php
+++ b/galette/lib/Galette/Features/Translatable.php
@@ -38,8 +38,6 @@ trait Translatable
      * Get field name
      *
      * @param bool $translated Get translated or raw name
-     *
-     * @return string
      */
     public function getName(bool $translated = true): string
     {

--- a/galette/lib/Galette/Filters/AdvancedMembersList.php
+++ b/galette/lib/Galette/Filters/AdvancedMembersList.php
@@ -37,45 +37,45 @@ use Galette\Repository\PaymentTypes;
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>
  *
- * @property ?string $creation_date_begin
- * @property ?string $creation_date_end
- * @property ?string $modif_date_begin
- * @property ?string $modif_date_end
- * @property ?string $due_date_begin
- * @property ?string $due_date_end
- * @property ?string $birth_date_begin
- * @property ?string $birth_date_end
- * @property int $show_public_infos
- * @property int[]|int $status
- * @property ?string $contrib_creation_date_begin
- * @property ?string $contrib_creation_date_end
- * @property ?string $contrib_begin_date_begin
- * @property ?string $contrib_begin_date_end
- * @property ?string $contrib_end_date_begin
- * @property ?string $contrib_end_date_end
- * @property int[] $contributions_types
- * @property int[] $payments_types
- * @property ?float $contrib_min_amount
- * @property ?float $contrib_max_amount
- * @property array<int, mixed> $contrib_dynamic
+ * @property ?string             $creation_date_begin
+ * @property ?string             $creation_date_end
+ * @property ?string             $modif_date_begin
+ * @property ?string             $modif_date_end
+ * @property ?string             $due_date_begin
+ * @property ?string             $due_date_end
+ * @property ?string             $birth_date_begin
+ * @property ?string             $birth_date_end
+ * @property int                 $show_public_infos
+ * @property int[]|int           $status
+ * @property ?string             $contrib_creation_date_begin
+ * @property ?string             $contrib_creation_date_end
+ * @property ?string             $contrib_begin_date_begin
+ * @property ?string             $contrib_begin_date_end
+ * @property ?string             $contrib_end_date_begin
+ * @property ?string             $contrib_end_date_end
+ * @property int[]               $contributions_types
+ * @property int[]               $payments_types
+ * @property ?float              $contrib_min_amount
+ * @property ?float              $contrib_max_amount
+ * @property array<int, mixed>   $contrib_dynamic
  * @property array<mixed, mixed> $free_search
  * @property array<mixed, mixed> $groups_search
- * @property int $groups_search_log_op
+ * @property int                 $groups_search_log_op
  *
- * @property-read ?string $rcreation_date_begin
- * @property-read ?string $rcreation_date_end
- * @property-read ?string $rmodif_date_begin
- * @property-read ?string $rmodif_date_end
- * @property-read ?string $rdue_date_begin
- * @property-read ?string $rdue_date_end
- * @property-read ?string $rbirth_date_begin
- * @property-read ?string $rbirth_date_end
- * @property-read ?string $rcontrib_creation_date_begin
- * @property-read ?string $rcontrib_creation_date_end
- * @property-read ?string $rcontrib_begin_date_begin
- * @property-read ?string $rcontrib_begin_date_end
- * @property-read ?string $rcontrib_end_date_begin
- * @property-read ?string $rcontrib_end_date_end
+ * @property-read ?string  $rcreation_date_begin
+ * @property-read ?string  $rcreation_date_end
+ * @property-read ?string  $rmodif_date_begin
+ * @property-read ?string  $rmodif_date_end
+ * @property-read ?string  $rdue_date_begin
+ * @property-read ?string  $rdue_date_end
+ * @property-read ?string  $rbirth_date_begin
+ * @property-read ?string  $rbirth_date_end
+ * @property-read ?string  $rcontrib_creation_date_begin
+ * @property-read ?string  $rcontrib_creation_date_end
+ * @property-read ?string  $rcontrib_begin_date_begin
+ * @property-read ?string  $rcontrib_begin_date_end
+ * @property-read ?string  $rcontrib_end_date_begin
+ * @property-read ?string  $rcontrib_end_date_end
  * @property-read string[] $search_fields
  */
 
@@ -221,8 +221,6 @@ class AdvancedMembersList extends MembersList
 
     /**
      * Do we want to filter within contributions?
-     *
-     * @return bool
      */
     public function withinContributions(): bool
     {
@@ -243,8 +241,6 @@ class AdvancedMembersList extends MembersList
 
     /**
      * Reinit default parameters
-     *
-     * @return void
      */
     public function reinit(): void
     {
@@ -367,8 +363,6 @@ class AdvancedMembersList extends MembersList
      * Required for twig to access properties via __get
      *
      * @param string $name name of the property we want to retrieve
-     *
-     * @return bool
      */
     public function __isset(string $name): bool
     {
@@ -384,8 +378,6 @@ class AdvancedMembersList extends MembersList
      *
      * @param string $name  name of the property we want to assign a value to
      * @param mixed  $value a relevant value for the property
-     *
-     * @return void
      */
     public function __set(string $name, mixed $value): void
     {
@@ -647,8 +639,6 @@ class AdvancedMembersList extends MembersList
      * Validate free search internal array
      *
      * @param array<string,mixed> $data Array to validate
-     *
-     * @return bool
      */
     public static function isValidFreeSearch(array $data): bool
     {

--- a/galette/lib/Galette/Filters/ContributionsList.php
+++ b/galette/lib/Galette/Filters/ContributionsList.php
@@ -33,19 +33,19 @@ use Galette\Core\Pagination;
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>
  *
- * @property ?string $start_date_filter
- * @property ?string $end_date_filter
- * @property ?int $filtre_cotis_adh
+ * @property ?string   $start_date_filter
+ * @property ?string   $end_date_filter
+ * @property ?int      $filtre_cotis_adh
  * @property int|false $filtre_cotis_children
- * @property int $date_field
- * @property ?int $payment_type_filter
- * @property ?int $contrib_type_filter
- * @property bool $filtre_transactions
+ * @property int       $date_field
+ * @property ?int      $payment_type_filter
+ * @property ?int      $contrib_type_filter
+ * @property bool      $filtre_transactions
  * @property int|false $from_transaction
- * @property ?int $max_amount
- * @property string $rstart_date_filter
- * @property string $rend_date_filter
- * @property int[] $selected
+ * @property ?int      $max_amount
+ * @property string    $rstart_date_filter
+ * @property string    $rend_date_filter
+ * @property int[]     $selected
  */
 
 class ContributionsList extends Pagination
@@ -112,8 +112,6 @@ class ContributionsList extends Pagination
 
     /**
      * Returns the field we want to default set order to
-     *
-     * @return int|string
      */
     protected function getDefaultOrder(): int|string
     {
@@ -122,8 +120,6 @@ class ContributionsList extends Pagination
 
     /**
      * Return the default direction for ordering
-     *
-     * @return SQLOrder
      */
     protected function getDefaultDirection(): SQLOrder
     {
@@ -134,8 +130,6 @@ class ContributionsList extends Pagination
      * Reinit default parameters
      *
      * @param bool $ajax Called form an ajax query
-     *
-     * @return void
      */
     public function reinit(bool $ajax = false): void
     {
@@ -196,8 +190,6 @@ class ContributionsList extends Pagination
      * Required for twig to access properties via __get
      *
      * @param string $name name of the property we want to retrieve
-     *
-     * @return bool
      */
     public function __isset(string $name): bool
     {
@@ -212,8 +204,6 @@ class ContributionsList extends Pagination
      *
      * @param string $name  name of the property we want to assign a value to
      * @param mixed  $value a relevant value for the property
-     *
-     * @return void
      */
     public function __set(string $name, mixed $value): void
     {

--- a/galette/lib/Galette/Filters/DocumentsList.php
+++ b/galette/lib/Galette/Filters/DocumentsList.php
@@ -41,8 +41,6 @@ class DocumentsList extends Pagination
 
     /**
      * Returns the field we want to default set order to
-     *
-     * @return int|string
      */
     protected function getDefaultOrder(): int|string
     {
@@ -51,8 +49,6 @@ class DocumentsList extends Pagination
 
     /**
      * Return the default direction for ordering
-     *
-     * @return SQLOrder
      */
     protected function getDefaultDirection(): SQLOrder
     {

--- a/galette/lib/Galette/Filters/HistoryList.php
+++ b/galette/lib/Galette/Filters/HistoryList.php
@@ -76,8 +76,6 @@ class HistoryList extends Pagination
 
     /**
      * Returns the field we want to default set order to
-     *
-     * @return int|string
      */
     protected function getDefaultOrder(): int|string
     {
@@ -86,8 +84,6 @@ class HistoryList extends Pagination
 
     /**
      * Return the default direction for ordering
-     *
-     * @return SQLOrder
      */
     protected function getDefaultDirection(): SQLOrder
     {
@@ -96,8 +92,6 @@ class HistoryList extends Pagination
 
     /**
      * Reinit default parameters
-     *
-     * @return void
      */
     public function reinit(): void
     {
@@ -142,8 +136,6 @@ class HistoryList extends Pagination
      * Required for twig to access properties via __get
      *
      * @param string $name name of the property we want to retrieve
-     *
-     * @return bool
      */
     public function __isset(string $name): bool
     {
@@ -155,8 +147,6 @@ class HistoryList extends Pagination
      *
      * @param string $name  name of the property we want to assign a value to
      * @param mixed  $value a relevant value for the property
-     *
-     * @return void
      */
     public function __set(string $name, mixed $value): void
     {

--- a/galette/lib/Galette/Filters/MailingsList.php
+++ b/galette/lib/Galette/Filters/MailingsList.php
@@ -31,11 +31,11 @@ use Galette\Core\MailingHistory;
  * @author Johan Cwiklinski <johan@x-tnd.be>
  *
  * @property ?string $start_date_filter
- * @property string $raw_start_date_filter
+ * @property string  $raw_start_date_filter
  * @property ?string $end_date_filter
- * @property string $raw_end_date_filter
- * @property int $sender_filter
- * @property int $sent_filter
+ * @property string  $raw_end_date_filter
+ * @property int     $sender_filter
+ * @property int     $sent_filter
  * @property ?string $subject_filter
  */
 
@@ -72,8 +72,6 @@ class MailingsList extends HistoryList
 
     /**
      * Returns the field we want to default set order to
-     *
-     * @return int|string
      */
     protected function getDefaultOrder(): int|string
     {
@@ -82,8 +80,6 @@ class MailingsList extends HistoryList
 
     /**
      * Reinit default parameters
-     *
-     * @return void
      */
     public function reinit(): void
     {
@@ -98,8 +94,6 @@ class MailingsList extends HistoryList
      *
      * @param string $name  name of the property we want to assign a value to
      * @param mixed  $value a relevant value for the property
-     *
-     * @return void
      */
     public function __set(string $name, mixed $value): void
     {

--- a/galette/lib/Galette/Filters/MembersList.php
+++ b/galette/lib/Galette/Filters/MembersList.php
@@ -35,14 +35,14 @@ use Slim\Views\Twig;
  * @author Johan Cwiklinski <johan@x-tnd.be>
  *
  * @property ?string $filter_str
- * @property ?int $field_filter
- * @property ?int $membership_filter
- * @property ?int $filter_account
- * @property ?int $email_filter
- * @property ?int $group_filter
- * @property int[] $selected
- * @property int[] $unreachable
- * @property string $query
+ * @property ?int    $field_filter
+ * @property ?int    $membership_filter
+ * @property ?int    $filter_account
+ * @property ?int    $email_filter
+ * @property ?int    $group_filter
+ * @property int[]   $selected
+ * @property int[]   $unreachable
+ * @property string  $query
  */
 
 class MembersList extends Pagination
@@ -85,8 +85,6 @@ class MembersList extends Pagination
 
     /**
      * Returns the field we want to default set order to
-     *
-     * @return int|string
      */
     protected function getDefaultOrder(): int|string
     {
@@ -95,8 +93,6 @@ class MembersList extends Pagination
 
     /**
      * Reinit default parameters
-     *
-     * @return void
      */
     public function reinit(): void
     {
@@ -141,8 +137,6 @@ class MembersList extends Pagination
      * Required for twig to access properties via __get
      *
      * @param string $name name of the property we want to retrieve
-     *
-     * @return bool
      */
     public function __isset(string $name): bool
     {
@@ -154,8 +148,6 @@ class MembersList extends Pagination
      *
      * @param string $name  name of the property we want to assign a value to
      * @param mixed  $value a relevant value for the property
-     *
-     * @return void
      */
     public function __set(string $name, mixed $value): void
     {
@@ -255,8 +247,6 @@ class MembersList extends Pagination
      * Set commons filters for templates
      *
      * @param Twig $view Template reference
-     *
-     * @return void
      */
     public function setViewCommonsFilters(Twig $view): void
     {

--- a/galette/lib/Galette/Filters/SavedSearchesList.php
+++ b/galette/lib/Galette/Filters/SavedSearchesList.php
@@ -38,8 +38,6 @@ class SavedSearchesList extends Pagination
 
     /**
      * Returns the field we want to default set order to
-     *
-     * @return int|string
      */
     protected function getDefaultOrder(): int|string
     {
@@ -48,8 +46,6 @@ class SavedSearchesList extends Pagination
 
     /**
      * Return the default direction for ordering
-     *
-     * @return SQLOrder
      */
     protected function getDefaultDirection(): SQLOrder
     {

--- a/galette/lib/Galette/Filters/ScheduledPaymentsList.php
+++ b/galette/lib/Galette/Filters/ScheduledPaymentsList.php
@@ -31,16 +31,16 @@ use Galette\Core\Pagination;
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>
  *
- * @property ?string $start_date_filter
- * @property ?string $end_date_filter
- * @property int $date_field
- * @property ?int $payment_type_filter
+ * @property ?string   $start_date_filter
+ * @property ?string   $end_date_filter
+ * @property int       $date_field
+ * @property ?int      $payment_type_filter
  * @property int|false $from_contribution
- * @property string $rstart_date_filter
- * @property string $rend_date_filter
- * @property int[] $selected
- * @property ?int $member_filter
- * @property int $paid
+ * @property string    $rstart_date_filter
+ * @property string    $rend_date_filter
+ * @property int[]     $selected
+ * @property ?int      $member_filter
+ * @property int       $paid
  */
 
 class ScheduledPaymentsList extends Pagination
@@ -105,8 +105,6 @@ class ScheduledPaymentsList extends Pagination
 
     /**
      * Returns the field we want to default set order to
-     *
-     * @return int|string
      */
     protected function getDefaultOrder(): int|string
     {
@@ -117,8 +115,6 @@ class ScheduledPaymentsList extends Pagination
      * Reinit default parameters
      *
      * @param bool $ajax Called form an ajax query
-     *
-     * @return void
      */
     public function reinit(bool $ajax = false): void
     {
@@ -176,8 +172,6 @@ class ScheduledPaymentsList extends Pagination
      * Required for twig to access properties via __get
      *
      * @param string $name name of the property we want to retrieve
-     *
-     * @return bool
      */
     public function __isset(string $name): bool
     {
@@ -189,8 +183,6 @@ class ScheduledPaymentsList extends Pagination
      *
      * @param string $name  name of the property we want to assign a value to
      * @param mixed  $value a relevant value for the property
-     *
-     * @return void
      */
     public function __set(string $name, mixed $value): void
     {

--- a/galette/lib/Galette/Filters/TransactionsList.php
+++ b/galette/lib/Galette/Filters/TransactionsList.php
@@ -33,13 +33,13 @@ use Galette\Core\Pagination;
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>
  *
- * @property ?string $start_date_filter
- * @property ?string $end_date_filter
- * @property ?int $filtre_cotis_adh
+ * @property ?string   $start_date_filter
+ * @property ?string   $end_date_filter
+ * @property ?int      $filtre_cotis_adh
  * @property int|false $filtre_cotis_children
- * @property string $rstart_date_filter
- * @property string $rend_date_filter
- * @property ?int $max_amount
+ * @property string    $rstart_date_filter
+ * @property string    $rend_date_filter
+ * @property ?int      $max_amount
  */
 class TransactionsList extends Pagination
 {
@@ -82,8 +82,6 @@ class TransactionsList extends Pagination
 
     /**
      * Returns the field we want to default set order to
-     *
-     * @return int|string
      */
     protected function getDefaultOrder(): int|string
     {
@@ -92,8 +90,6 @@ class TransactionsList extends Pagination
 
     /**
      * Return the default direction for ordering
-     *
-     * @return SQLOrder
      */
     protected function getDefaultDirection(): SQLOrder
     {
@@ -102,8 +98,6 @@ class TransactionsList extends Pagination
 
     /**
      * Reinit default parameters
-     *
-     * @return void
      */
     public function reinit(): void
     {
@@ -154,8 +148,6 @@ class TransactionsList extends Pagination
      * Required for twig to access properties via __get
      *
      * @param string $name name of the property we want to retrieve
-     *
-     * @return bool
      */
     public function __isset(string $name): bool
     {
@@ -167,8 +159,6 @@ class TransactionsList extends Pagination
      *
      * @param string $name  name of the property we want to assign a value to
      * @param mixed  $value a relevant value for the property
-     *
-     * @return void
      */
     public function __set(string $name, mixed $value): void
     {

--- a/galette/lib/Galette/Helpers/DatesHelper.php
+++ b/galette/lib/Galette/Helpers/DatesHelper.php
@@ -40,8 +40,6 @@ trait DatesHelper
      * Builds a Date
      *
      * @param string $value Date to build
-     *
-     * @return string
      */
     protected function buildDate(string $value): string
     {
@@ -67,8 +65,6 @@ trait DatesHelper
      *
      * @param string $field Field to store date
      * @param string $value Date to store
-     *
-     * @return self
      */
     protected function setDate(string $field, string $value): self
     {
@@ -104,8 +100,6 @@ trait DatesHelper
      * @param string $field Field to store date
      * @param string $value Date to store
      * @param bool   $start Is a start date (or is a end date))
-     *
-     * @return self
      */
     protected function setFilterDate(string $field, string $value, bool $start): self
     {
@@ -214,8 +208,6 @@ trait DatesHelper
      * @param string $field      Field name to retrieve
      * @param bool   $formatted  Get formatted date, or DateTime object
      * @param bool   $translated Get translated or db value
-     *
-     * @return string|DateTime|null
      */
     public function getDate(string $field, bool $formatted = true, bool $translated = true): string|DateTime|null
     {

--- a/galette/lib/Galette/Helpers/EntityHelper.php
+++ b/galette/lib/Galette/Helpers/EntityHelper.php
@@ -46,8 +46,6 @@ trait EntityHelper
 
     /**
      * Set fields, must populate $this->fields
-     *
-     * @return self
      */
     abstract protected function setFields(): self;
 
@@ -66,8 +64,6 @@ trait EntityHelper
      * Required for twig to access properties via __get
      *
      * @param string $name name of the property we want to retrieve
-     *
-     * @return bool
      */
     public function __isset(string $name): bool
     {
@@ -87,8 +83,6 @@ trait EntityHelper
      *
      * @param string $field Field name
      * @param string $entry Array entry to use (defaults to "label")
-     *
-     * @return string
      */
     public function getFieldLabel(string $field, string $entry = 'label'): string
     {
@@ -103,8 +97,6 @@ trait EntityHelper
      * Get property name for given field
      *
      * @param string $field Field
-     *
-     * @return string
      */
     protected function getFieldPropertyName(string $field): string
     {

--- a/galette/lib/Galette/IO/Charts.php
+++ b/galette/lib/Galette/IO/Charts.php
@@ -70,8 +70,6 @@ class Charts
 
     /**
      * Loads charts data
-     *
-     * @return void
      */
     private function load(): void
     {
@@ -93,8 +91,6 @@ class Charts
 
     /**
      * Loads data to produce a Pie chart based on members status
-     *
-     * @return void
      */
     private function getChartMembersStatusPie(): void
     {
@@ -138,8 +134,6 @@ class Charts
 
     /**
      * Loads data to produce a Pie chart based on members state of dues
-     *
-     * @return void
      */
     private function getChartMembersStateDuePie(): void
     {
@@ -238,8 +232,6 @@ class Charts
 
     /**
      * Loads data to produce a pie chart based on company/not company members
-     *
-     * @return void
      */
     private function getChartCompaniesOrNot(): void
     {
@@ -297,8 +289,6 @@ class Charts
 
     /**
      * Loads data to produce a Pie chart based on contributions types
-     *
-     * @return void
      */
     private function getChartContribsTypesPie(): void
     {
@@ -333,8 +323,6 @@ class Charts
 
     /**
      * Loads data to produce a Pie chart based on contributions types
-     *
-     * @return void
      */
     private function getChartContribsAllTime(): void
     {

--- a/galette/lib/Galette/IO/ContributionsCsv.php
+++ b/galette/lib/Galette/IO/ContributionsCsv.php
@@ -69,8 +69,6 @@ class ContributionsCsv extends CsvOut
      * Export members CSV
      *
      * @param ContributionsList $filters Current filters
-     *
-     * @return void
      */
     public function exportContributions(ContributionsList $filters): void
     {
@@ -166,8 +164,6 @@ class ContributionsCsv extends CsvOut
 
     /**
      * Get file path on disk
-     *
-     * @return string
      */
     public function getPath(): string
     {
@@ -176,8 +172,6 @@ class ContributionsCsv extends CsvOut
 
     /**
      * Get file name
-     *
-     * @return string
      */
     public function getFileName(): string
     {

--- a/galette/lib/Galette/IO/Csv.php
+++ b/galette/lib/Galette/IO/Csv.php
@@ -125,8 +125,6 @@ abstract class Csv
      * Remove existing CSV file
      *
      * @param string $name File name
-     *
-     * @return bool
      */
     public function remove(string $name): bool
     {
@@ -171,8 +169,6 @@ abstract class Csv
      * Add an error
      *
      * @param string $msg Error message
-     *
-     * @return void
      */
     public function addError(string $msg): void
     {
@@ -196,8 +192,6 @@ abstract class Csv
 
     /**
      * Reset errors
-     *
-     * @return void
      */
     protected function resetErrors(): void
     {

--- a/galette/lib/Galette/IO/CsvIn.php
+++ b/galette/lib/Galette/IO/CsvIn.php
@@ -125,8 +125,6 @@ class CsvIn extends Csv
 
     /**
      * Load fields list from database or from default values
-     *
-     * @return void
      */
     private function loadFields(): void
     {
@@ -160,8 +158,6 @@ class CsvIn extends Csv
      * @param array<string,mixed> $members_fields      Members fields
      * @param array<string,mixed> $members_fields_cats Members fields categories
      * @param bool                $dryrun              Run in dry run mode (do not store in database)
-     *
-     * @return bool|int
      */
     public function import(
         Db $zdb,
@@ -212,8 +208,6 @@ class CsvIn extends Csv
      * Check if input file meet requirements
      *
      * @param string $filename File name
-     *
-     * @return bool
      */
     private function check(string $filename): bool
     {
@@ -450,8 +444,6 @@ class CsvIn extends Csv
      * Store members in database
      *
      * @param string $filename CSV filename
-     *
-     * @return bool
      */
     private function storeMembers(string $filename): bool
     {

--- a/galette/lib/Galette/IO/CsvOut.php
+++ b/galette/lib/Galette/IO/CsvOut.php
@@ -162,8 +162,6 @@ class CsvOut extends Csv
      *   If not, it will be returned
      *
      * @param bool $last true if we write the latest line
-     *
-     * @return void
      */
     private function write(bool $last = false): void
     {
@@ -185,8 +183,6 @@ class CsvOut extends Csv
      * Retrieve parameted export name
      *
      * @param string $id Parameted export identifier
-     *
-     * @return ?string
      */
     public function getParamedtedExportName(string $id): ?string
     {

--- a/galette/lib/Galette/IO/ExternalScript.php
+++ b/galette/lib/Galette/IO/ExternalScript.php
@@ -125,8 +125,6 @@ class ExternalScript
      * Send data
      *
      * @param array<string,mixed> $params Array of params to send
-     *
-     * @return bool
      */
     public function send(array $params): bool
     {
@@ -231,8 +229,6 @@ class ExternalScript
 
     /**
      * Get full output (only relevant is method is file)
-     *
-     * @return string
      */
     public function getOutput(): string
     {

--- a/galette/lib/Galette/IO/FileTrait.php
+++ b/galette/lib/Galette/IO/FileTrait.php
@@ -194,8 +194,6 @@ trait FileTrait
      * @param ?array<string,string> $mimes       Array of permitted mime types
      * @param ?int                  $maxlength   Maximum length for each file
      * @param ?int                  $mincropsize Minimum image side size required for cropping
-     *
-     * @return void
      */
     protected function init(
         ?string $dest = null,
@@ -223,8 +221,6 @@ trait FileTrait
      * Copy existing file to new Location
      *
      * @param string $dest Destination directory
-     *
-     * @return bool
      */
     public function copyTo(string $dest): bool
     {
@@ -246,8 +242,6 @@ trait FileTrait
      * @param UploadedFileInterface[]|array<string, UploadedFileInterface []> $request_files Array of uploaded files (typically from PSR7 request)
      * @param string                                                          $key           Key to look for in uploaded files
      * @param callable|null                                                   $callback      Callback to use for storing the file. If null, will use $this->storeFile()
-     *
-     * @return bool
      */
     public function upload(array $request_files, string $key, ?callable $callback = null): bool
     {
@@ -281,8 +275,6 @@ trait FileTrait
      *
      * @param UploadedFileInterface[] $uploaded_files Array of uploaded files
      * @param callable                $callback       Callback to use for storing the file
-     *
-     * @return void
      */
     private function handleUpload(array $uploaded_files, callable $callback): void
     {
@@ -410,8 +402,6 @@ trait FileTrait
 
     /**
      * Build destination path
-     *
-     * @return string
      */
     protected function buildDestPath(): string
     {
@@ -453,8 +443,6 @@ trait FileTrait
 
     /**
      * Get destination dir
-     *
-     * @return ?string
      */
     public function getDestDir(): ?string
     {
@@ -465,8 +453,6 @@ trait FileTrait
      * Set destination directory
      *
      * @param string $dir Directory
-     *
-     * @return void
      */
     public function setDestDir(string $dir): void
     {
@@ -475,8 +461,6 @@ trait FileTrait
 
     /**
      * Get file name
-     *
-     * @return ?string
      */
     public function getFileName(): ?string
     {
@@ -487,8 +471,6 @@ trait FileTrait
      * Set file name
      *
      * @param string $name file name
-     *
-     * @return void
      */
     public function setFileName(string $name): void
     {
@@ -529,8 +511,6 @@ trait FileTrait
      * Get file mime type
      *
      * @param string $file File
-     *
-     * @return string
      */
     public static function getMimeType(string $file): string
     {

--- a/galette/lib/Galette/IO/MembersCsv.php
+++ b/galette/lib/Galette/IO/MembersCsv.php
@@ -76,8 +76,6 @@ class MembersCsv extends CsvOut
      * Export members CSV
      *
      * @param MembersList $filters Current filters
-     *
-     * @return void
      */
     public function exportMembers(MembersList $filters): void
     {
@@ -254,8 +252,6 @@ class MembersCsv extends CsvOut
 
     /**
      * Get file path on disk
-     *
-     * @return string
      */
     public function getPath(): string
     {
@@ -264,8 +260,6 @@ class MembersCsv extends CsvOut
 
     /**
      * Get file name
-     *
-     * @return string
      */
     public function getFileName(): string
     {

--- a/galette/lib/Galette/IO/News.php
+++ b/galette/lib/Galette/IO/News.php
@@ -76,8 +76,6 @@ class News
 
     /**
      * Get data to cache
-     *
-     * @return string
      */
     protected function getDataTocache(): string
     {
@@ -90,8 +88,6 @@ class News
      * Called once cache has been loaded.
      *
      * @param mixed $contents Content from cache
-     *
-     * @return bool
      */
     protected function cacheLoaded(mixed $contents): bool
     {
@@ -113,8 +109,6 @@ class News
 
     /**
      * Complete path to cache file
-     *
-     * @return string
      */
     protected function getCacheFilename(): string
     {
@@ -127,8 +121,6 @@ class News
 
     /**
      * Parse feed
-     *
-     * @return void
      */
     private function parseFeed(): void
     {
@@ -209,8 +201,6 @@ class News
      * Get feed url, handle Galette website to check available langs
      *
      * @param string $url Requested URL
-     *
-     * @return string
      */
     public function getFeedURL(string $url): string
     {
@@ -246,8 +236,6 @@ class News
 
     /**
      * Check if allow_url_fopen is enabled
-     *
-     * @return bool
      */
     protected function allowURLFOpen(): bool
     {
@@ -256,8 +244,6 @@ class News
 
     /**
      * Ensure data to cache are present
-     *
-     * @return void
      */
     protected function prepareForCache(): void
     {

--- a/galette/lib/Galette/IO/News/Entry.php
+++ b/galette/lib/Galette/IO/News/Entry.php
@@ -46,8 +46,6 @@ class Entry
 
     /**
      * Get entry title
-     *
-     * @return string
      */
     public function getTitle(): string
     {

--- a/galette/lib/Galette/IO/News/Post.php
+++ b/galette/lib/Galette/IO/News/Post.php
@@ -54,8 +54,6 @@ class Post
 
     /**
      * Get post title
-     *
-     * @return string
      */
     public function getTitle(): string
     {
@@ -64,8 +62,6 @@ class Post
 
     /**
      * Get post URL
-     *
-     * @return ?string
      */
     public function getUrl(): ?string
     {
@@ -74,8 +70,6 @@ class Post
 
     /**
      * Get post date
-     *
-     * @return ?string
      */
     public function getDate(): ?string
     {

--- a/galette/lib/Galette/IO/Pdf.php
+++ b/galette/lib/Galette/IO/Pdf.php
@@ -99,8 +99,6 @@ class Pdf extends TCPDF
 
     /**
      * Initialize PDF
-     *
-     * @return void
      */
     public function init(): void
     {
@@ -110,8 +108,6 @@ class Pdf extends TCPDF
 
     /**
      * No header
-     *
-     * @return void
      */
     protected function setNoHeader(): void
     {
@@ -121,8 +117,6 @@ class Pdf extends TCPDF
 
     /**
      * No footer
-     *
-     * @return void
      */
     protected function setNoFooter(): void
     {
@@ -133,8 +127,6 @@ class Pdf extends TCPDF
 
     /**
      * Calculate footer height
-     *
-     * @return void
      */
     private function calculateFooterHeight(): void
     {
@@ -147,8 +139,6 @@ class Pdf extends TCPDF
 
     /**
      * Set show pagination
-     *
-     * @return void
      */
     public function showPagination(): void
     {
@@ -166,10 +156,6 @@ class Pdf extends TCPDF
      * 2017-02-14 :: Johan Cwiklinski : use slim's flash message; do not rely on session for redirect
      *
      * @param string $msg The error message
-     *
-     * @return void
-     * @access public
-     * @since 1.0
      */
     public function Error(mixed $msg): void // phpcs:ignore PSR1.Methods.CamelCapsMethodName
     {
@@ -194,7 +180,7 @@ class Pdf extends TCPDF
      * Converts color from HTML format #RRVVBB
      * to RGB 3 colors array.
      *
-     *  @param string $hex6 7 chars string #RRVVBB
+     * @param string $hex6 7 chars string #RRVVBB
      *
      * @return array<string,float|int>
      */
@@ -209,8 +195,6 @@ class Pdf extends TCPDF
 
     /**
      * Draws PDF page Header
-     *
-     * @return void
      */
     public function Header(): void // phpcs:ignore PSR1.Methods.CamelCapsMethodName
     {
@@ -221,8 +205,6 @@ class Pdf extends TCPDF
      * Draws PDF page footer
      *
      * @param ?TCPDF $pdf PDF instance
-     *
-     * @return void
      */
     public function Footer(?TCPDF $pdf = null): void // phpcs:ignore PSR1.Methods.CamelCapsMethodName
     {
@@ -263,8 +245,6 @@ class Pdf extends TCPDF
      * Draws PDF page header
      *
      * @param ?string $title Additional title to display just after logo
-     *
-     * @return void
      */
     public function PageHeader(?string $title = null): void // phpcs:ignore PSR1.Methods.CamelCapsMethodName
     {
@@ -279,8 +259,6 @@ class Pdf extends TCPDF
      * Draws models PDF page header
      *
      * @param ?string $title Additional title to display just after logo
-     *
-     * @return void
      */
     protected function modelPageHeader(?string $title = null): void
     {
@@ -326,8 +304,6 @@ class Pdf extends TCPDF
      * Draws standard PDF page header
      *
      * @param ?string $title Additional title to display just after logo
-     *
-     * @return void
      */
     protected function standardPageHeader(?string $title = null): void
     {
@@ -382,8 +358,6 @@ class Pdf extends TCPDF
 
     /**
      * Draws body from model
-     *
-     * @return void
      */
     public function PageBody(): void // phpcs:ignore PSR1.Methods.CamelCapsMethodName
     {
@@ -403,8 +377,6 @@ class Pdf extends TCPDF
      * @param int     $fontsize  Font size
      * @param string  $fontstyle Font style (defaults to '')
      * @param ?string $fontname  Font name (defaults to static::FONT)
-     *
-     * @return void
      */
     protected function fixSize(
         string $text,
@@ -428,8 +400,6 @@ class Pdf extends TCPDF
      *
      * @param string $str    Original string
      * @param int    $length Max length
-     *
-     * @return string
      */
     protected function cut(string $str, int $length): string
     {
@@ -448,8 +418,6 @@ class Pdf extends TCPDF
      *
      * @param string $str    Original string
      * @param int    $length Max length
-     *
-     * @return string
      */
     protected function stretchHead(string $str, int $length): string
     {
@@ -465,8 +433,6 @@ class Pdf extends TCPDF
 
     /**
      * Get filename
-     *
-     * @return string
      */
     public function getFilename(): string
     {
@@ -475,8 +441,6 @@ class Pdf extends TCPDF
 
     /**
      * Download PDF from browser
-     *
-     * @return string
      */
     public function download(): string
     {

--- a/galette/lib/Galette/IO/PdfAdhesionForm.php
+++ b/galette/lib/Galette/IO/PdfAdhesionForm.php
@@ -70,8 +70,6 @@ class PdfAdhesionForm extends Pdf
 
     /**
      * Get model
-     *
-     * @return ?PdfModel
      */
     protected function getModel(): ?PdfModel
     {
@@ -85,8 +83,6 @@ class PdfAdhesionForm extends Pdf
      * Store PDF
      *
      * @param string $path Path
-     *
-     * @return bool
      */
     public function store(string $path): bool
     {
@@ -106,8 +102,6 @@ class PdfAdhesionForm extends Pdf
 
     /**
      * Get store path
-     *
-     * @return string
      */
     public function getPath(): string
     {

--- a/galette/lib/Galette/IO/PdfAttendanceSheet.php
+++ b/galette/lib/Galette/IO/PdfAttendanceSheet.php
@@ -49,8 +49,6 @@ class PdfAttendanceSheet extends Pdf
 
     /**
      * Page header
-     *
-     * @return void
      */
     public function Header(): void // phpcs:ignore PSR1.Methods.CamelCapsMethodName
     {
@@ -111,8 +109,6 @@ class PdfAttendanceSheet extends Pdf
 
     /**
      * Initialize PDF
-     *
-     * @return void
      */
     public function init(): void
     {
@@ -137,8 +133,6 @@ class PdfAttendanceSheet extends Pdf
      * Draw members cards
      *
      * @param array<Adherent> $members Members
-     *
-     * @return void
      */
     public function drawSheet(array $members): void
     {
@@ -208,8 +202,6 @@ class PdfAttendanceSheet extends Pdf
 
     /**
      * Add images to file
-     *
-     * @return self
      */
     public function withImages(): self
     {

--- a/galette/lib/Galette/IO/PdfContribution.php
+++ b/galette/lib/Galette/IO/PdfContribution.php
@@ -81,8 +81,6 @@ class PdfContribution extends Pdf
 
     /**
      * Download PDF from browser
-     *
-     * @return string
      */
     public function download(): string
     {
@@ -93,8 +91,6 @@ class PdfContribution extends Pdf
      * Store PDF
      *
      * @param string $path Path
-     *
-     * @return bool
      */
     public function store(string $path): bool
     {
@@ -114,8 +110,6 @@ class PdfContribution extends Pdf
 
     /**
      * Get store path
-     *
-     * @return string
      */
     public function getPath(): string
     {
@@ -124,8 +118,6 @@ class PdfContribution extends Pdf
 
     /**
      * Get filename
-     *
-     * @return string
      */
     public function getFilename(): string
     {

--- a/galette/lib/Galette/IO/PdfGroups.php
+++ b/galette/lib/Galette/IO/PdfGroups.php
@@ -55,8 +55,6 @@ class PdfGroups extends Pdf
 
     /**
      * Draws PDF page Header
-     *
-     * @return void
      */
     public function Header(): void // phpcs:ignore PSR1.Methods.CamelCapsMethodName
     {
@@ -78,8 +76,6 @@ class PdfGroups extends Pdf
 
     /**
      * Initialize PDF
-     *
-     * @return void
      */
     public function init(): void
     {
@@ -109,8 +105,6 @@ class PdfGroups extends Pdf
      *
      * @param array<Group> $groups Groups list
      * @param Login        $login  Login instance
-     *
-     * @return void
      */
     public function draw(array $groups, Login $login): void
     {

--- a/galette/lib/Galette/IO/PdfMembersCards.php
+++ b/galette/lib/Galette/IO/PdfMembersCards.php
@@ -82,8 +82,6 @@ class PdfMembersCards extends Pdf
 
     /**
      * Initialize PDF
-     *
-     * @return void
      */
     public function init(): void
     {
@@ -172,8 +170,6 @@ class PdfMembersCards extends Pdf
      * Draw members cards
      *
      * @param array<Adherent> $members Members
-     *
-     * @return void
      */
     public function drawCards(array $members): void
     {
@@ -340,8 +336,6 @@ class PdfMembersCards extends Pdf
 
     /**
      * Get card width
-     *
-     * @return int
      */
     public static function getWidth(): int
     {
@@ -353,8 +347,6 @@ class PdfMembersCards extends Pdf
 
     /**
      * Get card height
-     *
-     * @return int
      */
     public static function getHeight(): int
     {
@@ -366,8 +358,6 @@ class PdfMembersCards extends Pdf
 
     /**
      * Get number of columns
-     *
-     * @return int
      */
     public static function getCols(): int
     {
@@ -376,8 +366,6 @@ class PdfMembersCards extends Pdf
 
     /**
      * Get number of rows
-     *
-     * @return int
      */
     public static function getRows(): int
     {

--- a/galette/lib/Galette/IO/PdfMembersCardsAdaptative.php
+++ b/galette/lib/Galette/IO/PdfMembersCardsAdaptative.php
@@ -49,8 +49,6 @@ class PdfMembersCardsAdaptative extends PdfMembersCards
 
     /**
      * Initialize PDF
-     *
-     * @return void
      */
     public function init(): void
     {
@@ -97,8 +95,6 @@ class PdfMembersCardsAdaptative extends PdfMembersCards
      * Draw members cards
      *
      * @param array<Adherent> $members Members
-     *
-     * @return void
      */
     public function drawCards(array $members): void
     {
@@ -391,8 +387,6 @@ class PdfMembersCardsAdaptative extends PdfMembersCards
 
     /**
      * Get card width
-     *
-     * @return int
      */
     public static function getWidth(): int
     {
@@ -403,8 +397,6 @@ class PdfMembersCardsAdaptative extends PdfMembersCards
 
     /**
      * Get card height
-     *
-     * @return int
      */
     public static function getHeight(): int
     {
@@ -415,8 +407,6 @@ class PdfMembersCardsAdaptative extends PdfMembersCards
 
     /**
      * Get number of columns
-     *
-     * @return int
      */
     public static function getCols(): int
     {
@@ -438,8 +428,6 @@ class PdfMembersCardsAdaptative extends PdfMembersCards
 
     /**
      * Get number of rows
-     *
-     * @return int
      */
     public static function getRows(): int
     {

--- a/galette/lib/Galette/IO/PdfMembersLabels.php
+++ b/galette/lib/Galette/IO/PdfMembersLabels.php
@@ -54,8 +54,6 @@ class PdfMembersLabels extends Pdf
 
     /**
      * Initialize PDF
-     *
-     * @return void
      */
     public function init(): void
     {
@@ -104,8 +102,6 @@ class PdfMembersLabels extends Pdf
      * Draw members cards
      *
      * @param array<Adherent> $members Members
-     *
-     * @return void
      */
     public function drawLabels(array $members): void
     {

--- a/galette/lib/Galette/IO/ScheduledPaymentsCsv.php
+++ b/galette/lib/Galette/IO/ScheduledPaymentsCsv.php
@@ -67,8 +67,6 @@ class ScheduledPaymentsCsv extends CsvOut
      * Export members CSV
      *
      * @param ScheduledPaymentsList $filters Current filters
-     *
-     * @return void
      */
     public function exportScheduledPayments(ScheduledPaymentsList $filters): void
     {
@@ -140,8 +138,6 @@ class ScheduledPaymentsCsv extends CsvOut
 
     /**
      * Get file path on disk
-     *
-     * @return string
      */
     public function getPath(): string
     {
@@ -150,8 +146,6 @@ class ScheduledPaymentsCsv extends CsvOut
 
     /**
      * Get file name
-     *
-     * @return string
      */
     public function getFileName(): string
     {

--- a/galette/lib/Galette/Interfaces/AccessManagementInterface.php
+++ b/galette/lib/Galette/Interfaces/AccessManagementInterface.php
@@ -36,8 +36,6 @@ interface AccessManagementInterface
      * Can current logged-in user display object?
      *
      * @param Login $login Login instance
-     *
-     * @return bool
      */
     public function canShow(Login $login): bool;
 
@@ -45,8 +43,6 @@ interface AccessManagementInterface
      * Can current logged-in user create object?
      *
      * @param Login $login Login instance
-     *
-     * @return bool
      */
     public function canCreate(Login $login): bool;
 
@@ -54,8 +50,6 @@ interface AccessManagementInterface
      * Can current logged-in user edit object?
      *
      * @param Login $login Login instance
-     *
-     * @return bool
      */
     public function canEdit(Login $login): bool;
 
@@ -63,8 +57,6 @@ interface AccessManagementInterface
      * Can current logged-in user delete object?
      *
      * @param Login $login Login instance
-     *
-     * @return bool
      */
     public function canDelete(Login $login): bool;
 }

--- a/galette/lib/Galette/Middleware/Authenticate.php
+++ b/galette/lib/Galette/Middleware/Authenticate.php
@@ -70,8 +70,6 @@ class Authenticate
      *
      * @param Request        $request PSR7 request
      * @param RequestHandler $handler PSR7 request handler
-     *
-     * @return Response
      */
     public function __invoke(Request $request, RequestHandler $handler): Response
     {
@@ -168,8 +166,7 @@ class Authenticate
      *
      * @param string $name Route name
      *
-     * @return string
-     * @throw RuntimeException
+     * @throws \RuntimeException
      */
     public function getAclFor(string $name): string
     {

--- a/galette/lib/Galette/Middleware/Language.php
+++ b/galette/lib/Galette/Middleware/Language.php
@@ -55,10 +55,8 @@ class Language
     /**
      * Middleware invokable class
      *
-     * @param  Request        $request PSR7 request
-     * @param  RequestHandler $handler Request handler
-     *
-     * @return Response
+     * @param Request        $request PSR7 request
+     * @param RequestHandler $handler Request handler
      */
     public function __invoke(Request $request, RequestHandler $handler): Response
     {

--- a/galette/lib/Galette/Middleware/PublicPages.php
+++ b/galette/lib/Galette/Middleware/PublicPages.php
@@ -59,8 +59,6 @@ class PublicPages
      *
      * @param Request        $request PSR7 request
      * @param RequestHandler $handler PSR7 request handler
-     *
-     * @return Response
      */
     public function __invoke(Request $request, RequestHandler $handler): Response
     {

--- a/galette/lib/Galette/Middleware/Telemetry.php
+++ b/galette/lib/Galette/Middleware/Telemetry.php
@@ -61,10 +61,8 @@ class Telemetry
     /**
      * Middleware invokable class
      *
-     * @param  Request        $request PSR7 request
-     * @param  RequestHandler $handler Request response
-     *
-     * @return Response
+     * @param Request        $request PSR7 request
+     * @param RequestHandler $handler Request response
      */
     public function __invoke(Request $request, RequestHandler $handler): Response
     {

--- a/galette/lib/Galette/Middleware/UpdateAndMaintenance.php
+++ b/galette/lib/Galette/Middleware/UpdateAndMaintenance.php
@@ -77,8 +77,6 @@ class UpdateAndMaintenance
      *
      * @param Request        $request PSR7 request
      * @param RequestHandler $handler PSR7 request handler
-     *
-     * @return Response
      */
     public function __invoke(Request $request, RequestHandler $handler): Response
     {
@@ -95,8 +93,6 @@ class UpdateAndMaintenance
      *
      * @param Request              $request  PSR7 request
      * @param array<string, mixed> $contents HTML page contents
-     *
-     * @return string
      */
     private function renderPage(Request $request, array $contents): string
     {
@@ -140,8 +136,6 @@ class UpdateAndMaintenance
      * Displays maintenance page
      *
      * @param Request $request PSR7 request
-     *
-     * @return string
      */
     private function maintenancePage(Request $request): string
     {
@@ -156,8 +150,6 @@ class UpdateAndMaintenance
      * Displays needs update page
      *
      * @param Request $request PSR7 request
-     *
-     * @return string
      */
     private function needsUpdatePage(Request $request): string
     {

--- a/galette/lib/Galette/Renderers/Html.php
+++ b/galette/lib/Galette/Renderers/Html.php
@@ -55,8 +55,6 @@ class Html implements ErrorRendererInterface
      *
      * @param Throwable $exception           The exception
      * @param bool      $displayErrorDetails Should we display the error details
-     *
-     * @return string
      */
     public function __invoke(Throwable $exception, bool $displayErrorDetails): string
     {

--- a/galette/lib/Galette/Repository/Contributions.php
+++ b/galette/lib/Galette/Repository/Contributions.php
@@ -189,8 +189,6 @@ class Contributions
      * Count contributions from the query
      *
      * @param Select $select Original select
-     *
-     * @return void
      */
     private function proceedCount(Select $select): void
     {
@@ -227,8 +225,6 @@ class Contributions
      * Calculate sum of all selected contributions
      *
      * @param Select $select Original select
-     *
-     * @return void
      */
     private function calculateSum(Select $select): void
     {
@@ -300,8 +296,6 @@ class Contributions
      * Builds where clause, for filtering on simple list mode
      *
      * @param Select $select Original select
-     *
-     * @return void
      */
     private function buildWhereClause(Select $select): void
     {
@@ -463,8 +457,6 @@ class Contributions
 
     /**
      * Get count for current query
-     *
-     * @return int
      */
     public function getCount(): int
     {
@@ -473,8 +465,6 @@ class Contributions
 
     /**
      * Get sum
-     *
-     * @return float
      */
     public function getSum(): float
     {
@@ -487,8 +477,6 @@ class Contributions
      * @param int|array<int> $ids         Contributions identifiers to delete
      * @param History        $hist        History
      * @param bool           $transaction True to begin a database transaction
-     *
-     * @return bool
      */
     public function remove(int|array $ids, History $hist, bool $transaction = true): bool
     {

--- a/galette/lib/Galette/Repository/Groups.php
+++ b/galette/lib/Galette/Repository/Groups.php
@@ -223,8 +223,6 @@ class Groups
      * @param bool          $manager     Add member as manager, defaults to false
      * @param bool          $transaction Does a SQL transaction already exists? Defaults
      *                                   to false.
-     *
-     * @return bool
      */
     public static function addMemberToGroups(Adherent $adh, array $groups, bool $manager = false, bool $transaction = false): bool
     {
@@ -340,8 +338,6 @@ class Groups
      * Remove members from all their groups
      *
      * @param array<int> $ids Members ids
-     *
-     * @return void
      */
     public static function removeMembersFromGroups(array $ids): void
     {
@@ -369,8 +365,6 @@ class Groups
      * Remove member from all his groups
      *
      * @param int $id Member's id
-     *
-     * @return void
      */
     public static function removeMemberFromGroups(int $id): void
     {
@@ -384,8 +378,6 @@ class Groups
      * @param string   $name    Requested name
      * @param int|null $parent  Parent group (defaults to null)
      * @param int|null $current Current ID to be excluded (defaults to null)
-     *
-     * @return bool
      */
     public static function isUnique(Db $zdb, string $name, ?int $parent = null, ?int $current = null): bool
     {

--- a/galette/lib/Galette/Repository/Members.php
+++ b/galette/lib/Galette/Repository/Members.php
@@ -263,8 +263,6 @@ class Members
      * Remove specified members
      *
      * @param int|array<int> $ids Members identifiers to delete
-     *
-     * @return bool
      */
     public function removeMembers(int|array $ids): bool
     {
@@ -910,8 +908,6 @@ class Members
      * Count members from the query
      *
      * @param Select $select Original select
-     *
-     * @return void
      */
     private function proceedCount(Select $select): void
     {
@@ -965,8 +961,6 @@ class Members
      * @param Select         $select Original select
      * @param ?array<string> $fields Fields list to ensure ORDER clause
      *                               references selected fields. Optional.
-     *
-     * @return Select
      */
     private function buildOrderClause(Select $select, ?array $fields = null): Select
     {
@@ -1034,8 +1028,6 @@ class Members
      *
      * @param string         $field_name Field name to order by
      * @param ?array<string> $fields     SELECTE'ed fields
-     *
-     * @return bool
      */
     private function canOrderBy(string $field_name, ?array $fields): bool
     {
@@ -1057,8 +1049,6 @@ class Members
      * Builds where clause, for filtering on simple list mode
      *
      * @param Select $select Original select
-     *
-     * @return void
      */
     private function buildWhereClause(Select $select): void
     {
@@ -1250,8 +1240,6 @@ class Members
      * Builds where clause, for advanced filtering on simple list mode
      *
      * @param Select $select Original select
-     *
-     * @return void
      */
     private function buildAdvancedWhereClause(Select $select): void
     {
@@ -1567,8 +1555,6 @@ class Members
      *
      * If those are not required, or if a file has been imported
      * (from a CSV file for example), we fill here random values.
-     *
-     * @return bool
      */
     public function emptyLogins(): bool
     {
@@ -1764,8 +1750,6 @@ class Members
 
     /**
      * Get count for current query
-     *
-     * @return int
      */
     public function getCount(): int
     {
@@ -1807,8 +1791,6 @@ class Members
 
     /**
      * Get current filters
-     *
-     * @return MembersList|AdvancedMembersList
      */
     public function getFilters(): MembersList|AdvancedMembersList
     {

--- a/galette/lib/Galette/Repository/PaymentTypes.php
+++ b/galette/lib/Galette/Repository/PaymentTypes.php
@@ -87,8 +87,6 @@ class PaymentTypes extends Repository
      * Add default payment types in database
      *
      * @param bool $check_first Check first if it seems initialized
-     *
-     * @return bool
      */
     public function installInit(bool $check_first = true): bool
     {
@@ -137,8 +135,6 @@ class PaymentTypes extends Repository
 
     /**
      * Checks for missing payment types in the database
-     *
-     * @return bool
      */
     protected function checkUpdate(): bool
     {
@@ -195,8 +191,6 @@ class PaymentTypes extends Repository
      *
      * @param string              $table  Table name
      * @param array<string,mixed> $values Values to insert
-     *
-     * @return void
      */
     private function insert(string $table, array $values): void
     {

--- a/galette/lib/Galette/Repository/PdfModels.php
+++ b/galette/lib/Galette/Repository/PdfModels.php
@@ -67,8 +67,6 @@ class PdfModels extends Repository
      * Add default models in database
      *
      * @param bool $check_first Check first if it seems initialized
-     *
-     * @return bool
      */
     public function installInit(bool $check_first = true): bool
     {
@@ -122,8 +120,6 @@ class PdfModels extends Repository
 
     /**
      * Checks for missing texts in the database
-     *
-     * @return bool
      */
     protected function checkUpdate(): bool
     {
@@ -180,8 +176,6 @@ class PdfModels extends Repository
      *
      * @param string              $table  Table name
      * @param array<string,mixed> $values Values to insert
-     *
-     * @return void
      */
     private function insert(string $table, array $values): void
     {

--- a/galette/lib/Galette/Repository/Reminders.php
+++ b/galette/lib/Galette/Repository/Reminders.php
@@ -68,8 +68,6 @@ class Reminders
      * Load late members
      *
      * @param bool $nomail Get reminders for members who do not have email address
-     *
-     * @return void
      */
     private function loadLate(bool $nomail = false): void
     {
@@ -127,8 +125,6 @@ class Reminders
      * Load late members
      *
      * @param bool $nomail Get reminders for members who do not have email address
-     *
-     * @return void
      */
     private function loadImpendings(bool $nomail = false): void
     {
@@ -187,7 +183,6 @@ class Reminders
     /**
      * Get limit date calculated from preferences
      *
-     * @return DateTime
      * @throws Throwable
      */
     private function getLimitDate(): DateTime

--- a/galette/lib/Galette/Repository/Repository.php
+++ b/galette/lib/Galette/Repository/Repository.php
@@ -111,15 +111,11 @@ abstract class Repository
      * Add default values in database
      *
      * @param bool $check_first Check first if it seems initialized, defaults to true
-     *
-     * @return bool
      */
     abstract public function installInit(bool $check_first = true): bool;
 
     /**
      * Get filters
-     *
-     * @return Pagination
      */
     protected function getFilters(): Pagination
     {
@@ -130,8 +126,6 @@ abstract class Repository
      * Set filters
      *
      * @param Pagination $filters Filters
-     *
-     * @return self
      */
     protected function setFilters(Pagination $filters): self
     {
@@ -155,8 +149,6 @@ abstract class Repository
      *
      * @param string         $field_name Field name to order by
      * @param ?array<string> $fields     SELECTE'ed fields
-     *
-     * @return bool
      */
     protected function canOrderBy(string $field_name, ?array $fields): bool
     {

--- a/galette/lib/Galette/Repository/SavedSearches.php
+++ b/galette/lib/Galette/Repository/SavedSearches.php
@@ -137,8 +137,6 @@ class SavedSearches
      * Count searches from the query
      *
      * @param Select $select Original select
-     *
-     * @return void
      */
     private function proceedCount(Select $select): void
     {
@@ -183,8 +181,6 @@ class SavedSearches
 
     /**
      * Get count for current query
-     *
-     * @return int
      */
     public function getCount(): int
     {
@@ -197,8 +193,6 @@ class SavedSearches
      * @param int|array<int> $ids         Searches identifiers to delete
      * @param History        $hist        History
      * @param bool           $transaction True to begin a database transaction
-     *
-     * @return bool
      */
     public function remove(int|array $ids, History $hist, bool $transaction = true): bool
     {

--- a/galette/lib/Galette/Repository/ScheduledPayments.php
+++ b/galette/lib/Galette/Repository/ScheduledPayments.php
@@ -193,8 +193,6 @@ class ScheduledPayments
      * Count scheduled payments from the query
      *
      * @param Select $select Original select
-     *
-     * @return void
      */
     private function proceedCount(Select $select): void
     {
@@ -227,8 +225,6 @@ class ScheduledPayments
      * Calculate sum of all selected scheduled payments
      *
      * @param Select $select Original select
-     *
-     * @return void
      */
     private function calculateSum(Select $select): void
     {
@@ -303,8 +299,6 @@ class ScheduledPayments
      * Builds where clause, for filtering on simple list mode
      *
      * @param Select $select Original select
-     *
-     * @return void
      */
     private function buildWhereClause(Select $select): void
     {
@@ -377,8 +371,6 @@ class ScheduledPayments
      * Builds where clause for filtering on member
      *
      * @param Select $select Original select
-     *
-     * @return void
      */
     private function buildMemberWhereClause(Select $select): void
     {
@@ -424,8 +416,6 @@ class ScheduledPayments
 
     /**
      * Get count for current query
-     *
-     * @return int
      */
     public function getCount(): int
     {
@@ -434,8 +424,6 @@ class ScheduledPayments
 
     /**
      * Get sum
-     *
-     * @return float
      */
     public function getSum(): float
     {
@@ -448,8 +436,6 @@ class ScheduledPayments
      * @param int|array<int> $ids         Scheduled payments identifiers to delete
      * @param History        $hist        History
      * @param bool           $transaction True to begin a database transaction
-     *
-     * @return bool
      */
     public function remove(int|array $ids, History $hist, bool $transaction = true): bool
     {

--- a/galette/lib/Galette/Repository/Titles.php
+++ b/galette/lib/Galette/Repository/Titles.php
@@ -90,7 +90,6 @@ class Titles
     /**
      * Set default titles at install time
      *
-     * @return bool
      * @throws Throwable
      */
     public function installInit(): bool

--- a/galette/lib/Galette/Repository/Transactions.php
+++ b/galette/lib/Galette/Repository/Transactions.php
@@ -148,8 +148,6 @@ class Transactions
      * Count transactions from the query
      *
      * @param Select $select Original select
-     *
-     * @return void
      */
     private function proceedCount(Select $select): void
     {
@@ -216,8 +214,6 @@ class Transactions
      * Builds where clause, for filtering on simple list mode
      *
      * @param Select $select Original select
-     *
-     * @return void
      */
     private function buildWhereClause(Select $select): void
     {
@@ -335,8 +331,6 @@ class Transactions
 
     /**
      * Get count for current query
-     *
-     * @return int
      */
     public function getCount(): int
     {
@@ -348,8 +342,6 @@ class Transactions
      *
      * @param array<int>|int $ids  Transactions identifiers to delete
      * @param History        $hist History
-     *
-     * @return bool
      */
     public function remove(array|int $ids, History $hist): bool
     {

--- a/galette/lib/Galette/Twig/GettextExtension.php
+++ b/galette/lib/Galette/Twig/GettextExtension.php
@@ -56,8 +56,6 @@ class GettextExtension extends AbstractExtension
      *
      * @param string $string The string to translate
      * @param string $domain Translation domain. Default to galette
-     *
-     * @return string
      */
     public function __(
         string $string,
@@ -71,9 +69,6 @@ class GettextExtension extends AbstractExtension
      *
      * @param string $string The string to translate
      * @param string $domain Translation domain. Default to galette
-     *
-     * @return string
-     *
      */
     public function _T(// @phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps,PSR2.Methods.MethodDeclaration.Underscore
         string $string,
@@ -89,8 +84,6 @@ class GettextExtension extends AbstractExtension
      * @param string $plural   Plural string
      * @param int    $count    Count to determine singular/plural
      * @param string $domain   Translation domain. Default to galette
-     *
-     * @return string
      */
     public function _Tn(// @phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps,PSR2.Methods.MethodDeclaration.Underscore
         string $singular,
@@ -107,8 +100,6 @@ class GettextExtension extends AbstractExtension
      * @param string $context The context
      * @param string $string  The string to translate
      * @param string $domain  Translation domain. Default to galette
-     *
-     * @return string
      */
     public function _Tx(// @phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps,PSR2.Methods.MethodDeclaration.Underscore
         string $context,
@@ -126,8 +117,6 @@ class GettextExtension extends AbstractExtension
      * @param string $plural   Plural string
      * @param int    $count    Count to determine singular/plural
      * @param string $domain   Translation domain. Default to galette
-     *
-     * @return string
      */
     public function _Tnx(// @phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps,PSR2.Methods.MethodDeclaration.Underscore
         string $context,

--- a/galette/lib/Galette/Twig/StaticExtension.php
+++ b/galette/lib/Galette/Twig/StaticExtension.php
@@ -65,8 +65,6 @@ class StaticExtension extends AbstractExtension
      * Get member's formatted name
      *
      * @param int|array{id: int} $id Member ID or array with 'id' key
-     *
-     * @return string
      */
     public function memberName(int|array $id): string
     {
@@ -82,8 +80,6 @@ class StaticExtension extends AbstractExtension
      * @param string $class   Class name
      * @param string $method  Method name
      * @param mixed  ...$args Arguments to pass to method
-     *
-     * @return mixed
      */
     public function callStatic(string $class, string $method, mixed ...$args): mixed
     {

--- a/galette/lib/Galette/Updater/AbstractUpdater.php
+++ b/galette/lib/Galette/Updater/AbstractUpdater.php
@@ -86,8 +86,6 @@ abstract class AbstractUpdater
 
     /**
      * Does upgrade have a SQL script to run
-     *
-     * @return bool
      */
     private function hasSql(): bool
     {
@@ -107,8 +105,6 @@ abstract class AbstractUpdater
      *
      * @param Db      $zdb       Database instance
      * @param Install $installer Installer instance
-     *
-     * @return void
      */
     final public function run(Db $zdb, Install $installer): void
     {
@@ -150,16 +146,12 @@ abstract class AbstractUpdater
 
     /**
      * Update instructions
-     *
-     * @return bool
      */
     abstract protected function update(): bool;
 
     /**
      * Pre stuff, if any.
      * Will be executed first.
-     *
-     * @return bool
      */
     protected function preUpdate(): bool
     {
@@ -171,8 +163,6 @@ abstract class AbstractUpdater
      *
      * @param Db      $zdb       Database instance
      * @param Install $installer Installer instance
-     *
-     * @return bool
      */
     private function sql(Db $zdb, Install $installer): bool
     {
@@ -193,8 +183,6 @@ abstract class AbstractUpdater
     /**
      * Post stuff, if any.
      * Will be executed at the end.
-     *
-     * @return bool
      */
     protected function postUpdate(): bool
     {
@@ -205,8 +193,6 @@ abstract class AbstractUpdater
      * Set SQL files instructions for all supported databases
      *
      * @param string $version Version for scripts
-     *
-     * @return bool
      */
     protected function setSqlScripts(string $version): bool
     {
@@ -269,8 +255,6 @@ abstract class AbstractUpdater
      *
      * @param string $msg  Report message
      * @param int    $type Entry type
-     *
-     * @return void
      */
     public function addReportEntry(string $msg, int $type): void
     {
@@ -289,8 +273,6 @@ abstract class AbstractUpdater
      * Add an error in array
      *
      * @param string $msg Error message
-     *
-     * @return void
      */
     public function addError(string $msg): void
     {
@@ -299,8 +281,6 @@ abstract class AbstractUpdater
 
     /**
      * Has current update errors?
-     *
-     * @return bool
      */
     public function hasErrors(): bool
     {
@@ -324,8 +304,6 @@ abstract class AbstractUpdater
 
     /**
      * Update database version
-     *
-     * @return void
      */
     private function updateDbVersion(): void
     {

--- a/galette/lib/Galette/Util/FakeData.php
+++ b/galette/lib/Galette/Util/FakeData.php
@@ -50,8 +50,6 @@ class FakeData
      * Add photo to a member
      *
      * @param Adherent $member Member instance
-     *
-     * @return bool
      */
     public function addPhoto(Adherent $member): bool
     {
@@ -87,8 +85,6 @@ class FakeData
      * Add success message
      *
      * @param string $msg Message
-     *
-     * @return void
      */
     protected function addSuccess(string $msg): void
     {
@@ -99,8 +95,6 @@ class FakeData
      * Add error message
      *
      * @param string $msg Message
-     *
-     * @return void
      */
     protected function addError(string $msg): void
     {
@@ -111,8 +105,6 @@ class FakeData
      * Add warning message
      *
      * @param string $msg Message
-     *
-     * @return void
      */
     protected function addWarning(string $msg): void
     {

--- a/galette/lib/Galette/Util/Password.php
+++ b/galette/lib/Galette/Util/Password.php
@@ -72,8 +72,6 @@ class Password
      * Does password suits requirements?
      *
      * @param string $password Password to test
-     *
-     * @return bool
      */
     public function isValid(string $password): bool
     {
@@ -111,8 +109,6 @@ class Password
      * Is password blacklisted?
      *
      * @param string $password Password to check
-     *
-     * @return bool
      */
     public function isBlacklisted(string $password): bool
     {
@@ -130,8 +126,6 @@ class Password
      * Calculate password strength
      *
      * @param string $password Password to check
-     *
-     * @return int
      */
     public function calculateStrength(string $password): int
     {
@@ -168,8 +162,6 @@ class Password
 
     /**
      * Get current strength
-     *
-     * @return int
      */
     public function getStrenght(): int
     {
@@ -245,8 +237,6 @@ class Password
      * Set member and calculate personal information to blacklist
      *
      * @param Adherent $adh Adherent instance
-     *
-     * @return self
      */
     public function setAdherent(Adherent $adh): self
     {

--- a/galette/lib/Galette/Util/QrCode.php
+++ b/galette/lib/Galette/Util/QrCode.php
@@ -60,8 +60,6 @@ class QrCode
 
     /**
      * Build the QR code
-     *
-     * @return void
      */
     private function build(): void
     {
@@ -89,8 +87,6 @@ class QrCode
 
     /**
      * Get label
-     *
-     * @return string
      */
     public function getLabel(): string
     {
@@ -99,8 +95,6 @@ class QrCode
 
     /**
      * Get URL
-     *
-     * @return ?string
      */
     public function getURL(): ?string
     {
@@ -109,8 +103,6 @@ class QrCode
 
     /**
      * Get image data
-     *
-     * @return string
      */
     public function getImage(): string
     {

--- a/galette/lib/Galette/Util/Release.php
+++ b/galette/lib/Galette/Util/Release.php
@@ -59,8 +59,6 @@ class Release
 
     /**
      * Set ups Guzzle client
-     *
-     * @return Client
      */
     public function setupClient(): Client
     {
@@ -81,8 +79,6 @@ class Release
 
     /**
      * Get the latest release
-     *
-     * @return ?string
      */
     public function getLatestRelease(): ?string
     {
@@ -98,8 +94,6 @@ class Release
 
     /**
      * Get the latest release
-     *
-     * @return ?string
      */
     public function findLatestRelease(): ?string
     {
@@ -143,8 +137,6 @@ class Release
 
     /**
      * Check if a new release is available
-     *
-     * @return bool
      */
     public function checkNewRelease(): bool
     {
@@ -164,8 +156,6 @@ class Release
 
     /**
      * Get the current release
-     *
-     * @return string
      */
     public function getCurrentRelease(): string
     {
@@ -174,8 +164,6 @@ class Release
 
     /**
      * Get the URL to download releases
-     *
-     * @return string
      */
     public function getReleasesURL(): string
     {
@@ -184,8 +172,6 @@ class Release
 
     /**
      * Get data to cache
-     *
-     * @return string
      */
     protected function getDataTocache(): string
     {
@@ -196,8 +182,6 @@ class Release
      * Called once cache has been loaded.
      *
      * @param mixed $content Content from cache
-     *
-     * @return bool
      */
     protected function cacheLoaded(mixed $content): bool
     {
@@ -211,8 +195,6 @@ class Release
 
     /**
      * Complete path to cache file
-     *
-     * @return string
      */
     protected function getCacheFilename(): string
     {
@@ -221,8 +203,6 @@ class Release
 
     /**
      * Ensure data to cache are present
-     *
-     * @return void
      */
     protected function prepareForCache(): void
     {

--- a/galette/lib/Galette/Util/Telemetry.php
+++ b/galette/lib/Galette/Util/Telemetry.php
@@ -211,8 +211,6 @@ class Telemetry
      * Count
      *
      * @param string $table Table to query
-     *
-     * @return int
      */
     public function getCount(string $table): int
     {
@@ -231,8 +229,6 @@ class Telemetry
      * Calculate average parts
      *
      * @param string $table Table to query
-     *
-     * @return string
      */
     private function getAverage(string $table): string
     {
@@ -254,8 +250,6 @@ class Telemetry
 
     /**
      * Send telemetry information
-     *
-     * @return void
      */
     public function send(): void
     {
@@ -303,8 +297,6 @@ class Telemetry
      * Get UUID
      *
      * @param string $type UUID type (either instance or registration)
-     *
-     * @return string
      */
     private function getUuid(string $type): string
     {
@@ -318,8 +310,6 @@ class Telemetry
 
     /**
      * Get instance UUID
-     *
-     * @return string
      */
     private function getInstanceUuid(): string
     {
@@ -328,8 +318,6 @@ class Telemetry
 
     /**
      * Get registration UUID
-     *
-     * @return string
      */
     final public function getRegistrationUuid(): string
     {
@@ -338,8 +326,6 @@ class Telemetry
 
     /**
      * Get date telemetry has been sent
-     *
-     * @return string
      */
     public function getSentDate(): string
     {
@@ -348,8 +334,6 @@ class Telemetry
 
     /**
      * Get date of registration
-     *
-     * @return string
      */
     public function getRegistrationDate(): string
     {
@@ -358,8 +342,6 @@ class Telemetry
 
     /**
      * Does telemetry infos has been sent already?
-     *
-     * @return bool
      */
     public function isSent(): bool
     {
@@ -368,8 +350,6 @@ class Telemetry
 
     /**
      * Is instance registered?
-     *
-     * @return bool
      */
     public function isRegistered(): bool
     {
@@ -379,7 +359,6 @@ class Telemetry
     /**
      * Should telemetry information sent again?
      *
-     * @return bool
      * @throws Exception
      */
     public function shouldRenew(): bool

--- a/galette/lib/Galette/Util/Text.php
+++ b/galette/lib/Galette/Util/Text.php
@@ -40,8 +40,6 @@ class Text
      *
      * @param string $string String to slugify
      * @param string $prefix Prefix to use
-     *
-     * @return string
      */
     public static function slugify(string $string, string $prefix = ''): string
     {
@@ -61,11 +59,8 @@ class Text
     /**
      * Get a random string
      *
-     * @param int $length of the random string
-     *
-     * @return string
-     *
      * @see https://stackoverflow.com/questions/4356289/php-random-string-generator/31107425#31107425
+     * @param int $length of the random string
      */
     public static function getRandomString(int $length): string
     {
@@ -85,8 +80,6 @@ class Text
      * @param int    $max_words Maximum number of words to keep
      * @param string $suffix    Suffix to append if truncated
      * @param bool   $keep_html Keep HTML tags or not
-     *
-     * @return string
      */
     public static function truncateOnWords(
         string $text,
@@ -109,8 +102,6 @@ class Text
      * Convert HTML to text
      *
      * @param string $html HTML to convert
-     *
-     * @return string
      */
     public static function convertHtmlToText(string $html): string
     {

--- a/tests/Galette/Controllers/Crud/ContributionsController.php
+++ b/tests/Galette/Controllers/Crud/ContributionsController.php
@@ -36,8 +36,6 @@ class ContributionsController extends GaletteRoutingTestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -53,8 +51,6 @@ class ContributionsController extends GaletteRoutingTestCase
 
     /**
      * Cleanup after tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -67,8 +63,6 @@ class ContributionsController extends GaletteRoutingTestCase
 
     /**
      * Cleanup after class
-     *
-     * @return void
      */
     public static function tearDownAfterClass(): void
     {
@@ -78,8 +72,6 @@ class ContributionsController extends GaletteRoutingTestCase
 
     /**
      * Test contributions list
-     *
-     * @return void
      */
     public function testList(): void
     {
@@ -398,8 +390,6 @@ class ContributionsController extends GaletteRoutingTestCase
 
     /**
      * Test contributions filters
-     *
-     * @return void
      */
     public function testListFilter(): void
     {
@@ -478,8 +468,6 @@ class ContributionsController extends GaletteRoutingTestCase
      * Test contributions add page
      *
      * @param string $type Contribution type
-     *
-     * @return void
      */
     #[\PHPUnit\Framework\Attributes\DataProvider('contributionTypeProvider')]
     public function testAddPage(string $type): void
@@ -666,8 +654,6 @@ class ContributionsController extends GaletteRoutingTestCase
      * Test contributions edit page
      *
      * @param string $type Contribution type
-     *
-     * @return void
      */
     #[\PHPUnit\Framework\Attributes\DataProvider('contributionTypeProvider')]
     public function testEditPage(string $type): void
@@ -799,8 +785,6 @@ class ContributionsController extends GaletteRoutingTestCase
      * Test add contributions
      *
      * @param string $type Contribution type
-     *
-     * @return void
      */
     #[\PHPUnit\Framework\Attributes\DataProvider('contributionTypeProvider')]
     public function testAddContribution(string $type): void
@@ -1009,8 +993,6 @@ class ContributionsController extends GaletteRoutingTestCase
      * Test edit contributions
      *
      * @param string $type Contribution type
-     *
-     * @return void
      */
     #[\PHPUnit\Framework\Attributes\DataProvider('contributionTypeProvider')]
     public function testEditContribution(string $type): void
@@ -1146,8 +1128,6 @@ class ContributionsController extends GaletteRoutingTestCase
 
     /**
      * Test remove contribution page
-     *
-     * @return void
      */
     public function testRemovePage(): void
     {
@@ -1255,8 +1235,6 @@ class ContributionsController extends GaletteRoutingTestCase
 
     /**
      * Test delete contribution
-     *
-     * @return void
      */
     public function testDeleteContribution(): void
     {

--- a/tests/Galette/Controllers/Crud/DocumentsController.php
+++ b/tests/Galette/Controllers/Crud/DocumentsController.php
@@ -36,8 +36,6 @@ class DocumentsController extends GaletteRoutingTestCase
 
     /**
      * Cleanup after tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -56,8 +54,6 @@ class DocumentsController extends GaletteRoutingTestCase
      * Returns a fresh document instance (PDF status of the association)
      *
      * @param int $visibility Visibility of the document
-     *
-     * @return \Galette\Entity\Document
      */
     private function createStatusDocument(int $visibility = \Galette\Entity\FieldsConfig::ALL): \Galette\Entity\Document
     {
@@ -85,8 +81,6 @@ class DocumentsController extends GaletteRoutingTestCase
 
     /**
      * Test documents list
-     *
-     * @return void
      */
     public function testList(): void
     {
@@ -192,8 +186,6 @@ class DocumentsController extends GaletteRoutingTestCase
 
     /**
      * Test documents list
-     *
-     * @return void
      */
     public function testPublicList(): void
     {
@@ -227,8 +219,6 @@ class DocumentsController extends GaletteRoutingTestCase
 
     /**
      * Test documents add page
-     *
-     * @return void
      */
     public function testAddPage(): void
     {
@@ -250,8 +240,6 @@ class DocumentsController extends GaletteRoutingTestCase
 
     /**
      * Test documents edit page
-     *
-     * @return void
      */
     public function testEditPage(): void
     {
@@ -298,8 +286,6 @@ class DocumentsController extends GaletteRoutingTestCase
 
     /**
      * Test add document
-     *
-     * @return void
      */
     public function testAddDocument(): void
     {
@@ -345,8 +331,6 @@ class DocumentsController extends GaletteRoutingTestCase
 
     /**
      * Test edit document
-     *
-     * @return void
      */
     public function testEditDocument(): void
     {
@@ -378,8 +362,6 @@ class DocumentsController extends GaletteRoutingTestCase
 
     /**
      * Test remove document page
-     *
-     * @return void
      */
     public function testRemovePage(): void
     {
@@ -414,8 +396,6 @@ class DocumentsController extends GaletteRoutingTestCase
 
     /**
      * Test delete document
-     *
-     * @return void
      */
     public function testDeleteDocument(): void
     {
@@ -451,8 +431,6 @@ class DocumentsController extends GaletteRoutingTestCase
 
     /**
      * Test get document file
-     *
-     * @return void
      */
     public function testGetDocument(): void
     {
@@ -488,8 +466,6 @@ class DocumentsController extends GaletteRoutingTestCase
 
     /**
      * Test get document file
-     *
-     * @return void
      */
     public function testGetMissingDocument(): void
     {

--- a/tests/Galette/Controllers/Crud/DynamicFieldsController.php
+++ b/tests/Galette/Controllers/Crud/DynamicFieldsController.php
@@ -24,8 +24,6 @@ declare(strict_types=1);
 namespace GaletteTests\Controllers\Crud;
 
 use Galette\GaletteRoutingTestCase;
-use Slim\Psr7\Headers;
-use Slim\Psr7\Request;
 
 /**
  * DynamicFields controller tests
@@ -38,8 +36,6 @@ class DynamicFieldsController extends GaletteRoutingTestCase
 
     /**
      * Cleanup after tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -70,8 +66,6 @@ class DynamicFieldsController extends GaletteRoutingTestCase
 
     /**
      * Cleanup after class
-     *
-     * @return void
      */
     public static function tearDownAfterClass(): void
     {
@@ -81,8 +75,6 @@ class DynamicFieldsController extends GaletteRoutingTestCase
 
     /**
      * Test add page from controller
-     *
-     * @return void
      */
     public function testAddPageDynamicField(): void
     {
@@ -106,8 +98,6 @@ class DynamicFieldsController extends GaletteRoutingTestCase
 
     /**
      * Test edit page from controller
-     *
-     * @return void
      */
     public function testEditPageDynamicField(): void
     {
@@ -147,8 +137,6 @@ class DynamicFieldsController extends GaletteRoutingTestCase
 
     /**
      * Test adding dynamic field from controller
-     *
-     * @return void
      */
     public function testAddDynamicField(): void
     {
@@ -199,8 +187,6 @@ class DynamicFieldsController extends GaletteRoutingTestCase
 
     /**
      * Test cencelled adding dynamic field from controller
-     *
-     * @return void
      */
     public function testAddCancelynamicField(): void
     {
@@ -236,8 +222,6 @@ class DynamicFieldsController extends GaletteRoutingTestCase
 
     /**
      * Test adding dynamic field from controller with an error
-     *
-     * @return void
      */
     public function testAddErrorDynamicField(): void
     {
@@ -280,8 +264,6 @@ class DynamicFieldsController extends GaletteRoutingTestCase
 
     /**
      * Test updating dynamic field from controller
-     *
-     * @return void
      */
     public function testUpdateDynamicField(): void
     {
@@ -331,8 +313,6 @@ class DynamicFieldsController extends GaletteRoutingTestCase
 
     /**
      * Test canceled updating dynamic field from controller
-     *
-     * @return void
      */
     public function testUpdateCancelDynamicField(): void
     {
@@ -374,8 +354,6 @@ class DynamicFieldsController extends GaletteRoutingTestCase
 
     /**
      * Test error updating dynamic field from controller
-     *
-     * @return void
      */
     public function testUpdateErrorDynamicField(): void
     {
@@ -421,8 +399,6 @@ class DynamicFieldsController extends GaletteRoutingTestCase
 
     /**
      * Test remove page dynamic field from controller
-     *
-     * @return void
      */
     public function testRemovePageDynamicField(): void
     {
@@ -463,8 +439,6 @@ class DynamicFieldsController extends GaletteRoutingTestCase
 
     /**
      * Test dynamic field removal from controller
-     *
-     * @return void
      */
     public function testRemoveDynamicField(): void
     {
@@ -551,8 +525,6 @@ class DynamicFieldsController extends GaletteRoutingTestCase
 
     /**
      * Test dynamic field removal from controller
-     *
-     * @return void
      */
     public function testMoveDynamicField(): void
     {
@@ -620,8 +592,6 @@ class DynamicFieldsController extends GaletteRoutingTestCase
 
     /**
      * Test dynamic fields list
-     *
-     * @return void
      */
     public function testList(): void
     {
@@ -655,8 +625,6 @@ class DynamicFieldsController extends GaletteRoutingTestCase
 
     /**
      * Test getting dynamic file
-     *
-     * @return void
      */
     public function testGetDynamicFile(): void
     {

--- a/tests/Galette/Controllers/Crud/MembersController.php
+++ b/tests/Galette/Controllers/Crud/MembersController.php
@@ -36,8 +36,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -53,8 +51,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Cleanup after tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -70,8 +66,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Cleanup after class
-     *
-     * @return void
      */
     public static function tearDownAfterClass(): void
     {
@@ -81,8 +75,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Test members list
-     *
-     * @return void
      */
     public function testList(): void
     {
@@ -274,8 +266,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Test public members list
-     *
-     * @return void
      */
     public function testPublicMembersList(): void
     {
@@ -339,8 +329,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Test public members gallery
-     *
-     * @return void
      */
     public function testPublicMembersGallery(): void
     {
@@ -398,8 +386,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Test public staff list
-     *
-     * @return void
      */
     public function testPublicStaffList(): void
     {
@@ -464,8 +450,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Test public staff gallery
-     *
-     * @return void
      */
     public function testPublicStaffGallery(): void
     {
@@ -524,8 +508,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Test members filters
-     *
-     * @return void
      */
     public function testListFilter(): void
     {
@@ -674,8 +656,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Test public members list filters
-     *
-     * @return void
      */
     public function testPublicMembersListFilter(): void
     {
@@ -703,8 +683,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Test public members gallery filters
-     *
-     * @return void
      */
     public function testPublicMembersGalleryFilter(): void
     {
@@ -732,8 +710,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Test members add page
-     *
-     * @return void
      */
     public function testAddPage(): void
     {
@@ -882,8 +858,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Test members self subscription page
-     *
-     * @return void
      */
     public function testSelfSubscriptionPage(): void
     {
@@ -929,8 +903,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Test members add child page
-     *
-     * @return void
      */
     public function testAddChildPage(): void
     {
@@ -1050,8 +1022,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Test members edit page
-     *
-     * @return void
      */
     public function testEditPage(): void
     {
@@ -1216,8 +1186,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Test members show page
-     *
-     * @return void
      */
     public function testShowPage(): void
     {
@@ -1349,8 +1317,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Test "my" page
-     *
-     * @return void
      */
     public function testShowMePage(): void
     {
@@ -1413,8 +1379,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Test add members
-     *
-     * @return void
      */
     public function testAddMember(): void
     {
@@ -1639,8 +1603,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Test members adding their own children
-     *
-     * @return void
      */
     public function testMemberAddChild(): void
     {
@@ -1790,8 +1752,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Test members self subscription
-     *
-     * @return void
      */
     public function testMemberSelfSubscription(): void
     {
@@ -1850,8 +1810,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Test member duplication route
-     *
-     * @return void
      */
     public function testMemberDuplicate(): void
     {
@@ -1884,8 +1842,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Test edit members
-     *
-     * @return void
      */
     public function testEditMember(): void
     {
@@ -2231,8 +2187,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Test member photo
-     *
-     * @return void
      */
     public function testMemberPhoto(): void
     {
@@ -2291,8 +2245,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Test mass change page
-     *
-     * @return void
      */
     public function testMassChangePage(): void
     {
@@ -2389,8 +2341,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Test mass change validation page
-     *
-     * @return void
      */
     public function testValidateMassChange(): void
     {
@@ -2549,8 +2499,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Test mass change action
-     *
-     * @return void
      */
     public function testDoMassChanges(): void
     {
@@ -2752,8 +2700,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Test remove member page
-     *
-     * @return void
      */
     public function testRemovePage(): void
     {
@@ -2862,8 +2808,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Test delete member
-     *
-     * @return void
      */
     public function testDeleteMember(): void
     {
@@ -3015,8 +2959,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Test members advanced search page
-     *
-     * @return void
      */
     public function testAvancedSearchPage(): void
     {
@@ -3068,8 +3010,6 @@ class MembersController extends GaletteRoutingTestCase
 
     /**
      * Test disabled fields are well handled
-     *
-     * @return void
      */
     public function testDisabledFields(): void
     {

--- a/tests/Galette/Controllers/Crud/ScheduledPaymentController.php
+++ b/tests/Galette/Controllers/Crud/ScheduledPaymentController.php
@@ -36,8 +36,6 @@ class ScheduledPaymentController extends GaletteRoutingTestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -53,8 +51,6 @@ class ScheduledPaymentController extends GaletteRoutingTestCase
 
     /**
      * Cleanup after tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -71,8 +67,6 @@ class ScheduledPaymentController extends GaletteRoutingTestCase
 
     /**
      * Cleanup after class
-     *
-     * @return void
      */
     public static function tearDownAfterClass(): void
     {
@@ -82,8 +76,6 @@ class ScheduledPaymentController extends GaletteRoutingTestCase
 
     /**
      * Test scheduled payments list
-     *
-     * @return void
      */
     public function testList(): void
     {
@@ -239,8 +231,6 @@ class ScheduledPaymentController extends GaletteRoutingTestCase
 
     /**
      * Test scheduled payment filters
-     *
-     * @return void
      */
     public function testListFilter(): void
     {
@@ -313,8 +303,6 @@ class ScheduledPaymentController extends GaletteRoutingTestCase
 
     /**
      * Test scheduled payment add page
-     *
-     * @return void
      */
     public function testAddPage(): void
     {

--- a/tests/Galette/Controllers/Crud/TransactionsController.php
+++ b/tests/Galette/Controllers/Crud/TransactionsController.php
@@ -38,8 +38,6 @@ class TransactionsController extends GaletteRoutingTestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -55,8 +53,6 @@ class TransactionsController extends GaletteRoutingTestCase
 
     /**
      * Cleanup after tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -69,8 +65,6 @@ class TransactionsController extends GaletteRoutingTestCase
 
     /**
      * Cleanup after class
-     *
-     * @return void
      */
     public static function tearDownAfterClass(): void
     {
@@ -82,8 +76,6 @@ class TransactionsController extends GaletteRoutingTestCase
      * Create test transactions in database
      *
      * @param array $data Data to set
-     *
-     * @return \Galette\Entity\Transaction
      */
     private function createTransaction(array $data = []): \Galette\Entity\Transaction
     {
@@ -113,8 +105,6 @@ class TransactionsController extends GaletteRoutingTestCase
 
     /**
      * Test transactions list
-     *
-     * @return void
      */
     public function testList(): void
     {
@@ -407,8 +397,6 @@ class TransactionsController extends GaletteRoutingTestCase
 
     /**
      * Test transactions filters
-     *
-     * @return void
      */
     public function testListFilter(): void
     {
@@ -474,8 +462,6 @@ class TransactionsController extends GaletteRoutingTestCase
 
     /**
      * Test contributions add page
-     *
-     * @return void
      */
     public function testAddPage(): void
     {
@@ -650,8 +636,6 @@ class TransactionsController extends GaletteRoutingTestCase
 
     /**
      * Test transactions edit page
-     *
-     * @return void
      */
     public function testEditPage(): void
     {
@@ -813,8 +797,6 @@ class TransactionsController extends GaletteRoutingTestCase
 
     /**
      * Test add transactions
-     *
-     * @return void
      */
     public function testAddTransaction(): void
     {
@@ -1022,8 +1004,6 @@ class TransactionsController extends GaletteRoutingTestCase
 
     /**
      * Test edit transactions
-     *
-     * @return void
      */
     public function testEditTransaction(): void
     {
@@ -1164,8 +1144,6 @@ class TransactionsController extends GaletteRoutingTestCase
 
     /**
      * Test remove transaction page
-     *
-     * @return void
      */
     public function testRemovePage(): void
     {
@@ -1258,8 +1236,6 @@ class TransactionsController extends GaletteRoutingTestCase
 
     /**
      * Test delete transaction
-     *
-     * @return void
      */
     public function testDeleteTransaction(): void
     {
@@ -1402,8 +1378,6 @@ class TransactionsController extends GaletteRoutingTestCase
 
     /**
      * Test attach contribution
-     *
-     * @return void
      */
     public function testAttachContribution(): void
     {
@@ -1504,8 +1478,6 @@ class TransactionsController extends GaletteRoutingTestCase
 
     /**
      * Test deattach contribution
-     *
-     * @return void
      */
     public function testDetachContribution(): void
     {

--- a/tests/Galette/Controllers/CsvController.php
+++ b/tests/Galette/Controllers/CsvController.php
@@ -24,8 +24,6 @@ declare(strict_types=1);
 namespace GaletteTests\Controllers;
 
 use Galette\GaletteRoutingTestCase;
-use Slim\Psr7\Headers;
-use Slim\Psr7\Request;
 
 /**
  * CSV controller tests
@@ -38,8 +36,6 @@ class CsvController extends GaletteRoutingTestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -55,8 +51,6 @@ class CsvController extends GaletteRoutingTestCase
 
     /**
      * Cleanup after tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -76,8 +70,6 @@ class CsvController extends GaletteRoutingTestCase
 
     /**
      * Cleanup after class
-     *
-     * @return void
      */
     public static function tearDownAfterClass(): void
     {
@@ -87,8 +79,6 @@ class CsvController extends GaletteRoutingTestCase
 
     /**
      * Test export page
-     *
-     * @return void
      */
     public function testExportPage(): void
     {
@@ -116,8 +106,6 @@ class CsvController extends GaletteRoutingTestCase
 
     /**
      * Test do export (doExport, get file, remove file)
-     *
-     * @return void
      */
     public function testDoExport(): void
     {
@@ -243,8 +231,6 @@ class CsvController extends GaletteRoutingTestCase
 
     /**
      * Test file removal routes
-     *
-     * @return void
      */
     public function testFileRemoval(): void
     {
@@ -337,8 +323,6 @@ class CsvController extends GaletteRoutingTestCase
 
     /**
      * Test import page
-     *
-     * @return void
      */
     public function testImportPage(): void
     {
@@ -366,8 +350,6 @@ class CsvController extends GaletteRoutingTestCase
 
     /**
      * Test getFile route
-     *
-     * @return void
      */
     public function testGetFile(): void
     {
@@ -439,8 +421,6 @@ class CsvController extends GaletteRoutingTestCase
 
     /**
      * Test import model page
-     *
-     * @return void
      */
     public function testImportModelPage(): void
     {
@@ -468,8 +448,6 @@ class CsvController extends GaletteRoutingTestCase
 
     /**
      * Test import model routes (store, get)
-     *
-     * @return void
      */
     public function testImportModel(): void
     {
@@ -542,8 +520,6 @@ class CsvController extends GaletteRoutingTestCase
 
     /**
      * Test members CSV export
-     *
-     * @return void
      */
     public function testMembersExport(): void
     {
@@ -595,8 +571,6 @@ class CsvController extends GaletteRoutingTestCase
 
     /**
      * Test contributions CSV export
-     *
-     * @return void
      */
     public function testContributionExport(): void
     {
@@ -646,8 +620,6 @@ class CsvController extends GaletteRoutingTestCase
 
     /**
      * Test scheduled payment CSV export
-     *
-     * @return void
      */
     public function testScheduledPaymentExport(): void
     {
@@ -719,8 +691,6 @@ class CsvController extends GaletteRoutingTestCase
 
     /**
      * Test upload and import CSV file
-     *
-     * @return void
      */
     public function testImportFile(): void
     {

--- a/tests/Galette/Controllers/GaletteController.php
+++ b/tests/Galette/Controllers/GaletteController.php
@@ -37,8 +37,6 @@ class GaletteController extends GaletteRoutingTestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -56,8 +54,6 @@ class GaletteController extends GaletteRoutingTestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -72,8 +68,6 @@ class GaletteController extends GaletteRoutingTestCase
 
     /**
      * Test main route (redirections)
-     *
-     * @return void
      */
     public function testSlash(): void
     {
@@ -93,8 +87,6 @@ class GaletteController extends GaletteRoutingTestCase
 
     /**
      * Test system information route
-     *
-     * @return void
      */
     public function testSystemInformation(): void
     {
@@ -124,8 +116,6 @@ class GaletteController extends GaletteRoutingTestCase
 
     /**
      * Test dashboard route
-     *
-     * @return void
      */
     public function testDashboard(): void
     {
@@ -147,8 +137,6 @@ class GaletteController extends GaletteRoutingTestCase
 
     /**
      * Test preferences route
-     *
-     * @return void
      */
     public function testPreferences(): void
     {
@@ -178,8 +166,6 @@ class GaletteController extends GaletteRoutingTestCase
 
     /**
      * Test store preferences
-     *
-     * @return void
      */
     public function testStorePreferences(): void
     {
@@ -213,8 +199,6 @@ class GaletteController extends GaletteRoutingTestCase
 
     /**
      * Test store logo
-     *
-     * @return void
      */
     public function testStoreLogo(): void
     {
@@ -258,8 +242,6 @@ class GaletteController extends GaletteRoutingTestCase
 
     /**
      * Test store print logo
-     *
-     * @return void
      */
     public function testStorePrintLogo(): void
     {
@@ -304,8 +286,6 @@ class GaletteController extends GaletteRoutingTestCase
 
     /**
      * Test email test route
-     *
-     * @return void
      */
     public function testTestEmail(): void
     {
@@ -357,8 +337,6 @@ class GaletteController extends GaletteRoutingTestCase
 
     /**
      * Test charts route
-     *
-     * @return void
      */
     public function testCharts(): void
     {
@@ -379,8 +357,6 @@ class GaletteController extends GaletteRoutingTestCase
 
     /**
      * Test core fields configuration route
-     *
-     * @return void
      */
     public function testCoreFieldsConfiguration(): void
     {
@@ -401,8 +377,6 @@ class GaletteController extends GaletteRoutingTestCase
 
     /**
      * Test core fields configuration storage route
-     *
-     * @return void
      */
     public function testStoreCoreFieldsConfiguration(): void
     {
@@ -471,8 +445,6 @@ class GaletteController extends GaletteRoutingTestCase
 
     /**
      * Test core list configuration route
-     *
-     * @return void
      */
     public function testConfigureListFields(): void
     {
@@ -493,8 +465,6 @@ class GaletteController extends GaletteRoutingTestCase
 
     /**
      * Test core list configuration storage route
-     *
-     * @return void
      */
     public function testStoreConfigureListFields(): void
     {
@@ -571,8 +541,6 @@ class GaletteController extends GaletteRoutingTestCase
 
     /**
      * Test reminders route
-     *
-     * @return void
      */
     public function testReminders(): void
     {
@@ -609,8 +577,6 @@ class GaletteController extends GaletteRoutingTestCase
 
     /**
      * Test do reminders route
-     *
-     * @return void
      */
     public function testDoReminders(): void
     {
@@ -717,8 +683,6 @@ class GaletteController extends GaletteRoutingTestCase
 
     /**
      * Test filter reminders route
-     *
-     * @return void
      */
     public function testFilterReminders(): void
     {
@@ -738,8 +702,6 @@ class GaletteController extends GaletteRoutingTestCase
 
     /**
      * Test direct link route
-     *
-     * @return void
      */
     public function testDocumentLink(): void
     {
@@ -776,8 +738,6 @@ class GaletteController extends GaletteRoutingTestCase
      * Test empty route (default favicon.ico, robots.txt, ...)
      *
      * @param string $url URL to test
-     *
-     * @return void
      */
     #[DataProvider('emptyRoutesProvider')]
     public function testEmptyRoute(string $url): void

--- a/tests/Galette/Controllers/PdfController.php
+++ b/tests/Galette/Controllers/PdfController.php
@@ -24,8 +24,6 @@ declare(strict_types=1);
 namespace GaletteTests\Controllers;
 
 use Galette\GaletteRoutingTestCase;
-use Slim\Psr7\Headers;
-use Slim\Psr7\Request;
 
 /**
  * PDF controller tests
@@ -38,8 +36,6 @@ class PdfController extends GaletteRoutingTestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -55,8 +51,6 @@ class PdfController extends GaletteRoutingTestCase
 
     /**
      * Cleanup after tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -72,8 +66,6 @@ class PdfController extends GaletteRoutingTestCase
 
     /**
      * Cleanup after class
-     *
-     * @return void
      */
     public static function tearDownAfterClass(): void
     {
@@ -83,8 +75,6 @@ class PdfController extends GaletteRoutingTestCase
 
     /**
      * Test store models
-     *
-     * @return void
      */
     public function testStoreModels(): void
     {
@@ -125,8 +115,6 @@ class PdfController extends GaletteRoutingTestCase
 
     /**
      * Test display models
-     *
-     * @return void
      */
     public function testDisplayModels(): void
     {
@@ -151,8 +139,6 @@ class PdfController extends GaletteRoutingTestCase
 
     /**
      * Test membersCards
-     *
-     * @return void
      */
     public function testMembersCards(): void
     {
@@ -237,8 +223,6 @@ class PdfController extends GaletteRoutingTestCase
 
     /**
      * Test filtered membersCards
-     *
-     * @return void
      */
     public function testFilteredMembersCards(): void
     {
@@ -270,8 +254,6 @@ class PdfController extends GaletteRoutingTestCase
 
     /**
      * Test membersLabels
-     *
-     * @return void
      */
     public function testMembersLabels(): void
     {
@@ -320,8 +302,6 @@ class PdfController extends GaletteRoutingTestCase
 
     /**
      * Test filtered membersLabels
-     *
-     * @return void
      */
     public function testFilteredMembersLabels(): void
     {
@@ -356,8 +336,6 @@ class PdfController extends GaletteRoutingTestCase
 
     /**
      * Test adhesionForm
-     *
-     * @return void
      */
     public function testadhesionForm(): void
     {
@@ -412,8 +390,6 @@ class PdfController extends GaletteRoutingTestCase
 
     /**
      * Test attendanceSheet
-     *
-     * @return void
      */
     public function testAttendanceSheet(): void
     {
@@ -456,8 +432,6 @@ class PdfController extends GaletteRoutingTestCase
 
     /**
      * Test attendanceSheetConfig
-     *
-     * @return void
      */
     public function testAttendanceSheetConfig(): void
     {
@@ -480,8 +454,6 @@ class PdfController extends GaletteRoutingTestCase
 
     /**
      * Test contribution
-     *
-     * @return void
      */
     public function testContribution(): void
     {
@@ -537,8 +509,6 @@ class PdfController extends GaletteRoutingTestCase
 
     /**
      * Test group
-     *
-     * @return void
      */
     public function testGroup(): void
     {
@@ -575,8 +545,6 @@ class PdfController extends GaletteRoutingTestCase
 
     /**
      * Test direct member card link
-     *
-     * @return void
      */
     public function testDirectlinkDocumentMemberCard(): void
     {
@@ -614,8 +582,6 @@ class PdfController extends GaletteRoutingTestCase
 
     /**
      * Test direct contribution link
-     *
-     * @return void
      */
     public function testDirectlinkDocumentContribution(): void
     {

--- a/tests/Galette/Core/CheckModules.php
+++ b/tests/Galette/Core/CheckModules.php
@@ -34,8 +34,6 @@ class CheckModules extends TestCase
 {
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -48,8 +46,6 @@ class CheckModules extends TestCase
 
     /**
      * Test modules, all should be ok
-     *
-     * @return void
      */
     public function testAllOK(): void
     {
@@ -64,8 +60,6 @@ class CheckModules extends TestCase
 
     /**
      * Test all extensions missing
-     *
-     * @return void
      */
     public function testAllKO(): void
     {
@@ -87,8 +81,6 @@ class CheckModules extends TestCase
 
     /**
      * Test HTMl output
-     *
-     * @return void
      */
     public function testToHtml(): void
     {

--- a/tests/Galette/Core/Db.php
+++ b/tests/Galette/Core/Db.php
@@ -37,8 +37,6 @@ class Db extends TestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -47,8 +45,6 @@ class Db extends TestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -72,8 +68,6 @@ class Db extends TestCase
 
     /**
      * Test constructor
-     *
-     * @return void
      */
     public function testConstructor(): void
     {
@@ -112,8 +106,6 @@ class Db extends TestCase
 
     /**
      * Test database connectivity
-     *
-     * @return void
      */
     public function testConnectivity(): void
     {
@@ -130,8 +122,6 @@ class Db extends TestCase
 
     /**
      * Test database grants
-     *
-     * @return void
      */
     public function testGrant(): void
     {
@@ -158,8 +148,6 @@ class Db extends TestCase
 
     /**
      * Test database grants that throws an exception
-     *
-     * @return void
      */
     public function testGrantWException(): void
     {
@@ -283,8 +271,6 @@ class Db extends TestCase
 
     /**
      * Is database Postgresql powered?
-     *
-     * @return void
      */
     public function testIsPostgres(): void
     {
@@ -298,8 +284,6 @@ class Db extends TestCase
 
     /**
      * Test getters
-     *
-     * @return void
      */
     public function testGetters(): void
     {
@@ -329,8 +313,6 @@ class Db extends TestCase
 
     /**
      * Test getters with exception
-     *
-     * @return void
      */
     public function testGetterWException(): void
     {
@@ -340,8 +322,6 @@ class Db extends TestCase
 
     /**
      * Test select
-     *
-     * @return void
      */
     public function testSelect(): void
     {
@@ -352,12 +332,12 @@ class Db extends TestCase
 
         $query = $this->db->query_string;
 
-        $expected = 'SELECT "p".* FROM "galette_preferences" AS "p" ' .
-            'WHERE "p"."nom_pref" = \'pref_nom\'';
+        $expected = 'SELECT "p".* FROM "galette_preferences" AS "p" '
+            . 'WHERE "p"."nom_pref" = \'pref_nom\'';
 
         if (TYPE_DB === 'mysql') {
-            $expected = 'SELECT `p`.* FROM `galette_preferences` AS `p` ' .
-                'WHERE `p`.`nom_pref` = \'pref_nom\'';
+            $expected = 'SELECT `p`.* FROM `galette_preferences` AS `p` '
+                . 'WHERE `p`.`nom_pref` = \'pref_nom\'';
         }
 
         $this->assertSame($expected, $query);
@@ -365,8 +345,6 @@ class Db extends TestCase
 
     /**
      * Test selectAll
-     *
-     * @return void
      */
     public function testSelectAll(): void
     {
@@ -376,8 +354,6 @@ class Db extends TestCase
 
     /**
      * Test insert
-     *
-     * @return void
      */
     public function testInsert(): void
     {
@@ -404,8 +380,6 @@ class Db extends TestCase
 
     /**
      * Test update
-     *
-     * @return void
      */
     public function testUpdate(): void
     {
@@ -446,8 +420,6 @@ class Db extends TestCase
 
     /**
      * Test delete
-     *
-     * @return void
      */
     public function testDelete(): void
     {
@@ -478,8 +450,6 @@ class Db extends TestCase
 
     /**
      * Test database version
-     *
-     * @return void
      */
     public function testDbVersion(): void
     {
@@ -492,8 +462,6 @@ class Db extends TestCase
 
     /**
      * Test database version that throws an exception
-     *
-     * @return void
      */
     public function testDbVersionWException(): void
     {
@@ -519,8 +487,6 @@ class Db extends TestCase
 
     /**
      * Test get columns method
-     *
-     * @return void
      */
     public function testGetColumns(): void
     {
@@ -547,8 +513,6 @@ class Db extends TestCase
      * Test tables count
      *
      * this test will fail if some plugins tables are present
-     *
-     * @return void
      */
     public function testTables(): void
     {
@@ -601,8 +565,6 @@ class Db extends TestCase
 
     /**
      * Test table exists method
-     *
-     * @return void
      */
     public function testTableExists(): void
     {
@@ -612,8 +574,6 @@ class Db extends TestCase
 
     /**
      * Test UTF conversion, for MySQL only
-     *
-     * @return void
      */
     public function testConvertToUtf(): void
     {
@@ -623,24 +583,20 @@ class Db extends TestCase
 
     /**
      * Test get platform
-     *
-     * @return void
      */
     public function testGetPlatform(): void
     {
         $quoted = $this->db->platform->quoteValue('somethin\' to "quote"');
 
-        $expected = ($this->db->isPostgres()) ?
-            "'somethin'' to \"quote\"'" :
-            "'somethin\\' to \\\"quote\\\"'";
+        $expected = ($this->db->isPostgres())
+            ? "'somethin'' to \"quote\"'"
+            : "'somethin\\' to \\\"quote\\\"'";
 
         $this->assertSame($expected, $quoted);
     }
 
     /**
      * Test execute Method
-     *
-     * @return void
      */
     public function testExecute(): void
     {
@@ -653,8 +609,6 @@ class Db extends TestCase
 
     /**
      * Test execute Method
-     *
-     * @return void
      */
     public function testExecuteWException(): void
     {
@@ -677,8 +631,6 @@ class Db extends TestCase
 
     /**
      * Test serialization
-     *
-     * @return void
      */
     public function testSerialization(): void
     {
@@ -692,8 +644,6 @@ class Db extends TestCase
 
     /**
      * Test getSequenceName
-     *
-     * @return void
      */
     public function testSequenceName(): void
     {
@@ -704,8 +654,6 @@ class Db extends TestCase
 
     /**
      * Test isset
-     *
-     * @return void
      */
     public function testIsset(): void
     {
@@ -717,13 +665,11 @@ class Db extends TestCase
 
     /**
      * Test supported engine
-     *
-     * @return void
      */
     public function testSupportedEngine(): void
     {
         $zdb = $this->getMockBuilder(\Galette\Core\Db::class)
-            ->onlyMethods(['getInfos' , 'isPostgres'])
+            ->onlyMethods(['getInfos', 'isPostgres'])
             ->getMock();
 
         $zdb->method('isPostgres')->willReturn(false);
@@ -736,7 +682,7 @@ class Db extends TestCase
         $this->assertTrue($zdb->isEngineSUpported());
 
         $zdb = $this->getMockBuilder(\Galette\Core\Db::class)
-            ->onlyMethods(['getInfos' , 'isPostgres'])
+            ->onlyMethods(['getInfos', 'isPostgres'])
             ->getMock();
 
         $zdb->method('isPostgres')->willReturn(false);
@@ -753,7 +699,7 @@ class Db extends TestCase
         );
 
         $zdb = $this->getMockBuilder(\Galette\Core\Db::class)
-            ->onlyMethods(['getInfos' , 'isPostgres'])
+            ->onlyMethods(['getInfos', 'isPostgres'])
             ->getMock();
 
         $zdb->method('isPostgres')->willReturn(true);
@@ -766,7 +712,7 @@ class Db extends TestCase
         $this->assertTrue($zdb->isEngineSUpported());
 
         $zdb = $this->getMockBuilder(\Galette\Core\Db::class)
-            ->onlyMethods(['getInfos' , 'isPostgres'])
+            ->onlyMethods(['getInfos', 'isPostgres'])
             ->getMock();
 
         $zdb->method('isPostgres')->willReturn(true);

--- a/tests/Galette/Core/Galette.php
+++ b/tests/Galette/Core/Galette.php
@@ -36,8 +36,6 @@ class Galette extends GaletteTestCase
 
     /**
      * Test gitVersion
-     *
-     * @return void
      */
     public function testGitVersion(): void
     {
@@ -54,8 +52,6 @@ class Galette extends GaletteTestCase
 
     /**
      * Test storing into session of various objects to detect serialization issues
-     *
-     * @return void
      */
     public function testSerialization(): void
     {
@@ -129,8 +125,6 @@ class Galette extends GaletteTestCase
 
     /**
      * Test getMenus
-     *
-     * @return void
      */
     public function testGetMenus(): void
     {
@@ -220,8 +214,6 @@ class Galette extends GaletteTestCase
 
     /**
      * Test getPublicMenus
-     *
-     * @return void
      */
     public function testGetPublicMenus(): void
     {
@@ -268,8 +260,6 @@ class Galette extends GaletteTestCase
 
     /**
      * Test getDashboards
-     *
-     * @return void
      */
     public function testGetDashboards(): void
     {
@@ -345,8 +335,6 @@ class Galette extends GaletteTestCase
 
     /**
      * Test getListActions
-     *
-     * @return void
      */
     public function testGetListActions(): void
     {
@@ -413,8 +401,6 @@ class Galette extends GaletteTestCase
 
     /**
      * Test getDetailledActions
-     *
-     * @return void
      */
     public function testGetDetailledActions(): void
     {
@@ -427,8 +413,6 @@ class Galette extends GaletteTestCase
 
     /**
      * Test getBatchActions
-     *
-     * @return void
      */
     public function testGetBatchActions(): void
     {
@@ -495,8 +479,6 @@ class Galette extends GaletteTestCase
 
     /**
      * Test Galette::getNews() method
-     *
-     * @return void
      */
     public function testGetNews(): void
     {
@@ -607,8 +589,6 @@ class Galette extends GaletteTestCase
 
     /**
      * Test isNightly
-     *
-     * @return void
      */
     public function testIsNightly(): void
     {
@@ -617,8 +597,6 @@ class Galette extends GaletteTestCase
 
     /**
      * Test jsonDecode
-     *
-     * @return void
      */
     public function testJsonDecode(): void
     {
@@ -639,8 +617,6 @@ class Galette extends GaletteTestCase
 
     /**
      * Test jsonEncode
-     *
-     * @return void
      */
     public function testJsonEncode(): void
     {

--- a/tests/Galette/Core/GaletteMail.php
+++ b/tests/Galette/Core/GaletteMail.php
@@ -65,8 +65,6 @@ class GaletteMail extends GaletteTestCase
      *
      * @param string $url      URL to test
      * @param bool   $expected Expected result
-     *
-     * @return void
      */
     #[DataProvider('urlProvider')]
     public function testIsURL(string $url, bool $expected): void
@@ -110,8 +108,6 @@ class GaletteMail extends GaletteTestCase
      *
      * @param string $email    Email to test
      * @param bool   $expected Expected result
-     *
-     * @return void
      */
     #[DataProvider('emailProvider')]
     public function testIsValidEmail(string $email, bool $expected): void
@@ -121,8 +117,6 @@ class GaletteMail extends GaletteTestCase
 
     /**
      * Test setRecipients
-     *
-     * @return void
      */
     public function testSetRecipients(): void
     {
@@ -139,8 +133,6 @@ class GaletteMail extends GaletteTestCase
 
     /**
      * Test sender information getters
-     *
-     * @return void
      */
     public function testGetSender(): void
     {
@@ -151,8 +143,6 @@ class GaletteMail extends GaletteTestCase
 
     /**
      * Test subject setter and getter
-     *
-     * @return void
      */
     public function testSubject(): void
     {
@@ -164,8 +154,6 @@ class GaletteMail extends GaletteTestCase
 
     /**
      * Test mail body
-     *
-     * @return void
      */
     public function testMessage(): void
     {
@@ -188,8 +176,6 @@ class GaletteMail extends GaletteTestCase
 
     /**
      * Test isHtml
-     *
-     * @return void
      */
     public function testIsHtml(): void
     {
@@ -203,8 +189,6 @@ class GaletteMail extends GaletteTestCase
 
     /**
      * Test various getters and setters
-     *
-     * @return void
      */
     public function testGettersSetters(): void
     {

--- a/tests/Galette/Core/Gaptcha.php
+++ b/tests/Galette/Core/Gaptcha.php
@@ -35,8 +35,6 @@ class Gaptcha extends TestCase
 {
     /**
      * Test getRawData
-     *
-     * @return void
      */
     public function testCheck(): void
     {

--- a/tests/Galette/Core/History.php
+++ b/tests/Galette/Core/History.php
@@ -34,8 +34,6 @@ class History extends GaletteTestCase
 {
     /**
      * Test class constants
-     *
-     * @return void
      */
     public function testConstants(): void
     {
@@ -45,8 +43,6 @@ class History extends GaletteTestCase
 
     /**
      * Test history workflow
-     *
-     * @return void
      */
     public function testHistoryFlow(): void
     {

--- a/tests/Galette/Core/I18n.php
+++ b/tests/Galette/Core/I18n.php
@@ -38,8 +38,6 @@ class I18n extends TestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -52,8 +50,6 @@ class I18n extends TestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -64,8 +60,6 @@ class I18n extends TestCase
 
     /**
      * Test lang autodetect
-     *
-     * @return void
      */
     public function testAutoLang(): void
     {
@@ -94,8 +88,6 @@ class I18n extends TestCase
 
     /**
      * Test languages list
-     *
-     * @return void
      */
     public function testGetList(): void
     {
@@ -110,8 +102,6 @@ class I18n extends TestCase
 
     /**
      * Test languages list as array
-     *
-     * @return void
      */
     public function testGetArrayList(): void
     {
@@ -122,8 +112,6 @@ class I18n extends TestCase
 
     /**
      * Test getting language name from its ID
-     *
-     * @return void
      */
     public function testGetNameFromid(): void
     {
@@ -136,8 +124,6 @@ class I18n extends TestCase
 
     /**
      * Test retrieving language information
-     *
-     * @return void
      */
     public function testGetLangInfos(): void
     {
@@ -165,8 +151,6 @@ class I18n extends TestCase
 
     /**
      * Change to an unknown language
-     *
-     * @return void
      */
     public function testChangeUnknownLanguage(): void
     {
@@ -178,8 +162,6 @@ class I18n extends TestCase
 
     /**
      * Check (non) UTF strings
-     *
-     * @return void
      */
     public function testSeemUtf8(): void
     {
@@ -192,8 +174,6 @@ class I18n extends TestCase
 
     /**
      * Test getting online documentation base URL
-     *
-     * @return void
      */
     public function testGetDocumentationBaseUrl(): void
     {

--- a/tests/Galette/Core/Install.php
+++ b/tests/Galette/Core/Install.php
@@ -36,8 +36,6 @@ class Install extends TestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -47,8 +45,6 @@ class Install extends TestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -60,8 +56,6 @@ class Install extends TestCase
 
     /**
      * Test constructor
-     *
-     * @return void
      */
     public function testConstructor(): void
     {
@@ -88,8 +82,6 @@ class Install extends TestCase
 
     /**
      * Tests update scripts list
-     *
-     * @return void
      */
     public function testGetUpgradeScripts(): void
     {
@@ -164,8 +156,6 @@ class Install extends TestCase
 
     /**
      * Test type step
-     *
-     * @return void
      */
     public function testTypeStep(): void
     {
@@ -183,8 +173,6 @@ class Install extends TestCase
 
     /**
      * Test DB installation step
-     *
-     * @return void
      */
     public function testInstallDbStep(): void
     {
@@ -210,8 +198,6 @@ class Install extends TestCase
 
     /**
      * Test DB upgrade step
-     *
-     * @return void
      */
     public function testUpgradeDbStep(): void
     {
@@ -238,8 +224,6 @@ class Install extends TestCase
 
     /**
      * Test unknown mode
-     *
-     * @return void
      */
     public function testUnknownMode(): void
     {
@@ -250,8 +234,6 @@ class Install extends TestCase
 
     /**
      * Test Db types
-     *
-     * @return void
      */
     public function testSetDbType(): void
     {
@@ -281,8 +263,6 @@ class Install extends TestCase
 
     /**
      * Test Db chack step (same for install and upgrade)
-     *
-     * @return void
      */
     public function testDbCheckStep(): void
     {
@@ -340,8 +320,6 @@ class Install extends TestCase
 
     /**
      * Test db install step
-     *
-     * @return void
      */
     public function testDbInstallStep(): void
     {
@@ -379,8 +357,6 @@ class Install extends TestCase
 
     /**
      * Test admin step
-     *
-     * @return void
      */
     public function testAdminStep(): void
     {
@@ -406,8 +382,6 @@ class Install extends TestCase
 
     /**
      * Test galette initialization
-     *
-     * @return void
      */
     public function testInitStep(): void
     {

--- a/tests/Galette/Core/L10n.php
+++ b/tests/Galette/Core/L10n.php
@@ -38,8 +38,6 @@ class L10n extends TestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -55,8 +53,6 @@ class L10n extends TestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -81,8 +77,6 @@ class L10n extends TestCase
 
     /**
      * Test add dynamic translation
-     *
-     * @return void
      */
     public function testAddDynamicTranslation(): void
     {
@@ -159,8 +153,6 @@ class L10n extends TestCase
 
     /**
      * Test dynamic translation flow (add/update/get/delete)
-     *
-     * @return void
      */
     public function testDynamicTranslationFlow(): void
     {
@@ -227,7 +219,7 @@ class L10n extends TestCase
         $results = $this->l10n->getDynamicTranslations(md5('A text for flow test'));
         $this->assertCount(count($langs), $results);
         foreach ($results as $result) {
-                $this->assertSame('', $result['text'], $result['key']);
+            $this->assertSame('', $result['text'], $result['key']);
         }
 
         //update method will create text if it does not exist
@@ -257,8 +249,6 @@ class L10n extends TestCase
 
     /**
      * Test add dynamic translation with exception
-     *
-     * @return void
      */
     public function testAddWException(): void
     {
@@ -282,8 +272,6 @@ class L10n extends TestCase
 
     /**
      * Test update dynamic translation with exception
-     *
-     * @return void
      */
     public function testUpdateWException(): void
     {
@@ -313,8 +301,6 @@ class L10n extends TestCase
 
     /**
      * Test delete dynamic translation with exception
-     *
-     * @return void
      */
     public function testDeleteWException(): void
     {
@@ -338,8 +324,6 @@ class L10n extends TestCase
 
     /**
      * Test get dynamic translation with exception
-     *
-     * @return void
      */
     public function testGetWException(): void
     {
@@ -364,8 +348,6 @@ class L10n extends TestCase
 
     /**
      * Test get dynamic translations with exception
-     *
-     * @return void
      */
     public function testGetsWException(): void
     {

--- a/tests/Galette/Core/Links.php
+++ b/tests/Galette/Core/Links.php
@@ -38,8 +38,6 @@ class Links extends GaletteTestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -58,8 +56,6 @@ class Links extends GaletteTestCase
 
     /**
      * Cleanup after testeach test method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -79,8 +75,6 @@ class Links extends GaletteTestCase
 
     /**
      * Test new Link generation
-     *
-     * @return void
      */
     public function testGenerateNewLink(): void
     {
@@ -129,8 +123,6 @@ class Links extends GaletteTestCase
 
     /**
      * Test expired is invalid
-     *
-     * @return void
      */
     public function testExpiredValidate(): void
     {
@@ -170,8 +162,6 @@ class Links extends GaletteTestCase
 
     /**
      * Test cleanExpired
-     *
-     * @return void
      */
     public function testCleanExpired(): void
     {
@@ -215,8 +205,6 @@ class Links extends GaletteTestCase
 
     /**
      * Test duplicate target
-     *
-     * @return void
      */
     public function testDuplicateLinkTarget(): void
     {
@@ -253,9 +241,9 @@ class Links extends GaletteTestCase
             $exception_trhown = true;
             $this->expectLogEntry(
                 \Analog::ERROR,
-                $this->zdb->isPostgres() ?
-                    'duplicate key value violates unique constraint "galette_tmplinks_pkey"' :
-                    "Duplicate entry '1-1' for key"
+                $this->zdb->isPostgres()
+                    ? 'duplicate key value violates unique constraint "galette_tmplinks_pkey"'
+                    : "Duplicate entry '1-1' for key"
             );
             $this->assertSame(
                 'Duplicate entry',
@@ -267,8 +255,6 @@ class Links extends GaletteTestCase
 
     /**
      * Create test contribution in database
-     *
-     * @return void
      */
     protected function createContribution(): void
     {
@@ -303,8 +289,6 @@ class Links extends GaletteTestCase
      *
      * @param ?\Galette\Entity\Contribution $contrib       Contribution instance, if any
      * @param array<string,mixed>           $new_expecteds Changes on expected values
-     *
-     * @return void
      */
     protected function checkContribExpected(?\Galette\Entity\Contribution $contrib = null, array $new_expecteds = []): void
     {

--- a/tests/Galette/Core/Login.php
+++ b/tests/Galette/Core/Login.php
@@ -38,8 +38,6 @@ class Login extends GaletteTestCase
 
     /**
      * Cleanup after tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -53,8 +51,6 @@ class Login extends GaletteTestCase
 
     /**
      * Test defaults
-     *
-     * @return void
      */
     public function testDefaults(): void
     {
@@ -71,8 +67,6 @@ class Login extends GaletteTestCase
 
     /**
      * Test not logged-in users Impersonating
-     *
-     * @return void
      */
     public function testNotLoggedCantImpersonate(): void
     {
@@ -88,8 +82,6 @@ class Login extends GaletteTestCase
 
     /**
      * Test staff users Impersonating
-     *
-     * @return void
      */
     public function testStaffCantImpersonate(): void
     {
@@ -109,8 +101,6 @@ class Login extends GaletteTestCase
 
     /**
      * Test admin users Impersonating
-     *
-     * @return void
      */
     public function testAdminCantImpersonate(): void
     {
@@ -130,8 +120,6 @@ class Login extends GaletteTestCase
 
     /**
      * Test Impersonating that throws an exception
-     *
-     * @return void
      */
     public function testImpersonateExistsWException(): void
     {
@@ -160,8 +148,6 @@ class Login extends GaletteTestCase
 
     /**
      * Test superadmin users Impersonating
-     *
-     * @return void
      */
     public function testSuperadminCanImpersonate(): void
     {
@@ -179,8 +165,6 @@ class Login extends GaletteTestCase
 
     /**
      * Test return requesting a non-existing property
-     *
-     * @return void
      */
     public function testInexistingGetter(): void
     {
@@ -191,8 +175,6 @@ class Login extends GaletteTestCase
 
     /**
      * Test login exists
-     *
-     * @return void
      */
     public function testLoginExists(): void
     {
@@ -202,8 +184,6 @@ class Login extends GaletteTestCase
 
     /**
      * Test login exists that throws an exception
-     *
-     * @return void
      */
     public function testLoginExistsWException(): void
     {
@@ -227,8 +207,6 @@ class Login extends GaletteTestCase
 
     /**
      * Test login as super admin
-     *
-     * @return void
      */
     public function testLogAdmin(): void
     {
@@ -250,8 +228,6 @@ class Login extends GaletteTestCase
 
     /**
      * Creates or load test user
-     *
-     * @return void
      */
     private function createUser(): void
     {
@@ -320,8 +296,6 @@ class Login extends GaletteTestCase
 
     /**
      * Look for a login that does exist
-     *
-     * @return void
      */
     public function testLoginExistsDb(): void
     {
@@ -331,8 +305,6 @@ class Login extends GaletteTestCase
 
     /**
      * Test user login
-     *
-     * @return void
      */
     public function testLogin(): void
     {
@@ -344,8 +316,6 @@ class Login extends GaletteTestCase
 
     /**
      * Test logged user name
-     *
-     * @return void
      */
     public function testLoggedInAs(): void
     {
@@ -354,7 +324,7 @@ class Login extends GaletteTestCase
         $this->createUser();
         $this->assertTrue($this->login->login($this->login_adh, $this->mdp_adh));
 
-        /** Should get message in the right locale but doesn't... */
+        /* Should get message in the right locale but doesn't... */
         $this->i18n->changeLanguage('en_US');
         $tstring = $translator->translate(
             "Logged in as:<br/>%login",
@@ -374,8 +344,6 @@ class Login extends GaletteTestCase
 
     /**
      * Test login from cron
-     *
-     * @return void
      */
     public function testLogCron(): void
     {

--- a/tests/Galette/Core/Logo.php
+++ b/tests/Galette/Core/Logo.php
@@ -36,8 +36,6 @@ class Logo extends TestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -48,8 +46,6 @@ class Logo extends TestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -60,8 +56,6 @@ class Logo extends TestCase
 
     /**
      * Test defaults after initialization
-     *
-     * @return void
      */
     public function testDefaults(): void
     {

--- a/tests/Galette/Core/Logs.php
+++ b/tests/Galette/Core/Logs.php
@@ -34,8 +34,6 @@ class Logs extends GaletteTestCase
 {
     /**
      * Test cleanup
-     *
-     * @return void
      */
     public function testCleanup(): void
     {

--- a/tests/Galette/Core/Mailing.php
+++ b/tests/Galette/Core/Mailing.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace GaletteTests\Core;
 
 use Galette\GaletteTestCase;
-use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Mailing tests class
@@ -35,8 +34,6 @@ class Mailing extends GaletteTestCase
 {
     /**
      * Test setRecipients
-     *
-     * @return void
      */
     public function testSetRecipients(): void
     {
@@ -65,8 +62,6 @@ class Mailing extends GaletteTestCase
 
     /**
      * Test cleanHTML
-     *
-     * @return void
      */
     public function testCleanHTML(): void
     {
@@ -79,8 +74,6 @@ class Mailing extends GaletteTestCase
 
     /**
      * Test getPhpMailer
-     *
-     * @return void
      */
     public function testGetPhpMailer(): void
     {
@@ -90,8 +83,6 @@ class Mailing extends GaletteTestCase
 
     /**
      * Test __isset
-     *
-     * @return void
      */
     public function testIsset(): void
     {
@@ -106,8 +97,6 @@ class Mailing extends GaletteTestCase
 
     /**
      * Test getters and setters
-     *
-     * @return void
      */
     public function testGetterSetters(): void
     {

--- a/tests/Galette/Core/MailingHistory.php
+++ b/tests/Galette/Core/MailingHistory.php
@@ -36,8 +36,6 @@ class MailingHistory extends GaletteTestCase
 
     /**
      * Cleanup after each test method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -50,8 +48,6 @@ class MailingHistory extends GaletteTestCase
 
     /**
      * Test history workflow
-     *
-     * @return void
      */
     public function testHistoryFlow(): void
     {

--- a/tests/Galette/Core/Password.php
+++ b/tests/Galette/Core/Password.php
@@ -36,8 +36,6 @@ class Password extends GaletteTestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -47,8 +45,6 @@ class Password extends GaletteTestCase
 
     /**
      * Test unique password generator
-     *
-     * @return void
      */
     public function testRandom(): void
     {
@@ -71,8 +67,6 @@ class Password extends GaletteTestCase
 
     /**
      * Create member and get its id
-     *
-     * @return int
      */
     private function localCreateMember(): int
     {
@@ -112,8 +106,6 @@ class Password extends GaletteTestCase
 
     /**
      * Delete member
-     *
-     * @return void
      */
     private function deleteMember(): void
     {
@@ -124,8 +116,6 @@ class Password extends GaletteTestCase
 
     /**
      * Test new Password generation
-     *
-     * @return void
      */
     public function testGenerateNewPassword(): void
     {
@@ -156,8 +146,6 @@ class Password extends GaletteTestCase
 
     /**
      * Test cleanExpired
-     *
-     * @return void
      */
     public function testCleanExpired(): void
     {
@@ -190,8 +178,6 @@ class Password extends GaletteTestCase
 
     /**
      * Generate new password that throws an exception
-     *
-     * @return void
      */
     public function testGenerateNewPasswordWException(): void
     {
@@ -214,8 +200,6 @@ class Password extends GaletteTestCase
 
     /**
      * Test cleanExpired that throws an exception
-     *
-     * @return void
      */
     public function testCleanExpiredWException(): void
     {
@@ -237,8 +221,6 @@ class Password extends GaletteTestCase
 
     /**
      * Test hash validity that throws an exception
-     *
-     * @return void
      */
     public function testIsHashValidWException(): void
     {
@@ -261,8 +243,6 @@ class Password extends GaletteTestCase
 
     /**
      * Test hash removal that throws an exception
-     *
-     * @return void
      */
     public function testRemoveHashWException(): void
     {

--- a/tests/Galette/Core/Picture.php
+++ b/tests/Galette/Core/Picture.php
@@ -51,8 +51,6 @@ class Picture extends TestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -62,8 +60,6 @@ class Picture extends TestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -74,8 +70,6 @@ class Picture extends TestCase
 
     /**
      * Test defaults after initialization
-     *
-     * @return void
      */
     public function testDefaults(): void
     {
@@ -102,8 +96,6 @@ class Picture extends TestCase
 
     /**
      * Test setters
-     *
-     * @return void
      */
     public function testSetters(): void
     {
@@ -120,8 +112,6 @@ class Picture extends TestCase
     /**
      * Test mimetype guess
      * FileInfo installed.
-     *
-     * @return void
      */
     public function testFileInfoMimeType(): void
     {
@@ -146,8 +136,6 @@ class Picture extends TestCase
 
     /**
      * Test storage
-     *
-     * @return void
      */
     public function testStore(): void
     {
@@ -188,8 +176,6 @@ class Picture extends TestCase
 
     /**
      * Test error messages
-     *
-     * @return void
      */
     public function testErrorMessages(): void
     {

--- a/tests/Galette/Core/Plugins.php
+++ b/tests/Galette/Core/Plugins.php
@@ -53,8 +53,6 @@ class Plugins extends TestCase
 
     /**
      * Get instantiated plugins instance
-     *
-     * @return \Galette\Core\Plugins
      */
     private function getPlugins(): \Galette\Core\Plugins
     {
@@ -66,8 +64,6 @@ class Plugins extends TestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -76,14 +72,12 @@ class Plugins extends TestCase
 
         $this->plugins = $this->getPlugins();
 
-        $this->plugin2['root'] = GALETTE_PLUGINS_PATH .
-            $this->plugin2['root'];
+        $this->plugin2['root'] = GALETTE_PLUGINS_PATH
+            . $this->plugin2['root'];
     }
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -94,8 +88,6 @@ class Plugins extends TestCase
 
     /**
      * Tests plugins load
-     *
-     * @return void
      */
     public function testLoadModules(): void
     {
@@ -110,8 +102,6 @@ class Plugins extends TestCase
 
     /**
      * Test module existence
-     *
-     * @return void
      */
     public function testModuleExists(): void
     {
@@ -121,8 +111,6 @@ class Plugins extends TestCase
 
     /**
      * Test disabled plugin
-     *
-     * @return void
      */
     public function testDisabledModules(): void
     {
@@ -134,8 +122,6 @@ class Plugins extends TestCase
 
     /**
      * Test module root
-     *
-     * @return void
      */
     public function testModuleRoot(): void
     {
@@ -144,8 +130,6 @@ class Plugins extends TestCase
 
     /**
      * Test reset modules list
-     *
-     * @return void
      */
     public function testResetModulesList(): void
     {
@@ -156,8 +140,6 @@ class Plugins extends TestCase
 
     /**
      * Test plugin (des)activation
-     *
-     * @return void
      */
     public function testModuleActivation(): void
     {
@@ -181,8 +163,6 @@ class Plugins extends TestCase
 
     /**
      * Test non-existant module activation
-     *
-     * @return void
      */
     public function testNonExistantModuleActivation(): void
     {
@@ -193,8 +173,6 @@ class Plugins extends TestCase
 
     /**
      * Test non-existant module de-activation
-     *
-     * @return void
      */
     public function testNonExistantModuleDeactivation(): void
     {
@@ -205,8 +183,6 @@ class Plugins extends TestCase
 
     /**
      * Test if plugin needs database
-     *
-     * @return void
      */
     public function testNeedDatabse(): void
     {

--- a/tests/Galette/Core/Preferences.php
+++ b/tests/Galette/Core/Preferences.php
@@ -25,7 +25,6 @@ namespace GaletteTests\Core;
 
 use Galette\GaletteTestCase;
 use PHPMailer\PHPMailer\PHPMailer;
-use PHPUnit\Framework\TestCase;
 
 /**
  * Preferences tests class
@@ -38,8 +37,6 @@ class Preferences extends GaletteTestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -50,8 +47,6 @@ class Preferences extends GaletteTestCase
 
     /**
      * Test preferences initialization
-     *
-     * @return void
      */
     public function testInstallInit(): void
     {
@@ -142,8 +137,6 @@ class Preferences extends GaletteTestCase
 
     /**
      * Test fields names
-     *
-     * @return void
      */
     public function testFieldsNames(): void
     {
@@ -159,8 +152,6 @@ class Preferences extends GaletteTestCase
 
     /**
      * Test preferences updating when some are missing
-     *
-     * @return void
      */
     public function testUpdate(): void
     {
@@ -197,8 +188,6 @@ class Preferences extends GaletteTestCase
 
     /**
      * Test public pages visibility
-     *
-     * @return void
      */
     public function testPublicPagesVisibility(): void
     {
@@ -344,8 +333,6 @@ class Preferences extends GaletteTestCase
 
     /**
      * Data provider for cards sizes tests
-     *
-     * @return array
      */
     public static function sizesProvider(): array
     {
@@ -400,8 +387,6 @@ class Preferences extends GaletteTestCase
      * @param int $vs    Vertical spacing
      * @param int $hs    Horizontal spacing
      * @param int $count Number of expected errors
-     *
-     * @return void
      */
     public function testCheckCardsSizes(int $vm, int $hm, int $vs, int $hs, int $count): void
     {
@@ -414,8 +399,6 @@ class Preferences extends GaletteTestCase
 
     /**
      * Data provider for colors
-     *
-     * @return array
      */
     public static function colorsProvider(): array
     {
@@ -449,8 +432,6 @@ class Preferences extends GaletteTestCase
      * @param string $prop     Property to be set
      * @param string $color    Color to set
      * @param string $expected Expected color
-     *
-     * @return void
      */
     public function testColors(string $prop, string $color, string $expected): void
     {
@@ -461,8 +442,6 @@ class Preferences extends GaletteTestCase
 
     /**
      * Test social networks
-     *
-     * @return void
      */
     public function testSocials(): void
     {
@@ -598,8 +577,6 @@ class Preferences extends GaletteTestCase
 
     /**
      * Test email signature
-     *
-     * @return void
      */
     public function testGetMailSignature(): void
     {
@@ -673,8 +650,6 @@ class Preferences extends GaletteTestCase
 
     /**
      * Test getLegend
-     *
-     * @return void
      */
     public function testGetLegend(): void
     {
@@ -684,8 +659,8 @@ class Preferences extends GaletteTestCase
         $this->assertCount(10, $legend['socials']['patterns']);
         $this->assertSame(
             [
-            'title' => __('Mastodon'),
-            'pattern' => '/{ASSO_SOCIAL_MASTODON}/'
+                'title' => __('Mastodon'),
+                'pattern' => '/{ASSO_SOCIAL_MASTODON}/'
             ],
             $legend['socials']['patterns']['asso_social_mastodon']
         );
@@ -714,8 +689,6 @@ class Preferences extends GaletteTestCase
 
     /**
      * Test website URL
-     *
-     * @return void
      */
     public function testWebsiteURL(): void
     {
@@ -740,8 +713,6 @@ class Preferences extends GaletteTestCase
 
     /**
      * Test updateTelemetryDate
-     *
-     * @return void
      */
     public function testUpdateTelemetryDate(): void
     {
@@ -755,8 +726,6 @@ class Preferences extends GaletteTestCase
 
     /**
      * Test updateRegistrationDate
-     *
-     * @return void
      */
     public function testUpdateRegistrationDate(): void
     {
@@ -770,8 +739,6 @@ class Preferences extends GaletteTestCase
 
     /**
      * Test generateUUID
-     *
-     * @return void
      */
     public function testGenerateUUID(): void
     {
@@ -785,8 +752,6 @@ class Preferences extends GaletteTestCase
 
     /**
      * Test for required end of membership parameter(s) presence and values
-     *
-     * @return void
      */
     public function testRequiredEndOfMembership(): void
     {
@@ -840,8 +805,6 @@ class Preferences extends GaletteTestCase
 
     /**
      * Test email related parameters
-     *
-     * @return void
      */
     public function testEmailParameters(): void
     {
@@ -1012,8 +975,6 @@ class Preferences extends GaletteTestCase
 
     /**
      * Test for required fields
-     *
-     * @return void
      */
     public function testRequireds(): void
     {
@@ -1060,8 +1021,6 @@ class Preferences extends GaletteTestCase
 
     /**
      * Test admin password check
-     *
-     * @return void
      */
     public function testAdminPassCheck(): void
     {
@@ -1083,8 +1042,6 @@ class Preferences extends GaletteTestCase
 
     /**
      * Test postal address
-     *
-     * @return void
      */
     public function testPostalAddress(): void
     {
@@ -1121,8 +1078,6 @@ class Preferences extends GaletteTestCase
 
     /**
      * Test phone number
-     *
-     * @return void
      */
     public function testOrgPhone(): void
     {
@@ -1163,8 +1118,6 @@ class Preferences extends GaletteTestCase
 
     /**
      * Test for admin login
-     *
-     * @return void
      */
     public function testAdminLogin(): void
     {
@@ -1200,8 +1153,6 @@ class Preferences extends GaletteTestCase
 
     /**
      * Test __isset
-     *
-     * @return void
      */
     public function testIsset(): void
     {

--- a/tests/Galette/Core/PrintLogo.php
+++ b/tests/Galette/Core/PrintLogo.php
@@ -36,8 +36,6 @@ class PrintLogo extends TestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -48,8 +46,6 @@ class PrintLogo extends TestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -60,8 +56,6 @@ class PrintLogo extends TestCase
 
     /**
      * Test defaults after initialization
-     *
-     * @return void
      */
     public function testDefaults(): void
     {

--- a/tests/Galette/Core/SysInfos.php
+++ b/tests/Galette/Core/SysInfos.php
@@ -34,8 +34,6 @@ class SysInfos extends GaletteTestCase
 {
     /**
      * Test getRawData
-     *
-     * @return void
      */
     public function testGetRawData(): void
     {

--- a/tests/Galette/DynamicFields/Boolean.php
+++ b/tests/Galette/DynamicFields/Boolean.php
@@ -36,8 +36,6 @@ class Boolean extends GaletteTestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -47,8 +45,6 @@ class Boolean extends GaletteTestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -62,8 +58,6 @@ class Boolean extends GaletteTestCase
 
     /**
      * Test constructor
-     *
-     * @return void
      */
     public function testConstructor(): void
     {
@@ -73,8 +67,6 @@ class Boolean extends GaletteTestCase
 
     /**
      * Test get type name
-     *
-     * @return void
      */
     public function testGetTypeName(): void
     {
@@ -83,8 +75,6 @@ class Boolean extends GaletteTestCase
 
     /**
      * Test if basic properties are ok
-     *
-     * @return void
      */
     public function testBaseProperties(): void
     {
@@ -138,8 +128,6 @@ class Boolean extends GaletteTestCase
 
     /**
      * Test from database
-     *
-     * @return void
      */
     public function testInDb(): void
     {
@@ -176,8 +164,6 @@ class Boolean extends GaletteTestCase
 
     /**
      * Test displayed value
-     *
-     * @return void
      */
     public function testDisplayValue(): void
     {

--- a/tests/Galette/DynamicFields/Choice.php
+++ b/tests/Galette/DynamicFields/Choice.php
@@ -37,8 +37,6 @@ class Choice extends TestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -48,8 +46,6 @@ class Choice extends TestCase
 
     /**
      * Test constructor
-     *
-     * @return void
      */
     public function testConstructor(): void
     {
@@ -59,8 +55,6 @@ class Choice extends TestCase
 
     /**
      * Test get type name
-     *
-     * @return void
      */
     public function testGetTypeName(): void
     {
@@ -69,8 +63,6 @@ class Choice extends TestCase
 
     /**
      * Test if basic properties are ok
-     *
-     * @return void
      */
     public function testBaseProperties(): void
     {
@@ -124,8 +116,6 @@ class Choice extends TestCase
 
     /**
      * Test displayed value
-     *
-     * @return void
      */
     public function testDisplayValue(): void
     {

--- a/tests/Galette/DynamicFields/Date.php
+++ b/tests/Galette/DynamicFields/Date.php
@@ -37,8 +37,6 @@ class Date extends TestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -48,8 +46,6 @@ class Date extends TestCase
 
     /**
      * Test constructor
-     *
-     * @return void
      */
     public function testConstructor(): void
     {
@@ -59,8 +55,6 @@ class Date extends TestCase
 
     /**
      * Test get type name
-     *
-     * @return void
      */
     public function testGetTypeName(): void
     {
@@ -69,8 +63,6 @@ class Date extends TestCase
 
     /**
      * Test if basic properties are ok
-     *
-     * @return void
      */
     public function testBaseProperties(): void
     {
@@ -124,8 +116,6 @@ class Date extends TestCase
 
     /**
      * Test displayed value
-     *
-     * @return void
      */
     public function testDisplayValue(): void
     {

--- a/tests/Galette/DynamicFields/DynamicField.php
+++ b/tests/Galette/DynamicFields/DynamicField.php
@@ -36,8 +36,6 @@ class DynamicField extends TestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -46,8 +44,6 @@ class DynamicField extends TestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -70,8 +66,6 @@ class DynamicField extends TestCase
 
     /**
      * Test loadFieldType
-     *
-     * @return void
      */
     public function testLoadFieldType(): void
     {
@@ -134,8 +128,6 @@ class DynamicField extends TestCase
 
     /**
      * Permissions names provider
-     *
-     * @return array
      */
     public static function permsProvider(): array
     {
@@ -152,8 +144,6 @@ class DynamicField extends TestCase
 
     /**
      * Test getPermissionsList
-     *
-     * @return void
      */
     public function testGetPermissionsList(): void
     {
@@ -177,8 +167,6 @@ class DynamicField extends TestCase
      * @param string $name Name
      *
      * @dataProvider permsProvider
-     *
-     * @return void
      */
     public function testGetPermissionName(int $perm, string $name): void
     {
@@ -206,8 +194,6 @@ class DynamicField extends TestCase
 
     /**
      * Test getFormsNames
-     *
-     * @return void
      */
     public function testGetFormsNames(): void
     {
@@ -252,8 +238,6 @@ class DynamicField extends TestCase
      * @param string $expected Expected name
      *
      * @dataProvider formNamesProvider
-     *
-     * @return void
      */
     public function testGetFormTitle(string $form, string $expected): void
     {
@@ -262,8 +246,6 @@ class DynamicField extends TestCase
 
     /**
      * Test getFixedValuesTableName
-     *
-     * @return void
      */
     public function testGetFixedValuesTableName(): void
     {
@@ -274,8 +256,6 @@ class DynamicField extends TestCase
 
     /**
      * Test getValues
-     *
-     * @return void
      */
     public function testGetValues(): void
     {
@@ -312,8 +292,6 @@ class DynamicField extends TestCase
 
     /**
      * Test check
-     *
-     * @return void
      */
     public function testCheck(): void
     {
@@ -473,8 +451,6 @@ class DynamicField extends TestCase
 
     /**
      * Test move
-     *
-     * @return void
      */
     public function testMove(): void
     {
@@ -564,8 +540,6 @@ class DynamicField extends TestCase
 
     /**
      * Test remove
-     *
-     * @return void
      */
     public function testRemove(): void
     {
@@ -609,8 +583,6 @@ class DynamicField extends TestCase
 
     /**
      * Test information
-     *
-     * @return void
      */
     public function testInformation(): void
     {

--- a/tests/Galette/DynamicFields/File.php
+++ b/tests/Galette/DynamicFields/File.php
@@ -37,8 +37,6 @@ class File extends TestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -48,8 +46,6 @@ class File extends TestCase
 
     /**
      * Test constructor
-     *
-     * @return void
      */
     public function testConstructor(): void
     {
@@ -59,8 +55,6 @@ class File extends TestCase
 
     /**
      * Test get type name
-     *
-     * @return void
      */
     public function testGetTypeName(): void
     {
@@ -69,8 +63,6 @@ class File extends TestCase
 
     /**
      * Test if basic properties are ok
-     *
-     * @return void
      */
     public function testBaseProperties(): void
     {
@@ -124,8 +116,6 @@ class File extends TestCase
 
     /**
      * Test displayed value
-     *
-     * @return void
      */
     public function testDisplayValue(): void
     {

--- a/tests/Galette/DynamicFields/Line.php
+++ b/tests/Galette/DynamicFields/Line.php
@@ -36,8 +36,6 @@ class Line extends GaletteTestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -47,8 +45,6 @@ class Line extends GaletteTestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -62,8 +58,6 @@ class Line extends GaletteTestCase
 
     /**
      * Test constructor
-     *
-     * @return void
      */
     public function testConstructor(): void
     {
@@ -73,8 +67,6 @@ class Line extends GaletteTestCase
 
     /**
      * Test get type name
-     *
-     * @return void
      */
     public function testGetTypeName(): void
     {
@@ -83,8 +75,6 @@ class Line extends GaletteTestCase
 
     /**
      * Test if basic properties are ok
-     *
-     * @return void
      */
     public function testBaseProperties(): void
     {
@@ -138,8 +128,6 @@ class Line extends GaletteTestCase
 
     /**
      * Test from database
-     *
-     * @return void
      */
     public function testInDb(): void
     {
@@ -179,8 +167,6 @@ class Line extends GaletteTestCase
 
     /**
      * Test displayed value
-     *
-     * @return void
      */
     public function testDisplayValue(): void
     {

--- a/tests/Galette/DynamicFields/Separator.php
+++ b/tests/Galette/DynamicFields/Separator.php
@@ -37,8 +37,6 @@ class Separator extends TestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -48,8 +46,6 @@ class Separator extends TestCase
 
     /**
      * Test constructor
-     *
-     * @return void
      */
     public function testConstructor(): void
     {
@@ -59,8 +55,6 @@ class Separator extends TestCase
 
     /**
      * Test get type name
-     *
-     * @return void
      */
     public function testGetTypeName(): void
     {
@@ -69,8 +63,6 @@ class Separator extends TestCase
 
     /**
      * Test if basic properties are ok
-     *
-     * @return void
      */
     public function testBaseProperties(): void
     {

--- a/tests/Galette/DynamicFields/Text.php
+++ b/tests/Galette/DynamicFields/Text.php
@@ -37,8 +37,6 @@ class Text extends TestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -48,8 +46,6 @@ class Text extends TestCase
 
     /**
      * Test constructor
-     *
-     * @return void
      */
     public function testConstructor(): void
     {
@@ -59,8 +55,6 @@ class Text extends TestCase
 
     /**
      * Test get type name
-     *
-     * @return void
      */
     public function testGetTypeName(): void
     {
@@ -69,8 +63,6 @@ class Text extends TestCase
 
     /**
      * Test if basic properties are ok
-     *
-     * @return void
      */
     public function testBaseProperties(): void
     {
@@ -124,8 +116,6 @@ class Text extends TestCase
 
     /**
      * Test displayed value
-     *
-     * @return void
      */
     public function testDisplayValue(): void
     {

--- a/tests/Galette/Entity/Adherent.php
+++ b/tests/Galette/Entity/Adherent.php
@@ -37,8 +37,6 @@ class Adherent extends GaletteTestCase
 
     /**
      * Cleanup after tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -81,8 +79,6 @@ class Adherent extends GaletteTestCase
 
     /**
      * Cleanup after class
-     *
-     * @return void
      */
     public static function tearDownAfterClass(): void
     {
@@ -93,8 +89,6 @@ class Adherent extends GaletteTestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -120,8 +114,6 @@ class Adherent extends GaletteTestCase
 
     /**
      * Test empty member
-     *
-     * @return void
      */
     public function testEmpty(): void
     {
@@ -168,8 +160,6 @@ class Adherent extends GaletteTestCase
 
     /**
      * Test member load dependencies
-     *
-     * @return void
      */
     public function testDependencies(): void
     {
@@ -276,8 +266,6 @@ class Adherent extends GaletteTestCase
 
     /**
      * Tests getter
-     *
-     * @return void
      */
     public function testGetterWException(): void
     {
@@ -289,8 +277,6 @@ class Adherent extends GaletteTestCase
 
     /**
      * Set dependencies from constructor
-     *
-     * @return void
      */
     public function testDepsAtConstuct(): void
     {
@@ -314,8 +300,6 @@ class Adherent extends GaletteTestCase
 
     /**
      * Test simple member creation
-     *
-     * @return void
      */
     public function testSimpleMember(): void
     {
@@ -329,8 +313,6 @@ class Adherent extends GaletteTestCase
 
     /**
      * Test send email property
-     *
-     * @return void
      */
     public function testSendEmail(): void
     {
@@ -342,8 +324,6 @@ class Adherent extends GaletteTestCase
 
     /**
      * Test isset
-     *
-     * @return void
      */
     public function testIsset(): void
     {
@@ -368,8 +348,6 @@ class Adherent extends GaletteTestCase
 
     /**
      * Test load form login and email
-     *
-     * @return void
      */
     public function testLoadForLogin(): void
     {
@@ -389,8 +367,6 @@ class Adherent extends GaletteTestCase
 
     /**
      * Test password updating
-     *
-     * @return void
      */
     public function testUpdatePassword(): void
     {
@@ -410,8 +386,6 @@ class Adherent extends GaletteTestCase
 
     /**
      * Tests check errors
-     *
-     * @return void
      */
     public function testCheckErrors(): void
     {
@@ -578,8 +552,6 @@ class Adherent extends GaletteTestCase
 
     /**
      * Test picture
-     *
-     * @return void
      */
     public function testPhoto(): void
     {
@@ -598,8 +570,6 @@ class Adherent extends GaletteTestCase
 
     /**
      * Test canEdit
-     *
-     * @return void
      */
     public function testCanEdit(): void
     {
@@ -670,8 +640,6 @@ class Adherent extends GaletteTestCase
 
     /**
      * Test canDelete
-     *
-     * @return void
      */
     public function testCanDelete(): void
     {
@@ -742,8 +710,6 @@ class Adherent extends GaletteTestCase
 
     /**
      * Test member duplication
-     *
-     * @return void
      */
     public function testDuplicate(): void
     {
@@ -767,8 +733,6 @@ class Adherent extends GaletteTestCase
 
     /**
      * Test parents
-     *
-     * @return void
      */
     public function testParents(): void
     {
@@ -852,8 +816,6 @@ class Adherent extends GaletteTestCase
 
     /**
      * Test XSS/SQL injection
-     *
-     * @return void
      */
     public function testInjection(): void
     {
@@ -873,8 +835,6 @@ class Adherent extends GaletteTestCase
 
     /**
      * Test can* methods
-     *
-     * @return void
      */
     public function testCan(): void
     {
@@ -936,12 +896,12 @@ class Adherent extends GaletteTestCase
         $this->logSuperAdmin();
 
         $child_data = [
-                'nom_adh'       => 'Doe',
-                'prenom_adh'    => 'Johny',
-                'parent_id'     => $member->id,
-                'attach'        => true,
-                'login_adh'     => 'child.johny.doe',
-                'fingerprint' => 'FAKER' . $this->seed
+            'nom_adh'       => 'Doe',
+            'prenom_adh'    => 'Johny',
+            'parent_id'     => $member->id,
+            'attach'        => true,
+            'login_adh'     => 'child.johny.doe',
+            'fingerprint' => 'FAKER' . $this->seed
         ];
         $child = $this->createMember($child_data);
         $cid = $child->id;
@@ -1079,8 +1039,6 @@ class Adherent extends GaletteTestCase
      * @param int|false                   $id       ID
      * @param string|false                $nick     Nick
      * @param string                      $expected Expected result
-     *
-     * @return void
      */
     public function testsGetNameWithCase(
         string $name,
@@ -1106,8 +1064,6 @@ class Adherent extends GaletteTestCase
      * Change member active status
      *
      * @param bool $active Activation status
-     *
-     * @return void
      */
     private function changeMemberActivation(bool $active): void
     {
@@ -1122,8 +1078,6 @@ class Adherent extends GaletteTestCase
 
     /**
      * Test getDueStatus
-     *
-     * @return void
      */
     public function testGetDueStatus(): void
     {
@@ -1224,8 +1178,6 @@ class Adherent extends GaletteTestCase
 
     /**
      * Test isSponsor
-     *
-     * @return void
      */
     public function testIsSponsor(): void
     {
@@ -1287,8 +1239,6 @@ class Adherent extends GaletteTestCase
     /**
      * Test dynamic boolean field uncheck
      * @see https://bugs.galette.eu/issues/1472
-     *
-     * @return void
      */
     public function testDynamicBooleanUncheck(): void
     {
@@ -1461,8 +1411,6 @@ class Adherent extends GaletteTestCase
     /**
      * Test dynamic dates
      * @see https://bugs.galette.eu/issues/1881
-     *
-     * @return void
      */
     public function testDynamicDates(): void
     {
@@ -1645,8 +1593,8 @@ class Adherent extends GaletteTestCase
         );
 
         $data = $this->dataAdherentOne() + [
-                'info_field_' . $ddate->getId() . '_1'   => date('d/m/Y')
-            ];
+            'info_field_' . $ddate->getId() . '_1'   => date('d/m/Y')
+        ];
 
         $check = $adh->check($data, [], []);
         $this->assertIsArray($check);
@@ -1667,8 +1615,8 @@ class Adherent extends GaletteTestCase
         );
 
         $data = $this->dataAdherentOne() + [
-                'info_field_' . $ddate->getId() . '_1'   => date('d/m/Y')
-            ];
+            'info_field_' . $ddate->getId() . '_1'   => date('d/m/Y')
+        ];
 
         $check = $adh->check($data, [], []);
         if (is_array($check)) {
@@ -1775,8 +1723,8 @@ class Adherent extends GaletteTestCase
         );
 
         $data = $this->dataAdherentOne() + [
-                'info_field_' . $ddate->getId() . '_1'   => '2025-13-13'
-            ];
+            'info_field_' . $ddate->getId() . '_1'   => '2025-13-13'
+        ];
 
         $check = $adh->check($data, [], []);
         $this->assertIsArray($check);
@@ -1786,8 +1734,6 @@ class Adherent extends GaletteTestCase
 
     /**
      * Test group membership
-     *
-     * @return void
      */
     public function testTitle(): void
     {
@@ -1809,8 +1755,6 @@ class Adherent extends GaletteTestCase
 
     /**
      * Test group membership
-     *
-     * @return void
      */
     public function testGroupMembership(): void
     {
@@ -1867,8 +1811,6 @@ class Adherent extends GaletteTestCase
 
     /**
      * Test vCard export
-     *
-     * @return void
      */
     public function testgetVCard(): void
     {
@@ -1885,8 +1827,6 @@ class Adherent extends GaletteTestCase
 
     /**
      * Test QR codes generation
-     *
-     * @return void
      */
     public function testGetQrCodes(): void
     {
@@ -1919,8 +1859,6 @@ class Adherent extends GaletteTestCase
 
     /**
      * Test there is no empty login possible
-     *
-     * @return void
      */
     public function testNoEmptyLogin(): void
     {

--- a/tests/Galette/Entity/Contribution.php
+++ b/tests/Galette/Entity/Contribution.php
@@ -37,8 +37,6 @@ class Contribution extends GaletteTestCase
 
     /**
      * Cleanup after each test method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -57,8 +55,6 @@ class Contribution extends GaletteTestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -76,8 +72,6 @@ class Contribution extends GaletteTestCase
 
     /**
      * pref_beg_membership provider
-     *
-     * @return array
      */
     public static function begProvider(): array
     {
@@ -89,8 +83,6 @@ class Contribution extends GaletteTestCase
 
     /**
      * Test empty contribution
-     *
-     * @return void
      */
     public function testMembershipExtensionJustEmpty(): void
     {
@@ -137,8 +129,6 @@ class Contribution extends GaletteTestCase
      * Test empty contribution with begin of membership set in preferences
      *
      * @param string $interval Interval to subtract from now to set begin of membership
-     *
-     * @return void
      */
     #[DataProvider("begProvider")]
     public function testBeginMembershipJustEmpty(string $interval): void
@@ -203,8 +193,6 @@ class Contribution extends GaletteTestCase
 
     /**
      * Test empty donation
-     *
-     * @return void
      */
     public function testEmptyDonation(): void
     {
@@ -258,8 +246,6 @@ class Contribution extends GaletteTestCase
      * Test empty donation with begin of membership set in preferences
      *
      * @param string $interval Interval to subtract from now to set begin of membership
-     *
-     * @return void
      */
     #[DataProvider("begProvider")]
     public function testBeginMembershipEmptyDonation(string $interval): void
@@ -330,8 +316,6 @@ class Contribution extends GaletteTestCase
 
     /**
      * Test empty fee
-     *
-     * @return void
      */
     public function testEmptyFee(): void
     {
@@ -393,8 +377,6 @@ class Contribution extends GaletteTestCase
 
     /**
      * Test empty fee with a "monthly" contribution type
-     *
-     * @return void
      */
     public function testEmptyMonthlyFee(): void
     {
@@ -462,8 +444,6 @@ class Contribution extends GaletteTestCase
      * Test empty fee with begin of membership set in preferences
      *
      * @param string $interval Interval to subtract from now to set begin of membership
-     *
-     * @return void
      */
     #[DataProvider("begProvider")]
     public function testBeginMembershipEmptyFee(string $interval): void
@@ -548,8 +528,6 @@ class Contribution extends GaletteTestCase
      * Test empty fee with begin of membership set in preferences and a "monthly" contribution type
      *
      * @param string $interval Interval to subtract from now to set begin of membership
-     *
-     * @return void
      */
     #[DataProvider("begProvider")]
     public function testBeginMembershipEmptyMonthlyFee(string $interval): void
@@ -637,8 +615,6 @@ class Contribution extends GaletteTestCase
 
     /**
      * Test getter and setter special cases
-     *
-     * @return void
      */
     public function testGetterSetter(): void
     {
@@ -752,8 +728,6 @@ class Contribution extends GaletteTestCase
 
     /**
      * Test contribution creation
-     *
-     * @return void
      */
     public function testCreation(): void
     {
@@ -766,8 +740,6 @@ class Contribution extends GaletteTestCase
 
     /**
      * Test contributions can have an amount equals to zero
-     *
-     * @return void
      */
     public function testZeroAmountContribution(): void
     {
@@ -814,8 +786,6 @@ class Contribution extends GaletteTestCase
 
     /**
      * Test donation update
-     *
-     * @return void
      */
     public function testDonationUpdate(): void
     {
@@ -892,8 +862,6 @@ class Contribution extends GaletteTestCase
 
     /**
      * Test contribution update
-     *
-     * @return void
      */
     public function testContributionUpdate(): void
     {
@@ -978,8 +946,6 @@ class Contribution extends GaletteTestCase
     /**
      * Test end date retrieving
      * This is based on some Preferences parameters
-     *
-     * @return void
      */
     public function testRetrieveEndDate(): void
     {
@@ -1060,8 +1026,6 @@ class Contribution extends GaletteTestCase
 
     /**
      * Test monthly contribution
-     *
-     * @return void
      */
     public function testMonthlyContribution(): void
     {
@@ -1083,8 +1047,6 @@ class Contribution extends GaletteTestCase
 
     /**
      * Test checkOverlap method
-     *
-     * @return void
      */
     public function testCheckOverlap(): void
     {
@@ -1182,8 +1144,6 @@ class Contribution extends GaletteTestCase
 
     /**
      * Test fields labels
-     *
-     * @return void
      */
     public function testGetFieldLabel(): void
     {
@@ -1211,8 +1171,6 @@ class Contribution extends GaletteTestCase
 
     /**
      * Test contribution loading
-     *
-     * @return void
      */
     public function testLoad(): void
     {
@@ -1246,8 +1204,6 @@ class Contribution extends GaletteTestCase
 
     /**
      * Test contribution removal
-     *
-     * @return void
      */
     public function testRemove(): void
     {
@@ -1266,8 +1222,6 @@ class Contribution extends GaletteTestCase
 
     /**
      * Test can* methods
-     *
-     * @return void
      */
     public function testCan(): void
     {
@@ -1398,8 +1352,6 @@ class Contribution extends GaletteTestCase
 
     /**
      * Test next year contribution
-     *
-     * @return void
      */
     public function testNextYear(): void
     {
@@ -1435,8 +1387,6 @@ class Contribution extends GaletteTestCase
 
     /**
      * Test next year contribution from a 0.9.x
-     *
-     * @return void
      */
     public function testNextYearFrom096(): void
     {
@@ -1496,8 +1446,6 @@ class Contribution extends GaletteTestCase
 
     /**
      * Test contribution end date is set after start date - when relevant
-     *
-     * @return void
      */
     public function testEndDateBeforeStartDate(): void
     {
@@ -1551,8 +1499,6 @@ class Contribution extends GaletteTestCase
 
     /**
      * Test login checks
-     *
-     * @return void
      */
     public function testCheckLogin(): void
     {

--- a/tests/Galette/Entity/ContributionsTypes.php
+++ b/tests/Galette/Entity/ContributionsTypes.php
@@ -39,8 +39,6 @@ class ContributionsTypes extends TestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -52,8 +50,6 @@ class ContributionsTypes extends TestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -65,8 +61,6 @@ class ContributionsTypes extends TestCase
 
     /**
      * Delete contributions types
-     *
-     * @return void
      */
     private function deleteTypes(): void
     {
@@ -85,8 +79,6 @@ class ContributionsTypes extends TestCase
 
     /**
      * Test contributions types
-     *
-     * @return void
      */
     public function testContributionsTypes(): void
     {
@@ -205,8 +197,6 @@ class ContributionsTypes extends TestCase
 
     /**
      * Test getList
-     *
-     * @return void
      */
     public function testGetList(): void
     {

--- a/tests/Galette/Entity/Document.php
+++ b/tests/Galette/Entity/Document.php
@@ -36,8 +36,6 @@ class Document extends GaletteTestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -52,8 +50,6 @@ class Document extends GaletteTestCase
 
     /**
      * Delete documents
-     *
-     * @return void
      */
     private function deleteDocuments(): void
     {
@@ -63,8 +59,6 @@ class Document extends GaletteTestCase
 
     /**
      * Test document object
-     *
-     * @return void
      */
     public function testObject(): void
     {
@@ -87,8 +81,6 @@ class Document extends GaletteTestCase
 
     /**
      * Test document "system" types
-     *
-     * @return void
      */
     public function testGetSystemTypes(): void
     {
@@ -98,8 +90,6 @@ class Document extends GaletteTestCase
 
     /**
      * Test getList
-     *
-     * @return void
      */
     public function testGetList(): void
     {
@@ -294,8 +284,6 @@ class Document extends GaletteTestCase
 
     /**
      * Test getTypes
-     *
-     * @return void
      */
     public function testGetTypes(): void
     {

--- a/tests/Galette/Entity/FieldsConfig.php
+++ b/tests/Galette/Entity/FieldsConfig.php
@@ -39,8 +39,6 @@ class FieldsConfig extends TestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -62,8 +60,6 @@ class FieldsConfig extends TestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -73,8 +69,6 @@ class FieldsConfig extends TestCase
 
     /**
      * Test non required fields
-     *
-     * @return void
      */
     public function testNonRequired(): void
     {
@@ -99,8 +93,6 @@ class FieldsConfig extends TestCase
 
     /**
      * Test FieldsConfig initialization
-     *
-     * @return void
      */
     public function testInstallInit(): void
     {
@@ -146,10 +138,10 @@ class FieldsConfig extends TestCase
 
         $visibles = $fields_config->getVisibilities();
         $this->assertCount(
-            count($categorized[\Galette\Entity\FieldsCategories::ADH_CATEGORY_IDENTITY]) +
-            count($categorized[\Galette\Entity\FieldsCategories::ADH_CATEGORY_GALETTE]) +
-            count($categorized[\Galette\Entity\FieldsCategories::ADH_CATEGORY_CONTACT]) +
-            count($lists_config->getAclMapping()),
+            count($categorized[\Galette\Entity\FieldsCategories::ADH_CATEGORY_IDENTITY])
+            + count($categorized[\Galette\Entity\FieldsCategories::ADH_CATEGORY_GALETTE])
+            + count($categorized[\Galette\Entity\FieldsCategories::ADH_CATEGORY_CONTACT])
+            + count($lists_config->getAclMapping()),
             $visibles
         );
 
@@ -161,8 +153,6 @@ class FieldsConfig extends TestCase
      * Count categorized_fields
      *
      * @param array $categorized Categorized fields
-     *
-     * @return void
      */
     private function countCategorizedFields(array $categorized): void
     {
@@ -174,8 +164,6 @@ class FieldsConfig extends TestCase
 
     /**
      * Test setNotRequired
-     *
-     * @return void
      */
     public function testSetNotRequired(): void
     {
@@ -200,8 +188,6 @@ class FieldsConfig extends TestCase
 
     /**
      * Test getVisibility
-     *
-     * @return void
      */
     public function testGetVisibility(): void
     {
@@ -219,8 +205,6 @@ class FieldsConfig extends TestCase
 
     /**
      * Test setFields and storage
-     *
-     * @return void
      */
     public function testSetFields(): void
     {
@@ -260,8 +244,6 @@ class FieldsConfig extends TestCase
 
     /**
      * Test isSelfExcluded
-     *
-     * @return void
      */
     public function testIsSelfExcluded(): void
     {
@@ -272,8 +254,6 @@ class FieldsConfig extends TestCase
 
     /**
      * Test checkUpdate
-     *
-     * @return void
      */
     public function testCheckUpdate(): void
     {
@@ -323,8 +303,6 @@ class FieldsConfig extends TestCase
 
     /**
      * Test check update when all is empty
-     *
-     * @return void
      */
     public function testCheckUpdateWhenEmpty(): void
     {
@@ -351,8 +329,6 @@ class FieldsConfig extends TestCase
 
     /**
      * Test get display elements
-     *
-     * @return void
      */
     public function testGetDisplayElements(): void
     {
@@ -407,8 +383,6 @@ class FieldsConfig extends TestCase
 
     /**
      * Test get form elements
-     *
-     * @return void
      */
     public function testGetFormElements(): void
     {
@@ -512,8 +486,6 @@ class FieldsConfig extends TestCase
 
     /**
      * Test permissions list
-     *
-     * @return void
      */
     public function testGetPermissionsList(): void
     {

--- a/tests/Galette/Entity/Group.php
+++ b/tests/Galette/Entity/Group.php
@@ -23,9 +23,7 @@ declare(strict_types=1);
 
 namespace GaletteTests\Entity;
 
-use PHPUnit\Framework\TestCase;
 use Galette\GaletteTestCase;
-use Laminas\Db\Adapter\Adapter;
 
 /**
  * Group tests
@@ -38,8 +36,6 @@ class Group extends GaletteTestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -49,8 +45,6 @@ class Group extends GaletteTestCase
 
     /**
      * Delete groups
-     *
-     * @return void
      */
     private function deleteGroups(): void
     {
@@ -70,8 +64,6 @@ class Group extends GaletteTestCase
 
     /**
      * Test empty group
-     *
-     * @return void
      */
     public function testGroup(): void
     {
@@ -91,8 +83,6 @@ class Group extends GaletteTestCase
 
     /**
      * Test single group
-     *
-     * @return void
      */
     public function testSingleGroup(): void
     {
@@ -132,8 +122,6 @@ class Group extends GaletteTestCase
 
     /**
      * Test group name uniqueness when adding
-     *
-     * @return void
      */
     public function testAddUnicity(): void
     {
@@ -158,8 +146,6 @@ class Group extends GaletteTestCase
 
     /**
      * Test group name uniqueness when editing
-     *
-     * @return void
      */
     public function testEditUnicity(): void
     {
@@ -194,8 +180,6 @@ class Group extends GaletteTestCase
 
     /**
      * Test sub groups
-     *
-     * @return void
      */
     public function testSubGroup(): void
     {
@@ -263,8 +247,6 @@ class Group extends GaletteTestCase
 
     /**
      * Test removal
-     *
-     * @return void
      */
     public function testRemove(): void
     {

--- a/tests/Galette/Entity/ListsConfig.php
+++ b/tests/Galette/Entity/ListsConfig.php
@@ -47,8 +47,6 @@ class ListsConfig extends TestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -70,8 +68,6 @@ class ListsConfig extends TestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -85,8 +81,6 @@ class ListsConfig extends TestCase
 
     /**
      * Resets lists configuration to defaults
-     *
-     * @return void
      */
     private function resetListsConfig(): void
     {
@@ -100,8 +94,6 @@ class ListsConfig extends TestCase
 
     /**
      * Test getVisibility
-     *
-     * @return void
      */
     public function testGetVisibility(): void
     {
@@ -124,8 +116,6 @@ class ListsConfig extends TestCase
 
     /**
      * Test setFields and storage
-     *
-     * @return void
      */
     public function testSetFields(): void
     {
@@ -209,8 +199,6 @@ class ListsConfig extends TestCase
 
     /**
      * Test get display elements
-     *
-     * @return void
      */
     public function testGetDisplayElements(): void
     {

--- a/tests/Galette/Entity/PaymentType.php
+++ b/tests/Galette/Entity/PaymentType.php
@@ -40,8 +40,6 @@ class PaymentType extends TestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -59,8 +57,6 @@ class PaymentType extends TestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -72,8 +68,6 @@ class PaymentType extends TestCase
 
     /**
      * Delete payment type
-     *
-     * @return void
      */
     private function deletePaymentType(): void
     {
@@ -92,8 +86,6 @@ class PaymentType extends TestCase
 
     /**
      * Test payment type
-     *
-     * @return void
      */
     public function testPaymentType(): void
     {

--- a/tests/Galette/Entity/PdfModel.php
+++ b/tests/Galette/Entity/PdfModel.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace GaletteTests\Entity;
 
-use Galette\Entity\Adherent;
 use Galette\DynamicFields\DynamicField;
 use Galette\GaletteTestCase;
 
@@ -38,8 +37,6 @@ class PdfModel extends GaletteTestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -60,8 +57,6 @@ class PdfModel extends GaletteTestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -91,8 +86,6 @@ class PdfModel extends GaletteTestCase
 
     /**
      * Test expected patterns
-     *
-     * @return void
      */
     public function testExpectedPatterns(): void
     {
@@ -189,8 +182,6 @@ class PdfModel extends GaletteTestCase
 
     /**
      * Types provider
-     *
-     * @return array
      */
     public static function typesProvider(): array
     {
@@ -220,8 +211,6 @@ class PdfModel extends GaletteTestCase
      *
      * @param int    $type     Requested type
      * @param string $expected Expected class name
-     *
-     * @return void
      */
     public function testGetypeClass(int $type, string $expected): void
     {
@@ -232,8 +221,6 @@ class PdfModel extends GaletteTestCase
      * Create dynamic field
      *
      * @param array $field_data Field data
-     *
-     * @return DynamicField
      */
     private function createDynamicField(array $field_data): DynamicField
     {
@@ -257,8 +244,6 @@ class PdfModel extends GaletteTestCase
 
     /**
      * Test model replacements
-     *
-     * @return void
      */
     public function testReplacements(): void
     {
@@ -321,11 +306,11 @@ class PdfModel extends GaletteTestCase
             'model_subtitle' => 'The subtitle',
             'model_header' => null,
             'model_footer' => null,
-            'model_body' => 'name: {NAME_ADH} login: {LOGIN_ADH} birthdate: {ADH_BIRTH_DATE} dynlabel: {LABEL_DYNFIELD_' .
-            $adf->getId() . '_ADH} dynvalue: {INPUT_DYNFIELD_' . $adf->getId() . '_ADH} ' .
-            '- enddate: {CONTRIB_END_DATE} amount: {CONTRIB_AMOUNT} ({CONTRIB_AMOUNT_LETTERS}) dynlabel: ' .
-            '{LABEL_DYNFIELD_' . $cdf->getId() . '_CONTRIB} dynvalue: {INPUT_DYNFIELD_' . $cdf->getId() . '_CONTRIB}' .
-            ' pref dynlabel: {LABEL_DYNFIELD_' . $pdf->getId() . '_PREFS} pref dynvalue: {DYNFIELD_' . $pdf->getId() . '_PREFS}',
+            'model_body' => 'name: {NAME_ADH} login: {LOGIN_ADH} birthdate: {ADH_BIRTH_DATE} dynlabel: {LABEL_DYNFIELD_'
+            . $adf->getId() . '_ADH} dynvalue: {INPUT_DYNFIELD_' . $adf->getId() . '_ADH} '
+            . '- enddate: {CONTRIB_END_DATE} amount: {CONTRIB_AMOUNT} ({CONTRIB_AMOUNT_LETTERS}) dynlabel: '
+            . '{LABEL_DYNFIELD_' . $cdf->getId() . '_CONTRIB} dynvalue: {INPUT_DYNFIELD_' . $cdf->getId() . '_CONTRIB}'
+            . ' pref dynlabel: {LABEL_DYNFIELD_' . $pdf->getId() . '_PREFS} pref dynvalue: {DYNFIELD_' . $pdf->getId() . '_PREFS}',
             'model_styles' => null,
             'model_parent' => \Galette\Entity\PdfModel::MAIN_MODEL
         ], \ArrayObject::ARRAY_AS_PROPS);
@@ -361,10 +346,10 @@ class PdfModel extends GaletteTestCase
         );
 
         $this->assertSame(
-            'name: DURAND René login: arthur.hamon' .  $this->seed . ' birthdate: ' . $data['ddn_adh'] . ' dynlabel: Dynamic text field dynvalue: ' .
-            'My value (: ' .
-            '- enddate: ' . $this->contrib->end_date . ' amount: 92 (ninety-two) dynlabel: Dynamic date field ' .
-            'dynvalue: 2020-12-03 pref dynlabel: Settings line field pref dynvalue: A dynamic value in settings \o/',
+            'name: DURAND René login: arthur.hamon' . $this->seed . ' birthdate: ' . $data['ddn_adh'] . ' dynlabel: Dynamic text field dynvalue: '
+            . 'My value (: '
+            . '- enddate: ' . $this->contrib->end_date . ' amount: 92 (ninety-two) dynlabel: Dynamic date field '
+            . 'dynvalue: 2020-12-03 pref dynlabel: Settings line field pref dynvalue: A dynamic value in settings \o/',
             $model->hbody
         );
 
@@ -385,8 +370,6 @@ class PdfModel extends GaletteTestCase
      * Create test contribution in database
      *
      * @param DynamicField $cdf Contribution dynamic field
-     *
-     * @return void
      */
     protected function createPdfContribution(DynamicField $cdf): void
     {
@@ -417,8 +400,6 @@ class PdfModel extends GaletteTestCase
 
     /**
      * Test model storage in db
-     *
-     * @return void
      */
     public function testStorage(): void
     {

--- a/tests/Galette/Entity/SavedSearch.php
+++ b/tests/Galette/Entity/SavedSearch.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace GaletteTests\Entity;
 
 use PHPUnit\Framework\TestCase;
-use Laminas\Db\Adapter\Adapter;
 
 /**
  * Saved search tests
@@ -39,8 +38,6 @@ class SavedSearch extends TestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -58,8 +55,6 @@ class SavedSearch extends TestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -71,8 +66,6 @@ class SavedSearch extends TestCase
 
     /**
      * Delete status
-     *
-     * @return void
      */
     private function deleteCreated(): void
     {
@@ -84,8 +77,6 @@ class SavedSearch extends TestCase
 
     /**
      * Test saved search
-     *
-     * @return void
      */
     public function testSave(): void
     {

--- a/tests/Galette/Entity/ScheduledPayment.php
+++ b/tests/Galette/Entity/ScheduledPayment.php
@@ -36,8 +36,6 @@ class ScheduledPayment extends GaletteTestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -47,8 +45,6 @@ class ScheduledPayment extends GaletteTestCase
 
     /**
      * Delete scheduled payments
-     *
-     * @return void
      */
     private function deleteScheduledPayments(): void
     {
@@ -67,8 +63,6 @@ class ScheduledPayment extends GaletteTestCase
 
     /**
      * Test add
-     *
-     * @return void
      */
     public function testAdd(): void
     {
@@ -114,8 +108,6 @@ class ScheduledPayment extends GaletteTestCase
 
     /**
      * Test update
-     *
-     * @return void
      */
     public function testUpdate(): void
     {
@@ -173,8 +165,6 @@ class ScheduledPayment extends GaletteTestCase
 
     /**
      * Test update
-     *
-     * @return void
      */
     public function testCheck(): void
     {
@@ -295,8 +285,6 @@ class ScheduledPayment extends GaletteTestCase
 
     /**
      * Test delete
-     *
-     * @return void
      */
     public function testDelete(): void
     {
@@ -334,8 +322,6 @@ class ScheduledPayment extends GaletteTestCase
 
     /**
      * Test restrictions on contributions with a scheduled payment
-     *
-     * @return void
      */
     public function testContributionRestriction(): void
     {
@@ -382,8 +368,6 @@ class ScheduledPayment extends GaletteTestCase
 
     /**
      * Test getNotFullyAllocated
-     *
-     * @return void
      */
     public function testGetNotFullyAllocated(): void
     {
@@ -466,8 +450,6 @@ class ScheduledPayment extends GaletteTestCase
 
     /**
      * Test getAllocation
-     *
-     * @return void
      */
     public function testGetAllocation(): void
     {
@@ -511,8 +493,6 @@ class ScheduledPayment extends GaletteTestCase
 
     /**
      * Test isFullyAllocated
-     *
-     * @return void
      */
     public function testIsFullyAllocated(): void
     {
@@ -578,8 +558,6 @@ class ScheduledPayment extends GaletteTestCase
 
     /**
      * Test isDue
-     *
-     * @return void
      */
     public function testIsDue(): void
     {

--- a/tests/Galette/Entity/Social.php
+++ b/tests/Galette/Entity/Social.php
@@ -36,8 +36,6 @@ class Social extends GaletteTestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -56,8 +54,6 @@ class Social extends GaletteTestCase
 
     /**
      * Delete socials
-     *
-     * @return void
      */
     private function deleteSocials(): void
     {
@@ -67,8 +63,6 @@ class Social extends GaletteTestCase
 
     /**
      * Test social object
-     *
-     * @return void
      */
     public function testObject(): void
     {
@@ -95,8 +89,6 @@ class Social extends GaletteTestCase
 
     /**
      * Test socials "system" types
-     *
-     * @return void
      */
     public function testGetSystemTypes(): void
     {
@@ -111,8 +103,6 @@ class Social extends GaletteTestCase
 
     /**
      * Test getListForMember
-     *
-     * @return void
      */
     public function testGetListForMember(): void
     {

--- a/tests/Galette/Entity/Status.php
+++ b/tests/Galette/Entity/Status.php
@@ -37,8 +37,6 @@ class Status extends GaletteTestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -48,8 +46,6 @@ class Status extends GaletteTestCase
 
     /**
      * Delete status
-     *
-     * @return void
      */
     private function deleteStatus(): void
     {
@@ -68,8 +64,6 @@ class Status extends GaletteTestCase
 
     /**
      * Test status
-     *
-     * @return void
      */
     public function testStatus(): void
     {
@@ -158,8 +152,6 @@ class Status extends GaletteTestCase
 
     /**
      * Test getList
-     *
-     * @return void
      */
     public function testGetList(): void
     {

--- a/tests/Galette/Entity/Texts.php
+++ b/tests/Galette/Entity/Texts.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace GaletteTests\Entity;
 
-use PHPUnit\Framework\TestCase;
 use Galette\GaletteTestCase;
 use Laminas\Db\Adapter\Adapter;
 
@@ -36,8 +35,6 @@ class Texts extends GaletteTestCase
 {
     /**
      * Test getList
-     *
-     * @return void
      */
     public function testGetList(): void
     {

--- a/tests/Galette/Entity/Title.php
+++ b/tests/Galette/Entity/Title.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace GaletteTests\Entity;
 
 use PHPUnit\Framework\TestCase;
-use Laminas\Db\Adapter\Adapter;
 
 /**
  * Status tests
@@ -38,8 +37,6 @@ class Title extends TestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -48,8 +45,6 @@ class Title extends TestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -61,8 +56,6 @@ class Title extends TestCase
 
     /**
      * Delete status
-     *
-     * @return void
      */
     private function deleteTitle(): void
     {
@@ -81,8 +74,6 @@ class Title extends TestCase
 
     /**
      * Test title
-     *
-     * @return void
      */
     public function testTitle(): void
     {

--- a/tests/Galette/Entity/Transaction.php
+++ b/tests/Galette/Entity/Transaction.php
@@ -37,8 +37,6 @@ class Transaction extends GaletteTestCase
 
     /**
      * Cleanup after each test method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -84,8 +82,6 @@ class Transaction extends GaletteTestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -104,8 +100,6 @@ class Transaction extends GaletteTestCase
 
     /**
      * Create test transaction in database
-     *
-     * @return \Galette\Entity\Transaction
      */
     private function createTransaction(): \Galette\Entity\Transaction
     {
@@ -133,8 +127,6 @@ class Transaction extends GaletteTestCase
 
     /**
      * Test empty transaction
-     *
-     * @return void
      */
     public function testEmpty(): void
     {
@@ -163,8 +155,6 @@ class Transaction extends GaletteTestCase
 
     /**
      * Test getter and setter special cases
-     *
-     * @return void
      */
     public function testGetterSetter(): void
     {
@@ -206,8 +196,6 @@ class Transaction extends GaletteTestCase
 
     /**
      * Test transaction creation
-     *
-     * @return void
      */
     public function testCreation(): void
     {
@@ -220,8 +208,6 @@ class Transaction extends GaletteTestCase
 
     /**
      * Test transaction update
-     *
-     * @return void
      */
     public function testUpdate(): void
     {
@@ -248,8 +234,6 @@ class Transaction extends GaletteTestCase
 
     /**
      * Test fields labels
-     *
-     * @return void
      */
     public function testGetFieldLabel(): void
     {
@@ -276,8 +260,6 @@ class Transaction extends GaletteTestCase
 
     /**
      * Test transaction loading
-     *
-     * @return void
      */
     public function testLoad(): void
     {
@@ -310,8 +292,6 @@ class Transaction extends GaletteTestCase
 
     /**
      * Test transaction removal
-     *
-     * @return void
      */
     public function testRemove(): void
     {
@@ -337,8 +317,6 @@ class Transaction extends GaletteTestCase
 
     /**
      * Test can* methods
-     *
-     * @return void
      */
     public function testCan(): void
     {
@@ -503,8 +481,6 @@ class Transaction extends GaletteTestCase
 
     /**
      * Test a transaction
-     *
-     * @return void
      */
     public function testTransaction(): void
     {

--- a/tests/Galette/Features/HasEvent.php
+++ b/tests/Galette/Features/HasEvent.php
@@ -36,8 +36,6 @@ class HasEvent extends GaletteTestCase
 
     /**
      * Test HasEvent capacities
-     *
-     * @return void
      */
     public function testCapacities(): void
     {

--- a/tests/Galette/Filters/ContributionsList.php
+++ b/tests/Galette/Filters/ContributionsList.php
@@ -36,8 +36,6 @@ class ContributionsList extends GaletteTestCase
      * Test filter defaults values
      *
      * @param \Galette\Filters\ContributionsList $filters Filters instance
-     *
-     * @return void
      */
     protected function testDefaults(\Galette\Filters\ContributionsList $filters): void
     {
@@ -57,8 +55,6 @@ class ContributionsList extends GaletteTestCase
 
     /**
      * Test creation
-     *
-     * @return void
      */
     public function testCreate(): void
     {
@@ -138,8 +134,6 @@ class ContributionsList extends GaletteTestCase
 
     /**
      * Test localized date in filter
-     *
-     * @return void
      */
     public function testLocalizedDates(): void
     {

--- a/tests/Galette/Filters/HistoryList.php
+++ b/tests/Galette/Filters/HistoryList.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace GaletteTests\Filters;
 
-use Galette\Enums\SQLOrder;
 use Galette\GaletteTestCase;
 
 /**
@@ -37,8 +36,6 @@ class HistoryList extends GaletteTestCase
      * Test filter defaults values
      *
      * @param \Galette\Filters\HistoryList $filters Filters instance
-     *
-     * @return void
      */
     protected function testDefaults(\Galette\Filters\HistoryList $filters): void
     {
@@ -52,8 +49,6 @@ class HistoryList extends GaletteTestCase
 
     /**
      * Test creation
-     *
-     * @return void
      */
     public function testCreate(): void
     {
@@ -112,8 +107,6 @@ class HistoryList extends GaletteTestCase
 
     /**
      * Test localized date in filter
-     *
-     * @return void
      */
     public function testLocalizedDates(): void
     {

--- a/tests/Galette/Filters/TransactionsList.php
+++ b/tests/Galette/Filters/TransactionsList.php
@@ -36,8 +36,6 @@ class TransactionsList extends GaletteTestCase
      * Test filter defaults values
      *
      * @param \Galette\Filters\TransactionsList $filters Filters instance
-     *
-     * @return void
      */
     protected function testDefaults(\Galette\Filters\TransactionsList $filters): void
     {
@@ -51,8 +49,6 @@ class TransactionsList extends GaletteTestCase
 
     /**
      * Test creation
-     *
-     * @return void
      */
     public function testCreate(): void
     {
@@ -111,8 +107,6 @@ class TransactionsList extends GaletteTestCase
 
     /**
      * Test localized date in filter
-     *
-     * @return void
      */
     public function testLocalizedDates(): void
     {

--- a/tests/Galette/IO/CsvIn.php
+++ b/tests/Galette/IO/CsvIn.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace GaletteTests\IO;
 
 use Galette\Entity\FieldsConfig;
-use PHPUnit\Framework\TestCase;
 use Galette\Entity\Adherent;
 use Galette\DynamicFields\DynamicField;
 use Galette\GaletteTestCase;
@@ -40,8 +39,6 @@ class CsvIn extends GaletteTestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -51,8 +48,6 @@ class CsvIn extends GaletteTestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -94,8 +89,6 @@ class CsvIn extends GaletteTestCase
      * @param ?int   $count_before   Count before insertions. Defaults to 0 if null.
      * @param ?int   $count_after    Count after insertions. Default to $count_before + count $members_list
      * @param array  $values         Textual values for dynamic choices fields
-     *
-     * @return void
      */
     private function doImportFileTest(
         array $fields,
@@ -240,8 +233,6 @@ class CsvIn extends GaletteTestCase
 
     /**
      * Test CSV import loading
-     *
-     * @return void
      */
     public function testImport(): void
     {
@@ -494,8 +485,6 @@ class CsvIn extends GaletteTestCase
      * Get CSV import model
      *
      * @param array $fields Fields list
-     *
-     * @return \Galette\Entity\ImportModel
      */
     protected function getModel(array $fields): \Galette\Entity\ImportModel
     {
@@ -513,8 +502,6 @@ class CsvIn extends GaletteTestCase
      *
      * @param string $text_orig Original text
      * @param string $lang      Lang text has been added in
-     *
-     * @return void
      */
     protected function checkDynamicTranslation(string $text_orig, string $lang = 'fr_FR.utf8'): void
     {
@@ -541,8 +528,6 @@ class CsvIn extends GaletteTestCase
 
     /**
      * Test import with dynamic fields
-     *
-     * @return void
      */
     public function testImportDynamics(): void
     {
@@ -630,8 +615,8 @@ class CsvIn extends GaletteTestCase
         $i = 0;
         foreach ($members_list as &$data) {
             //two lines without required dynamic field.
-            $data['dynfield_' . $df->getId()] = (($i == 2 || $i == 5) ? '' :
-                'Dynamic field value for ' . $data['fingerprint']);
+            $data['dynfield_' . $df->getId()] = (($i == 2 || $i == 5) ? ''
+                : 'Dynamic field value for ' . $data['fingerprint']);
             ++$i;
         }
         unset($data);
@@ -804,8 +789,6 @@ class CsvIn extends GaletteTestCase
 
     /**
      * Test non existing file
-     *
-     * @return void
      */
     public function testNoFile(): void
     {
@@ -834,8 +817,6 @@ class CsvIn extends GaletteTestCase
 
     /**
      * Test empty file
-     *
-     * @return void
      */
     public function testEmptyFile(): void
     {
@@ -858,8 +839,6 @@ class CsvIn extends GaletteTestCase
 
     /**
      * Test missing columns
-     *
-     * @return void
      */
     public function testMissingColumn(): void
     {
@@ -964,8 +943,6 @@ class CsvIn extends GaletteTestCase
 
     /**
      * Get first set of member data
-     *
-     * @return array
      */
     private function getMemberData1(): array
     {
@@ -1250,8 +1227,6 @@ class CsvIn extends GaletteTestCase
     /**
      * Get second set of member data
      * two lines without name.
-     *
-     * @return array
      */
     private function getMemberData2(): array
     {
@@ -1533,8 +1508,6 @@ class CsvIn extends GaletteTestCase
 
     /**
      * Get second set of member data but two lines without name.
-     *
-     * @return array
      */
     private function getMemberData2NoName(): array
     {

--- a/tests/Galette/IO/News.php
+++ b/tests/Galette/IO/News.php
@@ -37,8 +37,6 @@ class News extends TestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -50,8 +48,6 @@ class News extends TestCase
 
     /**
      * Test news loading
-     *
-     * @return void
      */
     public function testLoadNews(): void
     {
@@ -65,8 +61,6 @@ class News extends TestCase
 
     /**
      * Test news loading
-     *
-     * @return void
      */
     public function testLoadRSSNews(): void
     {
@@ -89,8 +83,6 @@ class News extends TestCase
 
     /**
      * Test news caching
-     *
-     * @return void
      */
     public function testCacheNews(): void
     {
@@ -142,8 +134,6 @@ class News extends TestCase
 
     /**
      * Test news loading with allow_url_fopen off
-     *
-     * @return void
      */
     public function testLoadNewsWExeption(): void
     {

--- a/tests/Galette/IO/News/units/Entry.php
+++ b/tests/Galette/IO/News/units/Entry.php
@@ -34,8 +34,6 @@ class Entry extends TestCase
 {
     /**
      * Test entry
-     *
-     * @return void
      */
     public function testEntry(): void
     {

--- a/tests/Galette/IO/News/units/Post.php
+++ b/tests/Galette/IO/News/units/Post.php
@@ -34,8 +34,6 @@ class Post extends TestCase
 {
     /**
      * Test post
-     *
-     * @return void
      */
     public function testPost(): void
     {

--- a/tests/Galette/Repository/Contributions.php
+++ b/tests/Galette/Repository/Contributions.php
@@ -36,8 +36,6 @@ class Contributions extends GaletteTestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -65,8 +63,6 @@ class Contributions extends GaletteTestCase
 
     /**
      * Test getList
-     *
-     * @return void
      */
     public function testGetList(): void
     {
@@ -242,8 +238,6 @@ class Contributions extends GaletteTestCase
 
     /**
      * Test getArrayList
-     *
-     * @return void
      */
     public function testGetArrayList(): void
     {
@@ -271,8 +265,6 @@ class Contributions extends GaletteTestCase
 
     /**
      * Test remove
-     *
-     * @return void
      */
     public function testRemove(): void
     {
@@ -294,7 +286,6 @@ class Contributions extends GaletteTestCase
     /**
      * Test order by
      *
-     * @return void
      * @throws \Throwable
      */
     public function testOrderBy(): void

--- a/tests/Galette/Repository/Groups.php
+++ b/tests/Galette/Repository/Groups.php
@@ -39,8 +39,6 @@ class Groups extends GaletteTestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -49,8 +47,6 @@ class Groups extends GaletteTestCase
 
     /**
      * Delete groups
-     *
-     * @return void
      */
     private function deleteGroups(): void
     {
@@ -140,8 +136,6 @@ class Groups extends GaletteTestCase
      * @param array  $children    Children
      *
      * @dataProvider groupsProvider
-     *
-     * @return void
      */
     public function testCreateGroups(string $parent_name, array $children): void
     {
@@ -171,8 +165,6 @@ class Groups extends GaletteTestCase
 
     /**
      * Test getSimpleList
-     *
-     * @return void
      */
     public function testGetSimpleList(): void
     {
@@ -197,8 +189,6 @@ class Groups extends GaletteTestCase
 
     /**
      * Test getSimpleList
-     *
-     * @return void
      */
     public function testGetList(): void
     {
@@ -239,8 +229,6 @@ class Groups extends GaletteTestCase
 
     /**
      * Test group name uniqueness
-     *
-     * @return void
      */
     public function testUniqueness(): void
     {
@@ -280,8 +268,6 @@ class Groups extends GaletteTestCase
 
     /**
      * Test members/groups
-     *
-     * @return void
      */
     public function testMembersGroups(): void
     {

--- a/tests/Galette/Repository/Members.php
+++ b/tests/Galette/Repository/Members.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace GaletteTests\Repository;
 
 use Galette\GaletteTestCase;
-use Slim\Psr7\UploadedFile;
 
 /**
  * Members repository tests
@@ -40,8 +39,6 @@ class Members extends GaletteTestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -52,8 +49,6 @@ class Members extends GaletteTestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -84,8 +79,6 @@ class Members extends GaletteTestCase
 
     /**
      * Create members and store their id
-     *
-     * @return void
      */
     private function createMembers(): void
     {
@@ -180,8 +173,6 @@ class Members extends GaletteTestCase
 
     /**
      * Delete member
-     *
-     * @return void
      */
     private function deleteMembers(): void
     {
@@ -210,8 +201,6 @@ class Members extends GaletteTestCase
 
     /**
      * Delete groups
-     *
-     * @return void
      */
     private function deleteGroups(): void
     {
@@ -229,8 +218,6 @@ class Members extends GaletteTestCase
 
     /**
      * Test getList
-     *
-     * @return void
      */
     public function testGetList(): void
     {
@@ -653,8 +640,6 @@ class Members extends GaletteTestCase
 
     /**
      * Test getList with contribution dynamic fields
-     *
-     * @return void
      */
     public function testGetListContributionDynamics(): void
     {
@@ -830,8 +815,6 @@ class Members extends GaletteTestCase
 
     /**
      * Test getPublicList
-     *
-     * @return void
      */
     public function testGetPublicList(): void
     {
@@ -871,8 +854,6 @@ class Members extends GaletteTestCase
 
     /**
      * Test search on groups
-     *
-     * @return void
      */
     public function testGroupsSearch(): void
     {
@@ -1013,8 +994,6 @@ class Members extends GaletteTestCase
 
     /**
      * Test reminders count
-     *
-     * @return void
      */
     public function testGetRemindersCount(): void
     {
@@ -1196,8 +1175,6 @@ class Members extends GaletteTestCase
 
     /**
      * Test dropdown members
-     *
-     * @return void
      */
     public function testGetDropdownMembers(): void
     {
@@ -1211,8 +1188,6 @@ class Members extends GaletteTestCase
 
     /**
      * Test getArrayList
-     *
-     * @return void
      */
     public function testGetArrayList(): void
     {
@@ -1232,8 +1207,6 @@ class Members extends GaletteTestCase
 
     /**
      * Test getMembersList
-     *
-     * @return void
      */
     public function testRemoveMembers(): void
     {

--- a/tests/Galette/Repository/PaymentTypes.php
+++ b/tests/Galette/Repository/PaymentTypes.php
@@ -36,8 +36,6 @@ class PaymentTypes extends GaletteTestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -50,8 +48,6 @@ class PaymentTypes extends GaletteTestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -61,8 +57,6 @@ class PaymentTypes extends GaletteTestCase
 
     /**
      * Delete payment type
-     *
-     * @return void
      */
     private function deletePaymentType(): void
     {
@@ -81,8 +75,6 @@ class PaymentTypes extends GaletteTestCase
 
     /**
      * Test getList
-     *
-     * @return void
      */
     public function testGetList(): void
     {

--- a/tests/Galette/Repository/PdfModels.php
+++ b/tests/Galette/Repository/PdfModels.php
@@ -36,8 +36,6 @@ class PdfModels extends GaletteTestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -50,8 +48,6 @@ class PdfModels extends GaletteTestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -61,8 +57,6 @@ class PdfModels extends GaletteTestCase
 
     /**
      * Delete pdf models
-     *
-     * @return void
      */
     private function deletePdfModels(): void
     {
@@ -81,8 +75,6 @@ class PdfModels extends GaletteTestCase
 
     /**
      * Test getList
-     *
-     * @return void
      */
     public function testGetList(): void
     {

--- a/tests/Galette/Repository/Reminders.php
+++ b/tests/Galette/Repository/Reminders.php
@@ -36,8 +36,6 @@ class Reminders extends GaletteTestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -55,8 +53,6 @@ class Reminders extends GaletteTestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -70,8 +66,6 @@ class Reminders extends GaletteTestCase
 
     /**
      * Test getList
-     *
-     * @return void
      */
     public function testGetList(): void
     {
@@ -434,8 +428,6 @@ class Reminders extends GaletteTestCase
 
     /**
      * Test getList with reminders from previous period already present
-     *
-     * @return void
      */
     public function testGetListNextYear(): void
     {

--- a/tests/Galette/Repository/SavedSearches.php
+++ b/tests/Galette/Repository/SavedSearches.php
@@ -36,8 +36,6 @@ class SavedSearches extends GaletteTestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -51,7 +49,6 @@ class SavedSearches extends GaletteTestCase
     /**
      * Test getList
      *
-     * @return void
      * @throws \Throwable
      */
     public function testGetList(): void

--- a/tests/Galette/Repository/ScheduledPayments.php
+++ b/tests/Galette/Repository/ScheduledPayments.php
@@ -36,8 +36,6 @@ class ScheduledPayments extends GaletteTestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -47,8 +45,6 @@ class ScheduledPayments extends GaletteTestCase
 
     /**
      * Delete scheduled payments
-     *
-     * @return void
      */
     private function deleteScheduledPayments(): void
     {
@@ -67,8 +63,6 @@ class ScheduledPayments extends GaletteTestCase
 
     /**
      * Test getList
-     *
-     * @return void
      */
     public function testGetList(): void
     {
@@ -172,8 +166,6 @@ class ScheduledPayments extends GaletteTestCase
 
     /**
      * Test getArrayList
-     *
-     * @return void
      */
     public function testGetArrayList(): void
     {
@@ -242,8 +234,6 @@ class ScheduledPayments extends GaletteTestCase
 
     /**
      * Test remove
-     *
-     * @return void
      */
     public function testRemove(): void
     {

--- a/tests/Galette/Repository/Titles.php
+++ b/tests/Galette/Repository/Titles.php
@@ -38,8 +38,6 @@ class Titles extends GaletteTestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -52,8 +50,6 @@ class Titles extends GaletteTestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -63,8 +59,6 @@ class Titles extends GaletteTestCase
 
     /**
      * Delete payment type
-     *
-     * @return void
      */
     private function deleteTitles(): void
     {
@@ -83,8 +77,6 @@ class Titles extends GaletteTestCase
 
     /**
      * Test getList
-     *
-     * @return void
      */
     public function testGetList(): void
     {

--- a/tests/Galette/Repository/Transactions.php
+++ b/tests/Galette/Repository/Transactions.php
@@ -37,8 +37,6 @@ class Transactions extends GaletteTestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -66,8 +64,6 @@ class Transactions extends GaletteTestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -86,8 +82,6 @@ class Transactions extends GaletteTestCase
 
     /**
      * Create test transactions in database
-     *
-     * @return void
      */
     private function createTransaction(): void
     {
@@ -112,8 +106,6 @@ class Transactions extends GaletteTestCase
 
     /**
      * Test getList
-     *
-     * @return void
      */
     public function testGetList(): void
     {
@@ -220,8 +212,6 @@ class Transactions extends GaletteTestCase
 
     /**
      * Test remove
-     *
-     * @return void
      */
     public function testRemove(): void
     {

--- a/tests/Galette/Util/Password.php
+++ b/tests/Galette/Util/Password.php
@@ -39,8 +39,6 @@ class Password extends TestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDow(): void
     {
@@ -55,8 +53,6 @@ class Password extends TestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -66,8 +62,6 @@ class Password extends TestCase
 
     /**
      * Passwords data provider
-     *
-     * @return array
      */
     public static function passProvider(): array
     {
@@ -110,8 +104,6 @@ class Password extends TestCase
      * @param int    $level  Password level
      * @param string $pass   Password
      * @param array  $errors Errors
-     *
-     * @return void
      */
     #[DataProvider('passProvider')]
     public function testValidatePassword(int $level, string $pass, array $errors): void
@@ -153,8 +145,6 @@ class Password extends TestCase
 
     /**
      * Blacklist password provider
-     *
-     * @return array
      */
     public static function blacklistProvider(): array
     {
@@ -173,8 +163,6 @@ class Password extends TestCase
      *
      * @param string $pass     Password to test
      * @param bool   $expected Excpected return
-     *
-     * @return void
      */
     #[DataProvider('blacklistProvider')]
     public function testBlacklist(string $pass, bool $expected): void
@@ -190,8 +178,6 @@ class Password extends TestCase
 
     /**
      * Test with personal information
-     *
-     * @return void
      */
     public function testPersonalInformation(): void
     {

--- a/tests/Galette/Util/Release.php
+++ b/tests/Galette/Util/Release.php
@@ -56,7 +56,6 @@ class Release extends TestCase
      * @param bool   $expected Expected result
      *
      * @dataProvider releasesProvider
-     * @return void
      */
     public function testNewRelease(string $current, string $latest, bool $expected): void
     {
@@ -230,7 +229,6 @@ div.foot { font: 90% monospace; color: #787878; padding-top: 4px;}
      * @param string $page     Page content
      *
      * @dataProvider releasesPageProvider
-     * @return void
      */
     public function testFindLatestRelease(string $current, string $latest, bool $expected, string $page): void
     {

--- a/tests/Galette/Util/Telemetry.php
+++ b/tests/Galette/Util/Telemetry.php
@@ -38,8 +38,6 @@ class Telemetry extends TestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -54,8 +52,6 @@ class Telemetry extends TestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -67,8 +63,6 @@ class Telemetry extends TestCase
 
     /**
      * Test Galette infos
-     *
-     * @return void
      */
     public function testGrabGaletteInfos(): void
     {
@@ -136,8 +130,6 @@ class Telemetry extends TestCase
 
     /**
      * Test DB infos
-     *
-     * @return void
      */
     public function testGrabDbInfos(): void
     {
@@ -160,8 +152,6 @@ class Telemetry extends TestCase
 
     /**
      * Test web server infos
-     *
-     * @return void
      */
     public function testGrabWebserverInfos(): void
     {
@@ -180,8 +170,6 @@ class Telemetry extends TestCase
 
     /**
      * Test PHP infos
-     *
-     * @return void
      */
     public function testGrabPhpInfos(): void
     {
@@ -209,8 +197,6 @@ class Telemetry extends TestCase
 
     /**
      * Test OS infos
-     *
-     * @return void
      */
     public function testGrabOsInfos(): void
     {
@@ -239,8 +225,6 @@ class Telemetry extends TestCase
 
     /**
      * Test whole Telemetry infos
-     *
-     * @return void
      */
     public function testGetTelemetryInfos(): void
     {

--- a/tests/Galette/Util/Text.php
+++ b/tests/Galette/Util/Text.php
@@ -59,8 +59,6 @@ class Text extends TestCase
      *
      * @param string $string   String to slugify
      * @param string $expected Expected result
-     *
-     * @return void
      */
     #[DataProvider('slugifyProvider')]
     public function testSlugify(string $string, string $expected): void
@@ -70,8 +68,6 @@ class Text extends TestCase
 
     /**
      * Test failing slugify
-     *
-     * @return void
      */
     public function testFailSlugify(): void
     {
@@ -81,8 +77,6 @@ class Text extends TestCase
 
     /**
      * Test getRandomString method
-     *
-     * @return void
      */
     public function testGetRandomString(): void
     {
@@ -92,8 +86,6 @@ class Text extends TestCase
 
     /**
      * Test truncateOnWords method
-     *
-     * @return void
      */
     public function testTruncateOnWords(): void
     {
@@ -188,8 +180,6 @@ class Text extends TestCase
      *
      * @param string $input    Input text
      * @param string $expected Expected result
-     *
-     * @return void
      */
     #[DataProvider('textConversionProvider')]
     public function testTextConversion(string $input, string $expected): void

--- a/tests/GaletteDbFails/Core/Install.php
+++ b/tests/GaletteDbFails/Core/Install.php
@@ -40,8 +40,6 @@ class Install extends TestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -67,8 +65,6 @@ class Install extends TestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -79,8 +75,6 @@ class Install extends TestCase
 
     /**
      * Test if current database version is supported
-     *
-     * @return void
      */
     public function testDbSupport(): void
     {
@@ -89,8 +83,6 @@ class Install extends TestCase
 
     /**
      * Test if current database version is supported
-     *
-     * @return void
      */
     public function testGetUnsupportedMessage(): void
     {

--- a/tests/GaletteRoutingTestCase.php
+++ b/tests/GaletteRoutingTestCase.php
@@ -40,8 +40,6 @@ abstract class GaletteRoutingTestCase extends GaletteTestCase
      * @param string                $method       HTTP method to use
      * @param string                $content_type Content type to use
      * @param array<string, string> $query_params Query parameters to add to URL
-     *
-     * @return \Slim\Psr7\Request
      */
     protected function createRequest(
         string $route_name,
@@ -73,8 +71,6 @@ abstract class GaletteRoutingTestCase extends GaletteTestCase
      * Assert request has been refused from authentication middleware
      *
      * @param Response $test_response Response to test
-     *
-     * @return void
      */
     protected function expectAuthMiddlewareRefused(Response $test_response): void
     {
@@ -96,8 +92,6 @@ abstract class GaletteRoutingTestCase extends GaletteTestCase
      * Assert request requires a logged in user
      *
      * @param Response $test_response Response to test
-     *
-     * @return void
      */
     protected function expectLogin(Response $test_response): void
     {
@@ -115,8 +109,6 @@ abstract class GaletteRoutingTestCase extends GaletteTestCase
      *
      * @param Response $test_response Response to test
      * @param array    $headers       Expected headers
-     *
-     * @return void
      */
     protected function expectOK(Response $test_response, array $headers =  []): void
     {
@@ -130,8 +122,6 @@ abstract class GaletteRoutingTestCase extends GaletteTestCase
      * Assert Flash data correspond to what is expected, and reset it
      *
      * @param array $expected Expected flash data
-     *
-     * @return void
      */
     protected function expectFlashData(array $expected): void
     {

--- a/tests/GaletteTestCase.php
+++ b/tests/GaletteTestCase.php
@@ -59,8 +59,8 @@ abstract class GaletteTestCase extends TestCase
     protected bool $load_plugins = false;
 
     /**
-     * @see see \Analog\Handler\Level::$log_levels
      * @var string[]
+     * @see see \Analog\Handler\Level::$log_levels
      */
     private array $log_levels_names = [
         \Analog\Analog::DEBUG    => 'DEBUG',
@@ -75,8 +75,6 @@ abstract class GaletteTestCase extends TestCase
 
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -150,8 +148,6 @@ abstract class GaletteTestCase extends TestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -209,8 +205,6 @@ abstract class GaletteTestCase extends TestCase
      * Loads member from a resultset
      *
      * @param int $id Id
-     *
-     * @return void
      */
     protected function loadAdherent(int $id): void
     {
@@ -224,8 +218,6 @@ abstract class GaletteTestCase extends TestCase
 
     /**
      * Get Faker data for one member
-     *
-     * @return array
      */
     protected function dataAdherentOne(): array
     {
@@ -243,8 +235,8 @@ abstract class GaletteTestCase extends TestCase
             'ville_adh' => 'Martel',
             'cp_adh' => '39 069',
             'adresse_adh' => '66, boulevard De Oliveira',
-            'email_adh' => 'meunier.josephine' .  $this->seed . '@ledoux.com',
-            'login_adh' => 'arthur.hamon' .  $this->seed,
+            'email_adh' => 'meunier.josephine' . $this->seed . '@ledoux.com',
+            'login_adh' => 'arthur.hamon' . $this->seed,
             'mdp_adh' => 'J^B-()f',
             'mdp_adh2' => 'J^B-()f',
             'bool_admin_adh' => false,
@@ -270,8 +262,6 @@ abstract class GaletteTestCase extends TestCase
 
     /**
      * Get Faker data for second member
-     *
-     * @return array
      */
     protected function dataAdherentTwo(): array
     {
@@ -290,8 +280,8 @@ abstract class GaletteTestCase extends TestCase
             'ville_adh' => 'Reynaudnec',
             'cp_adh' => '63077',
             'adresse_adh' => '2, boulevard Legros',
-            'email_adh' => 'phoarau' .  $this->seed . '@tele2.fr',
-            'login_adh' => 'nathalie51' .  $this->seed,
+            'email_adh' => 'phoarau' . $this->seed . '@tele2.fr',
+            'login_adh' => 'nathalie51' . $this->seed,
             'mdp_adh' => 'T.u!IbKOi|06',
             'mdp_adh2' => 'T.u!IbKOi|06',
             'bool_admin_adh' => false,
@@ -320,8 +310,6 @@ abstract class GaletteTestCase extends TestCase
      * Create member from data
      *
      * @param array $data Data to use to create member
-     *
-     * @return \Galette\Entity\Adherent
      */
     public function createMember(array $data): \Galette\Entity\Adherent
     {
@@ -358,8 +346,6 @@ abstract class GaletteTestCase extends TestCase
      *
      * @param ?\Galette\Entity\Adherent $adh           Member instance, if any
      * @param array<string, mixed>      $new_expecteds Changes on expected values
-     *
-     * @return void
      */
     protected function checkMemberOneExpected(?\Galette\Entity\Adherent $adh = null, array $new_expecteds = []): void
     {
@@ -445,8 +431,6 @@ abstract class GaletteTestCase extends TestCase
      *
      * @param ?\Galette\Entity\Adherent $adh           Member instance, if any
      * @param array<string, mixed>      $new_expecteds Changes on expected values
-     *
-     * @return void
      */
     protected function checkMemberTwoExpected(?\Galette\Entity\Adherent $adh = null, array $new_expecteds = []): void
     {
@@ -524,8 +508,6 @@ abstract class GaletteTestCase extends TestCase
 
     /**
      * Look in database if test member already exists
-     *
-     * @return false|\Laminas\Db\ResultSet\ResultSet
      */
     protected function adhOneExists(): false|\Laminas\Db\ResultSet\ResultSet
     {
@@ -548,8 +530,6 @@ abstract class GaletteTestCase extends TestCase
 
     /**
      * Look in database if test member already exists
-     *
-     * @return false|\Laminas\Db\ResultSet\ResultSet
      */
     protected function adhTwoExists(): false|\Laminas\Db\ResultSet\ResultSet
     {
@@ -572,8 +552,6 @@ abstract class GaletteTestCase extends TestCase
 
     /**
      * Get member one
-     *
-     * @return \Galette\Entity\Adherent
      */
     protected function getMemberOne(): \Galette\Entity\Adherent
     {
@@ -588,8 +566,6 @@ abstract class GaletteTestCase extends TestCase
 
     /**
      * Get member two
-     *
-     * @return \Galette\Entity\Adherent
      */
     protected function getMemberTwo(): \Galette\Entity\Adherent
     {
@@ -607,8 +583,6 @@ abstract class GaletteTestCase extends TestCase
      *
      * @param array<string,mixed>           $data    Data to use to create contribution
      * @param ?\Galette\Entity\Contribution $contrib Contribution instance, if any
-     *
-     * @return \Galette\Entity\Contribution
      */
     public function createContrib(array $data, ?\Galette\Entity\Contribution $contrib = null): \Galette\Entity\Contribution
     {
@@ -663,8 +637,6 @@ abstract class GaletteTestCase extends TestCase
 
     /**
      * Create test contribution in database
-     *
-     * @return void
      */
     protected function createContribution(): void
     {
@@ -677,8 +649,6 @@ abstract class GaletteTestCase extends TestCase
      *
      * @param ?\Galette\Entity\Contribution $contrib       Contribution instance, if any
      * @param array<string,mixed>           $new_expecteds Changes on expected values
-     *
-     * @return void
      */
     protected function checkContribExpected(?\Galette\Entity\Contribution $contrib = null, array $new_expecteds = []): void
     {
@@ -769,8 +739,6 @@ abstract class GaletteTestCase extends TestCase
 
     /**
      * Initialize default status in database
-     *
-     * @return void
      */
     protected function initStatus(): void
     {
@@ -784,8 +752,6 @@ abstract class GaletteTestCase extends TestCase
 
     /**
      * Initialize default contributions types in database
-     *
-     * @return void
      */
     protected function initContributionsTypes(): void
     {
@@ -799,8 +765,6 @@ abstract class GaletteTestCase extends TestCase
 
     /**
      * Initialize default payment types in database
-     *
-     * @return void
      */
     protected function initPaymentTypes(): void
     {
@@ -814,8 +778,6 @@ abstract class GaletteTestCase extends TestCase
 
     /**
      * Initialize default titles in database
-     *
-     * @return void
      */
     protected function initTitles(): void
     {
@@ -828,8 +790,6 @@ abstract class GaletteTestCase extends TestCase
 
     /**
      * Initialize default PDF models in database
-     *
-     * @return void
      */
     protected function initModels(): void
     {
@@ -840,8 +800,6 @@ abstract class GaletteTestCase extends TestCase
 
     /**
      * Clean history
-     *
-     * @return void
      */
     protected function cleanHistory(): void
     {
@@ -853,8 +811,6 @@ abstract class GaletteTestCase extends TestCase
 
     /**
      * Log-in as super administrator
-     *
-     * @return void
      */
     protected function logSuperAdmin(): void
     {
@@ -868,8 +824,6 @@ abstract class GaletteTestCase extends TestCase
      *
      * @param int    $level   Log lovel
      * @param string $message Log message
-     *
-     * @return void
      */
     protected function expectLogEntry(int $level, string $message): void
     {
@@ -894,8 +848,6 @@ abstract class GaletteTestCase extends TestCase
 
     /**
      * Check there is no log entry.
-     *
-     * @return void
      */
     protected function expectNoLogEntry(): void
     {
@@ -905,8 +857,6 @@ abstract class GaletteTestCase extends TestCase
 
     /**
      * Clean created contributions
-     *
-     * @return void
      */
     protected function cleanContributions(): void
     {
@@ -921,8 +871,6 @@ abstract class GaletteTestCase extends TestCase
 
     /**
      * Clean created members and groups
-     *
-     * @return void
      */
     protected function cleanMembers(): void
     {
@@ -948,8 +896,6 @@ abstract class GaletteTestCase extends TestCase
      * Set given member as staff
      *
      * @param \Galette\Entity\Adherent $member Member to edit
-     *
-     * @return \Galette\Entity\Adherent
      */
     protected function getStaffMember(\Galette\Entity\Adherent $member): \Galette\Entity\Adherent
     {
@@ -973,8 +919,6 @@ abstract class GaletteTestCase extends TestCase
      *
      * @param \Galette\Entity\Adherent $staff_member Staff member to edit
      * @param \Galette\Entity\Adherent $member       Member to get status from
-     *
-     * @return void
      */
     protected function resetStaffStatus(\Galette\Entity\Adherent $staff_member, \Galette\Entity\Adherent $member): void
     {
@@ -993,8 +937,6 @@ abstract class GaletteTestCase extends TestCase
      * Set given member as admin
      *
      * @param \Galette\Entity\Adherent $member Member to edit
-     *
-     * @return \Galette\Entity\Adherent
      */
     protected function getAdminMember(\Galette\Entity\Adherent $member): \Galette\Entity\Adherent
     {
@@ -1017,8 +959,6 @@ abstract class GaletteTestCase extends TestCase
      * Reset given admin member flag
      *
      * @param \Galette\Entity\Adherent $admin_member Admin member to edit
-     *
-     * @return void
      */
     protected function resetAdminStatus(\Galette\Entity\Adherent $admin_member): void
     {
@@ -1034,8 +974,6 @@ abstract class GaletteTestCase extends TestCase
 
     /**
      * Get mocked document instance
-     *
-     * @return \Galette\Entity\Document
      */
     protected function getDocumentInstance(): \Galette\Entity\Document
     {

--- a/tests/GaletteUpdate/Core/Install.php
+++ b/tests/GaletteUpdate/Core/Install.php
@@ -40,8 +40,6 @@ class Install extends TestCase
     private string $latest_prefix = 'latest_galette_';
     /**
      * Set up tests
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -67,8 +65,6 @@ class Install extends TestCase
 
     /**
      * Tear down tests
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -79,8 +75,6 @@ class Install extends TestCase
 
     /**
      * Test if current database version is supported
-     *
-     * @return void
      */
     public function testDbSupport(): void
     {
@@ -89,8 +83,6 @@ class Install extends TestCase
 
     /**
      * Test updates
-     *
-     * @return void
      */
     public function testUpdates(): void
     {
@@ -125,8 +117,6 @@ class Install extends TestCase
 
     /**
      * Test updated database schema against fresh installed one
-     *
-     * @return void
      */
     public function testUpdatedDatabase(): void
     {
@@ -149,9 +139,9 @@ class Install extends TestCase
         //make sure all tables are present
         $this->assertEquals(
             array_map(
-                fn($table) =>
+                fn($table)
                     //table prefix differs
-                    str_replace($latest_prefix, PREFIX_DB, $table),
+                    => str_replace($latest_prefix, PREFIX_DB, $table),
                 $latest_tables
             ),
             $tables
@@ -181,11 +171,11 @@ class Install extends TestCase
 
                 //Q&D fixes... :'(
                 if (
-                    !$db->isPostgres() &&
-                    $table_name === 'galette_cotisations' &&
-                    (
-                        $latest_column->getName() === 'id_type_cotis' ||
-                        $latest_column->getName() === 'type_paiement_cotis'
+                    !$db->isPostgres()
+                    && $table_name === 'galette_cotisations'
+                    && (
+                        $latest_column->getName() === 'id_type_cotis'
+                        || $latest_column->getName() === 'type_paiement_cotis'
                     )
                 ) {
                     //dunno why default is not correct, 1.15-mysql upgrade does contain the correct statement.
@@ -314,8 +304,6 @@ class Install extends TestCase
      * Build constraint key since we can not rely on mysql ones
      *
      * @param \Laminas\Db\Metadata\Object\ConstraintObject $constraint Constraint from which key must be built
-     *
-     * @return string
      */
     private function buildConstraintKey(\Laminas\Db\Metadata\Object\ConstraintObject $constraint): string
     {
@@ -347,8 +335,6 @@ class Install extends TestCase
      * @param \Laminas\Db\Metadata\Object\ConstraintObject $latest_constraint Constraint from installed database
      * @param \Laminas\Db\Metadata\Object\ConstraintObject $constraint        Constraint from updated database
      * @param string                                       $rule_type         Rule type (either 'update' or 'delete')
-     *
-     * @return void
      */
     private function checkFkeysRules(
         \Laminas\Db\Metadata\Object\ConstraintObject $latest_constraint,

--- a/tests/TestsBootstrap.php
+++ b/tests/TestsBootstrap.php
@@ -21,7 +21,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * Test bootstrap
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>

--- a/tests/config/mysql/config.inc.php
+++ b/tests/config/mysql/config.inc.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © 2003-2025 The Galette Team
  *
@@ -18,7 +19,7 @@
  * along with Galette. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/**
+/*
  * MySQL configuration file for tests
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>

--- a/tests/config/mysql/galette_tcpdf_config.php
+++ b/tests/config/mysql/galette_tcpdf_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © 2003-2025 The Galette Team
  *
@@ -47,7 +48,7 @@
 // See LICENSE.TXT file for more information.
 //============================================================+
 
-/**
+/*
  * Alternative configuration file for TCPDF.
  * @author Nicola Asuni
  * @package com.tecnick.tcpdf
@@ -55,184 +56,184 @@
  * @since 2004-10-27
  */
 
-/**
+/*
  * Define the following constant to ignore the default configuration file.
  */
-define ('K_TCPDF_EXTERNAL_CONFIG', true);
+define('K_TCPDF_EXTERNAL_CONFIG', true);
 
-/**
+/*
  * Installation path (/var/www/tcpdf/).
  * By default it is automatically calculated but you can also set it as a fixed string to improve performances.
  */
-define ('K_PATH_MAIN', GALETTE_TCPDF_PATH);
+define('K_PATH_MAIN', GALETTE_TCPDF_PATH);
 
-/**
+/*
  * URL path to tcpdf installation folder (http://localhost/tcpdf/).
  * By default it is automatically set but you can also set it as a fixed string to improve performances.
  */
 //define ('K_PATH_URL', '');
 
-/**
+/*
  * Path for PDF fonts.
  * By default it is automatically set but you can also set it as a fixed string to improve performances.
  */
-define ('K_PATH_FONTS', GALETTE_TCPDF_PATH.'/fonts/');
+define('K_PATH_FONTS', GALETTE_TCPDF_PATH . '/fonts/');
 
-/**
+/*
  * Default images directory.
  * By default it is automatically set but you can also set it as a fixed string to improve performances.
  */
-define ('K_PATH_IMAGES', GALETTE_PHOTOS_PATH);
+define('K_PATH_IMAGES', GALETTE_PHOTOS_PATH);
 
-/**
+/*
  * Deafult image logo used be the default Header() method.
  * Please set here your own logo or an empty string to disable it.
  */
 //define ('PDF_HEADER_LOGO', '');
 
-/**
+/*
  * Header logo image width in user units.
  */
 //define ('PDF_HEADER_LOGO_WIDTH', 0);
 
-/**
+/*
  * Cache directory for temporary files (full path).
  */
-define ('K_PATH_CACHE', GALETTE_CACHE_DIR);
+define('K_PATH_CACHE', GALETTE_CACHE_DIR);
 
-/**
+/*
  * Generic name for a blank image.
  */
-define ('K_BLANK_IMAGE', '_blank.png');
+define('K_BLANK_IMAGE', '_blank.png');
 
-/**
+/*
  * Page format.
  */
-define ('PDF_PAGE_FORMAT', 'A4');
+define('PDF_PAGE_FORMAT', 'A4');
 
-/**
+/*
  * Page orientation (P=portrait, L=landscape).
  */
-define ('PDF_PAGE_ORIENTATION', 'P');
+define('PDF_PAGE_ORIENTATION', 'P');
 
-/**
+/*
  * Document creator.
  */
-define ('PDF_CREATOR', 'TCPDF');
+define('PDF_CREATOR', 'TCPDF');
 
-/**
+/*
  * Document author.
  */
-define ('PDF_AUTHOR', 'TCPDF');
+define('PDF_AUTHOR', 'TCPDF');
 
-/**
+/*
  * Header title.
  */
-define ('PDF_HEADER_TITLE', 'TCPDF Example');
+define('PDF_HEADER_TITLE', 'TCPDF Example');
 
-/**
+/*
  * Header description string.
  */
-define ('PDF_HEADER_STRING', "by Nicola Asuni - Tecnick.com\nwww.tcpdf.org");
+define('PDF_HEADER_STRING', "by Nicola Asuni - Tecnick.com\nwww.tcpdf.org");
 
-/**
+/*
  * Document unit of measure [pt=point, mm=millimeter, cm=centimeter, in=inch].
  */
-define ('PDF_UNIT', 'mm');
+define('PDF_UNIT', 'mm');
 
-/**
+/*
  * Header margin.
  */
-define ('PDF_MARGIN_HEADER', 5);
+define('PDF_MARGIN_HEADER', 5);
 
-/**
+/*
  * Footer margin.
  */
-define ('PDF_MARGIN_FOOTER', 10);
+define('PDF_MARGIN_FOOTER', 10);
 
-/**
+/*
  * Top margin.
  */
-define ('PDF_MARGIN_TOP', 27);
+define('PDF_MARGIN_TOP', 27);
 
-/**
+/*
  * Bottom margin.
  */
-define ('PDF_MARGIN_BOTTOM', 25);
+define('PDF_MARGIN_BOTTOM', 25);
 
-/**
+/*
  * Left margin.
  */
-define ('PDF_MARGIN_LEFT', 15);
+define('PDF_MARGIN_LEFT', 15);
 
-/**
+/*
  * Right margin.
  */
-define ('PDF_MARGIN_RIGHT', 15);
+define('PDF_MARGIN_RIGHT', 15);
 
-/**
+/*
  * Default main font name.
  */
-define ('PDF_FONT_NAME_MAIN', 'DejaVuSans');
+define('PDF_FONT_NAME_MAIN', 'DejaVuSans');
 
-/**
+/*
  * Default main font size.
  */
-define ('PDF_FONT_SIZE_MAIN', 10);
+define('PDF_FONT_SIZE_MAIN', 10);
 
-/**
+/*
  * Default data font name.
  */
-define ('PDF_FONT_NAME_DATA', 'DejaVuSans');
+define('PDF_FONT_NAME_DATA', 'DejaVuSans');
 
-/**
+/*
  * Default data font size.
  */
-define ('PDF_FONT_SIZE_DATA', 8);
+define('PDF_FONT_SIZE_DATA', 8);
 
-/**
+/*
  * Default monospaced font name.
  */
-define ('PDF_FONT_MONOSPACED', 'courier');
+define('PDF_FONT_MONOSPACED', 'courier');
 
-/**
+/*
  * Ratio used to adjust the conversion of pixels to user units.
  */
-define ('PDF_IMAGE_SCALE_RATIO', 1.25);
+define('PDF_IMAGE_SCALE_RATIO', 1.25);
 
-/**
+/*
  * Magnification factor for titles.
  */
 define('HEAD_MAGNIFICATION', 1.1);
 
-/**
+/*
  * Height of cell respect font height.
  */
 define('K_CELL_HEIGHT_RATIO', 1.25);
 
-/**
+/*
  * Title magnification respect main font size.
  */
 define('K_TITLE_MAGNIFICATION', 1.3);
 
-/**
+/*
  * Reduction factor for small font.
  */
-define('K_SMALL_RATIO', 2/3);
+define('K_SMALL_RATIO', 2 / 3);
 
-/**
+/*
  * Set to true to enable the special procedure used to avoid the overlappind of symbols on Thai language.
  */
 define('K_THAI_TOPCHARS', true);
 
-/**
+/*
  * If true allows to call TCPDF methods using HTML syntax
  * IMPORTANT: For security reason, disable this feature if you are printing user HTML content.
  */
 define('K_TCPDF_CALLS_IN_HTML', true);
 
-/**
- * If true adn PHP version is greater than 5, then the Error() method throw new exception instead of terminating the execution.
+/*
+ * If true and PHP version is greater than 5, then the Error() method throw new exception instead of terminating the execution.
  */
 define('K_TCPDF_THROW_EXCEPTION_ERROR', false);
 

--- a/tests/config/mysql_fail/config.inc.php
+++ b/tests/config/mysql_fail/config.inc.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © 2003-2025 The Galette Team
  *
@@ -18,7 +19,7 @@
  * along with Galette. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/**
+/*
  * MySQL configuration file for tests
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>

--- a/tests/config/mysql_fail/galette_tcpdf_config.php
+++ b/tests/config/mysql_fail/galette_tcpdf_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © 2003-2025 The Galette Team
  *
@@ -47,7 +48,7 @@
 // See LICENSE.TXT file for more information.
 //============================================================+
 
-/**
+/*
  * Alternative configuration file for TCPDF.
  * @author Nicola Asuni
  * @package com.tecnick.tcpdf
@@ -55,184 +56,184 @@
  * @since 2004-10-27
  */
 
-/**
+/*
  * Define the following constant to ignore the default configuration file.
  */
-define ('K_TCPDF_EXTERNAL_CONFIG', true);
+define('K_TCPDF_EXTERNAL_CONFIG', true);
 
-/**
+/*
  * Installation path (/var/www/tcpdf/).
  * By default it is automatically calculated but you can also set it as a fixed string to improve performances.
  */
-define ('K_PATH_MAIN', GALETTE_TCPDF_PATH);
+define('K_PATH_MAIN', GALETTE_TCPDF_PATH);
 
-/**
+/*
  * URL path to tcpdf installation folder (http://localhost/tcpdf/).
  * By default it is automatically set but you can also set it as a fixed string to improve performances.
  */
 //define ('K_PATH_URL', '');
 
-/**
+/*
  * Path for PDF fonts.
  * By default it is automatically set but you can also set it as a fixed string to improve performances.
  */
-define ('K_PATH_FONTS', GALETTE_TCPDF_PATH.'/fonts/');
+define('K_PATH_FONTS', GALETTE_TCPDF_PATH . '/fonts/');
 
-/**
+/*
  * Default images directory.
  * By default it is automatically set but you can also set it as a fixed string to improve performances.
  */
-define ('K_PATH_IMAGES', GALETTE_PHOTOS_PATH);
+define('K_PATH_IMAGES', GALETTE_PHOTOS_PATH);
 
-/**
+/*
  * Deafult image logo used be the default Header() method.
  * Please set here your own logo or an empty string to disable it.
  */
 //define ('PDF_HEADER_LOGO', '');
 
-/**
+/*
  * Header logo image width in user units.
  */
 //define ('PDF_HEADER_LOGO_WIDTH', 0);
 
-/**
+/*
  * Cache directory for temporary files (full path).
  */
-define ('K_PATH_CACHE', GALETTE_CACHE_DIR);
+define('K_PATH_CACHE', GALETTE_CACHE_DIR);
 
-/**
+/*
  * Generic name for a blank image.
  */
-define ('K_BLANK_IMAGE', '_blank.png');
+define('K_BLANK_IMAGE', '_blank.png');
 
-/**
+/*
  * Page format.
  */
-define ('PDF_PAGE_FORMAT', 'A4');
+define('PDF_PAGE_FORMAT', 'A4');
 
-/**
+/*
  * Page orientation (P=portrait, L=landscape).
  */
-define ('PDF_PAGE_ORIENTATION', 'P');
+define('PDF_PAGE_ORIENTATION', 'P');
 
-/**
+/*
  * Document creator.
  */
-define ('PDF_CREATOR', 'TCPDF');
+define('PDF_CREATOR', 'TCPDF');
 
-/**
+/*
  * Document author.
  */
-define ('PDF_AUTHOR', 'TCPDF');
+define('PDF_AUTHOR', 'TCPDF');
 
-/**
+/*
  * Header title.
  */
-define ('PDF_HEADER_TITLE', 'TCPDF Example');
+define('PDF_HEADER_TITLE', 'TCPDF Example');
 
-/**
+/*
  * Header description string.
  */
-define ('PDF_HEADER_STRING', "by Nicola Asuni - Tecnick.com\nwww.tcpdf.org");
+define('PDF_HEADER_STRING', "by Nicola Asuni - Tecnick.com\nwww.tcpdf.org");
 
-/**
+/*
  * Document unit of measure [pt=point, mm=millimeter, cm=centimeter, in=inch].
  */
-define ('PDF_UNIT', 'mm');
+define('PDF_UNIT', 'mm');
 
-/**
+/*
  * Header margin.
  */
-define ('PDF_MARGIN_HEADER', 5);
+define('PDF_MARGIN_HEADER', 5);
 
-/**
+/*
  * Footer margin.
  */
-define ('PDF_MARGIN_FOOTER', 10);
+define('PDF_MARGIN_FOOTER', 10);
 
-/**
+/*
  * Top margin.
  */
-define ('PDF_MARGIN_TOP', 27);
+define('PDF_MARGIN_TOP', 27);
 
-/**
+/*
  * Bottom margin.
  */
-define ('PDF_MARGIN_BOTTOM', 25);
+define('PDF_MARGIN_BOTTOM', 25);
 
-/**
+/*
  * Left margin.
  */
-define ('PDF_MARGIN_LEFT', 15);
+define('PDF_MARGIN_LEFT', 15);
 
-/**
+/*
  * Right margin.
  */
-define ('PDF_MARGIN_RIGHT', 15);
+define('PDF_MARGIN_RIGHT', 15);
 
-/**
+/*
  * Default main font name.
  */
-define ('PDF_FONT_NAME_MAIN', 'DejaVuSans');
+define('PDF_FONT_NAME_MAIN', 'DejaVuSans');
 
-/**
+/*
  * Default main font size.
  */
-define ('PDF_FONT_SIZE_MAIN', 10);
+define('PDF_FONT_SIZE_MAIN', 10);
 
-/**
+/*
  * Default data font name.
  */
-define ('PDF_FONT_NAME_DATA', 'DejaVuSans');
+define('PDF_FONT_NAME_DATA', 'DejaVuSans');
 
-/**
+/*
  * Default data font size.
  */
-define ('PDF_FONT_SIZE_DATA', 8);
+define('PDF_FONT_SIZE_DATA', 8);
 
-/**
+/*
  * Default monospaced font name.
  */
-define ('PDF_FONT_MONOSPACED', 'courier');
+define('PDF_FONT_MONOSPACED', 'courier');
 
-/**
+/*
  * Ratio used to adjust the conversion of pixels to user units.
  */
-define ('PDF_IMAGE_SCALE_RATIO', 1.25);
+define('PDF_IMAGE_SCALE_RATIO', 1.25);
 
-/**
+/*
  * Magnification factor for titles.
  */
 define('HEAD_MAGNIFICATION', 1.1);
 
-/**
+/*
  * Height of cell respect font height.
  */
 define('K_CELL_HEIGHT_RATIO', 1.25);
 
-/**
+/*
  * Title magnification respect main font size.
  */
 define('K_TITLE_MAGNIFICATION', 1.3);
 
-/**
+/*
  * Reduction factor for small font.
  */
-define('K_SMALL_RATIO', 2/3);
+define('K_SMALL_RATIO', 2 / 3);
 
-/**
+/*
  * Set to true to enable the special procedure used to avoid the overlappind of symbols on Thai language.
  */
 define('K_THAI_TOPCHARS', true);
 
-/**
+/*
  * If true allows to call TCPDF methods using HTML syntax
  * IMPORTANT: For security reason, disable this feature if you are printing user HTML content.
  */
 define('K_TCPDF_CALLS_IN_HTML', true);
 
-/**
- * If true adn PHP version is greater than 5, then the Error() method throw new exception instead of terminating the execution.
+/*
+ * If true and PHP version is greater than 5, then the Error() method throw new exception instead of terminating the execution.
  */
 define('K_TCPDF_THROW_EXCEPTION_ERROR', false);
 

--- a/tests/config/pgsql/config.inc.php
+++ b/tests/config/pgsql/config.inc.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © 2003-2025 The Galette Team
  *
@@ -18,7 +19,7 @@
  * along with Galette. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/**
+/*
  * PostgreSQL's configuration file for tests
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>

--- a/tests/config/pgsql/galette_tcpdf_config.php
+++ b/tests/config/pgsql/galette_tcpdf_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © 2003-2025 The Galette Team
  *
@@ -47,7 +48,7 @@
 // See LICENSE.TXT file for more information.
 //============================================================+
 
-/**
+/*
  * Alternative configuration file for TCPDF.
  * @author Nicola Asuni
  * @package com.tecnick.tcpdf
@@ -55,184 +56,184 @@
  * @since 2004-10-27
  */
 
-/**
+/*
  * Define the following constant to ignore the default configuration file.
  */
-define ('K_TCPDF_EXTERNAL_CONFIG', true);
+define('K_TCPDF_EXTERNAL_CONFIG', true);
 
-/**
+/*
  * Installation path (/var/www/tcpdf/).
  * By default it is automatically calculated but you can also set it as a fixed string to improve performances.
  */
-define ('K_PATH_MAIN', GALETTE_TCPDF_PATH);
+define('K_PATH_MAIN', GALETTE_TCPDF_PATH);
 
-/**
+/*
  * URL path to tcpdf installation folder (http://localhost/tcpdf/).
  * By default it is automatically set but you can also set it as a fixed string to improve performances.
  */
 //define ('K_PATH_URL', '');
 
-/**
+/*
  * Path for PDF fonts.
  * By default it is automatically set but you can also set it as a fixed string to improve performances.
  */
-define ('K_PATH_FONTS', GALETTE_TCPDF_PATH.'/fonts/');
+define('K_PATH_FONTS', GALETTE_TCPDF_PATH . '/fonts/');
 
-/**
+/*
  * Default images directory.
  * By default it is automatically set but you can also set it as a fixed string to improve performances.
  */
-define ('K_PATH_IMAGES', GALETTE_PHOTOS_PATH);
+define('K_PATH_IMAGES', GALETTE_PHOTOS_PATH);
 
-/**
+/*
  * Deafult image logo used be the default Header() method.
  * Please set here your own logo or an empty string to disable it.
  */
 //define ('PDF_HEADER_LOGO', '');
 
-/**
+/*
  * Header logo image width in user units.
  */
 //define ('PDF_HEADER_LOGO_WIDTH', 0);
 
-/**
+/*
  * Cache directory for temporary files (full path).
  */
-define ('K_PATH_CACHE', GALETTE_CACHE_DIR);
+define('K_PATH_CACHE', GALETTE_CACHE_DIR);
 
-/**
+/*
  * Generic name for a blank image.
  */
-define ('K_BLANK_IMAGE', '_blank.png');
+define('K_BLANK_IMAGE', '_blank.png');
 
-/**
+/*
  * Page format.
  */
-define ('PDF_PAGE_FORMAT', 'A4');
+define('PDF_PAGE_FORMAT', 'A4');
 
-/**
+/*
  * Page orientation (P=portrait, L=landscape).
  */
-define ('PDF_PAGE_ORIENTATION', 'P');
+define('PDF_PAGE_ORIENTATION', 'P');
 
-/**
+/*
  * Document creator.
  */
-define ('PDF_CREATOR', 'TCPDF');
+define('PDF_CREATOR', 'TCPDF');
 
-/**
+/*
  * Document author.
  */
-define ('PDF_AUTHOR', 'TCPDF');
+define('PDF_AUTHOR', 'TCPDF');
 
-/**
+/*
  * Header title.
  */
-define ('PDF_HEADER_TITLE', 'TCPDF Example');
+define('PDF_HEADER_TITLE', 'TCPDF Example');
 
-/**
+/*
  * Header description string.
  */
-define ('PDF_HEADER_STRING', "by Nicola Asuni - Tecnick.com\nwww.tcpdf.org");
+define('PDF_HEADER_STRING', "by Nicola Asuni - Tecnick.com\nwww.tcpdf.org");
 
-/**
+/*
  * Document unit of measure [pt=point, mm=millimeter, cm=centimeter, in=inch].
  */
-define ('PDF_UNIT', 'mm');
+define('PDF_UNIT', 'mm');
 
-/**
+/*
  * Header margin.
  */
-define ('PDF_MARGIN_HEADER', 5);
+define('PDF_MARGIN_HEADER', 5);
 
-/**
+/*
  * Footer margin.
  */
-define ('PDF_MARGIN_FOOTER', 10);
+define('PDF_MARGIN_FOOTER', 10);
 
-/**
+/*
  * Top margin.
  */
-define ('PDF_MARGIN_TOP', 27);
+define('PDF_MARGIN_TOP', 27);
 
-/**
+/*
  * Bottom margin.
  */
-define ('PDF_MARGIN_BOTTOM', 25);
+define('PDF_MARGIN_BOTTOM', 25);
 
-/**
+/*
  * Left margin.
  */
-define ('PDF_MARGIN_LEFT', 15);
+define('PDF_MARGIN_LEFT', 15);
 
-/**
+/*
  * Right margin.
  */
-define ('PDF_MARGIN_RIGHT', 15);
+define('PDF_MARGIN_RIGHT', 15);
 
-/**
+/*
  * Default main font name.
  */
-define ('PDF_FONT_NAME_MAIN', 'DejaVuSans');
+define('PDF_FONT_NAME_MAIN', 'DejaVuSans');
 
-/**
+/*
  * Default main font size.
  */
-define ('PDF_FONT_SIZE_MAIN', 10);
+define('PDF_FONT_SIZE_MAIN', 10);
 
-/**
+/*
  * Default data font name.
  */
-define ('PDF_FONT_NAME_DATA', 'DejaVuSans');
+define('PDF_FONT_NAME_DATA', 'DejaVuSans');
 
-/**
+/*
  * Default data font size.
  */
-define ('PDF_FONT_SIZE_DATA', 8);
+define('PDF_FONT_SIZE_DATA', 8);
 
-/**
+/*
  * Default monospaced font name.
  */
-define ('PDF_FONT_MONOSPACED', 'courier');
+define('PDF_FONT_MONOSPACED', 'courier');
 
-/**
+/*
  * Ratio used to adjust the conversion of pixels to user units.
  */
-define ('PDF_IMAGE_SCALE_RATIO', 1.25);
+define('PDF_IMAGE_SCALE_RATIO', 1.25);
 
-/**
+/*
  * Magnification factor for titles.
  */
 define('HEAD_MAGNIFICATION', 1.1);
 
-/**
+/*
  * Height of cell respect font height.
  */
 define('K_CELL_HEIGHT_RATIO', 1.25);
 
-/**
+/*
  * Title magnification respect main font size.
  */
 define('K_TITLE_MAGNIFICATION', 1.3);
 
-/**
+/*
  * Reduction factor for small font.
  */
-define('K_SMALL_RATIO', 2/3);
+define('K_SMALL_RATIO', 2 / 3);
 
-/**
+/*
  * Set to true to enable the special procedure used to avoid the overlappind of symbols on Thai language.
  */
 define('K_THAI_TOPCHARS', true);
 
-/**
+/*
  * If true allows to call TCPDF methods using HTML syntax
  * IMPORTANT: For security reason, disable this feature if you are printing user HTML content.
  */
 define('K_TCPDF_CALLS_IN_HTML', true);
 
-/**
- * If true adn PHP version is greater than 5, then the Error() method throw new exception instead of terminating the execution.
+/*
+ * If true and PHP version is greater than 5, then the Error() method throw new exception instead of terminating the execution.
  */
 define('K_TCPDF_THROW_EXCEPTION_ERROR', false);
 

--- a/tests/config/pgsql_fail/config.inc.php
+++ b/tests/config/pgsql_fail/config.inc.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © 2003-2025 The Galette Team
  *
@@ -18,7 +19,7 @@
  * along with Galette. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/**
+/*
  * PostgreSQL's configuration file for tests
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>

--- a/tests/config/pgsql_fail/galette_tcpdf_config.php
+++ b/tests/config/pgsql_fail/galette_tcpdf_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © 2003-2025 The Galette Team
  *
@@ -47,7 +48,7 @@
 // See LICENSE.TXT file for more information.
 //============================================================+
 
-/**
+/*
  * Alternative configuration file for TCPDF.
  * @author Nicola Asuni
  * @package com.tecnick.tcpdf
@@ -55,184 +56,184 @@
  * @since 2004-10-27
  */
 
-/**
+/*
  * Define the following constant to ignore the default configuration file.
  */
-define ('K_TCPDF_EXTERNAL_CONFIG', true);
+define('K_TCPDF_EXTERNAL_CONFIG', true);
 
-/**
+/*
  * Installation path (/var/www/tcpdf/).
  * By default it is automatically calculated but you can also set it as a fixed string to improve performances.
  */
-define ('K_PATH_MAIN', GALETTE_TCPDF_PATH);
+define('K_PATH_MAIN', GALETTE_TCPDF_PATH);
 
-/**
+/*
  * URL path to tcpdf installation folder (http://localhost/tcpdf/).
  * By default it is automatically set but you can also set it as a fixed string to improve performances.
  */
 //define ('K_PATH_URL', '');
 
-/**
+/*
  * Path for PDF fonts.
  * By default it is automatically set but you can also set it as a fixed string to improve performances.
  */
-define ('K_PATH_FONTS', GALETTE_TCPDF_PATH.'/fonts/');
+define('K_PATH_FONTS', GALETTE_TCPDF_PATH . '/fonts/');
 
-/**
+/*
  * Default images directory.
  * By default it is automatically set but you can also set it as a fixed string to improve performances.
  */
-define ('K_PATH_IMAGES', GALETTE_PHOTOS_PATH);
+define('K_PATH_IMAGES', GALETTE_PHOTOS_PATH);
 
-/**
+/*
  * Deafult image logo used be the default Header() method.
  * Please set here your own logo or an empty string to disable it.
  */
 //define ('PDF_HEADER_LOGO', '');
 
-/**
+/*
  * Header logo image width in user units.
  */
 //define ('PDF_HEADER_LOGO_WIDTH', 0);
 
-/**
+/*
  * Cache directory for temporary files (full path).
  */
-define ('K_PATH_CACHE', GALETTE_CACHE_DIR);
+define('K_PATH_CACHE', GALETTE_CACHE_DIR);
 
-/**
+/*
  * Generic name for a blank image.
  */
-define ('K_BLANK_IMAGE', '_blank.png');
+define('K_BLANK_IMAGE', '_blank.png');
 
-/**
+/*
  * Page format.
  */
-define ('PDF_PAGE_FORMAT', 'A4');
+define('PDF_PAGE_FORMAT', 'A4');
 
-/**
+/*
  * Page orientation (P=portrait, L=landscape).
  */
-define ('PDF_PAGE_ORIENTATION', 'P');
+define('PDF_PAGE_ORIENTATION', 'P');
 
-/**
+/*
  * Document creator.
  */
-define ('PDF_CREATOR', 'TCPDF');
+define('PDF_CREATOR', 'TCPDF');
 
-/**
+/*
  * Document author.
  */
-define ('PDF_AUTHOR', 'TCPDF');
+define('PDF_AUTHOR', 'TCPDF');
 
-/**
+/*
  * Header title.
  */
-define ('PDF_HEADER_TITLE', 'TCPDF Example');
+define('PDF_HEADER_TITLE', 'TCPDF Example');
 
-/**
+/*
  * Header description string.
  */
-define ('PDF_HEADER_STRING', "by Nicola Asuni - Tecnick.com\nwww.tcpdf.org");
+define('PDF_HEADER_STRING', "by Nicola Asuni - Tecnick.com\nwww.tcpdf.org");
 
-/**
+/*
  * Document unit of measure [pt=point, mm=millimeter, cm=centimeter, in=inch].
  */
-define ('PDF_UNIT', 'mm');
+define('PDF_UNIT', 'mm');
 
-/**
+/*
  * Header margin.
  */
-define ('PDF_MARGIN_HEADER', 5);
+define('PDF_MARGIN_HEADER', 5);
 
-/**
+/*
  * Footer margin.
  */
-define ('PDF_MARGIN_FOOTER', 10);
+define('PDF_MARGIN_FOOTER', 10);
 
-/**
+/*
  * Top margin.
  */
-define ('PDF_MARGIN_TOP', 27);
+define('PDF_MARGIN_TOP', 27);
 
-/**
+/*
  * Bottom margin.
  */
-define ('PDF_MARGIN_BOTTOM', 25);
+define('PDF_MARGIN_BOTTOM', 25);
 
-/**
+/*
  * Left margin.
  */
-define ('PDF_MARGIN_LEFT', 15);
+define('PDF_MARGIN_LEFT', 15);
 
-/**
+/*
  * Right margin.
  */
-define ('PDF_MARGIN_RIGHT', 15);
+define('PDF_MARGIN_RIGHT', 15);
 
-/**
+/*
  * Default main font name.
  */
-define ('PDF_FONT_NAME_MAIN', 'DejaVuSans');
+define('PDF_FONT_NAME_MAIN', 'DejaVuSans');
 
-/**
+/*
  * Default main font size.
  */
-define ('PDF_FONT_SIZE_MAIN', 10);
+define('PDF_FONT_SIZE_MAIN', 10);
 
-/**
+/*
  * Default data font name.
  */
-define ('PDF_FONT_NAME_DATA', 'DejaVuSans');
+define('PDF_FONT_NAME_DATA', 'DejaVuSans');
 
-/**
+/*
  * Default data font size.
  */
-define ('PDF_FONT_SIZE_DATA', 8);
+define('PDF_FONT_SIZE_DATA', 8);
 
-/**
+/*
  * Default monospaced font name.
  */
-define ('PDF_FONT_MONOSPACED', 'courier');
+define('PDF_FONT_MONOSPACED', 'courier');
 
-/**
+/*
  * Ratio used to adjust the conversion of pixels to user units.
  */
-define ('PDF_IMAGE_SCALE_RATIO', 1.25);
+define('PDF_IMAGE_SCALE_RATIO', 1.25);
 
-/**
+/*
  * Magnification factor for titles.
  */
 define('HEAD_MAGNIFICATION', 1.1);
 
-/**
+/*
  * Height of cell respect font height.
  */
 define('K_CELL_HEIGHT_RATIO', 1.25);
 
-/**
+/*
  * Title magnification respect main font size.
  */
 define('K_TITLE_MAGNIFICATION', 1.3);
 
-/**
+/*
  * Reduction factor for small font.
  */
-define('K_SMALL_RATIO', 2/3);
+define('K_SMALL_RATIO', 2 / 3);
 
-/**
+/*
  * Set to true to enable the special procedure used to avoid the overlappind of symbols on Thai language.
  */
 define('K_THAI_TOPCHARS', true);
 
-/**
+/*
  * If true allows to call TCPDF methods using HTML syntax
  * IMPORTANT: For security reason, disable this feature if you are printing user HTML content.
  */
 define('K_TCPDF_CALLS_IN_HTML', true);
 
-/**
- * If true adn PHP version is greater than 5, then the Error() method throw new exception instead of terminating the execution.
+/*
+ * If true and PHP version is greater than 5, then the Error() method throw new exception instead of terminating the execution.
  */
 define('K_TCPDF_THROW_EXCEPTION_ERROR', false);
 

--- a/tests/fixtures/translations.php
+++ b/tests/fixtures/translations.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © 2003-2025 The Galette Team
  *
@@ -18,7 +19,7 @@
  * along with Galette. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/**
+/*
  * Test translation features.
  *
  * example (see galette/lan/Makefile for up to date command):

--- a/tests/plugins/plugin-news/lib/GaletteNews/PluginGaletteNews.php
+++ b/tests/plugins/plugin-news/lib/GaletteNews/PluginGaletteNews.php
@@ -23,15 +23,10 @@ declare(strict_types=1);
 
 namespace GaletteNews;
 
-use DI\Attribute\Inject;
-use Galette\Core\Db;
-use Galette\Core\Login;
 use Galette\Entity\Adherent;
 use Galette\Core\GalettePlugin;
 use Galette\IO\News\Entry;
 use Galette\IO\News\Post;
-use GaletteEvents\Filters\EventsList;
-use GaletteEvents\Repository\Events;
 
 /**
  * Galette News plugin
@@ -117,8 +112,6 @@ class PluginGaletteNews extends GalettePlugin
 
     /**
      * Get plugin news
-     *
-     * @return ?Entry
      */
     public function getNews(): ?Entry
     {
@@ -142,8 +135,6 @@ class PluginGaletteNews extends GalettePlugin
 
     /**
      * Is the plugin fully installed (including database, extra configuration, etc)?
-     *
-     * @return bool
      */
     public function isInstalled(): bool
     {


### PR DESCRIPTION
No longer rely on PEAR commenting for methods, it just force all parameters and return to be documented; while this is now often useless since types are applied.