### PR TITLE
Plugins interface proposal

### DIFF
--- a/galette/lib/Galette/Core/Db.php
+++ b/galette/lib/Galette/Core/Db.php
@@ -556,9 +556,14 @@ class Db
      *
      * @param ?string $prefix       Specified table prefix
      * @param bool    $content_only Proceed only content (no table conversion)
+     * @deprecated 1.2.2 upgrading from 0.6 will be discontinued.
      */
     public function convertToUTF(?string $prefix = null, bool $content_only = false): void
     {
+        Analog::log(
+            'Upgrading from 0.6 will soon be discontinued.',
+            Analog::WARNING
+        );
         if ($this->isPostgres()) {
             Analog::log(
                 'Cannot change encoding on PostgreSQL database',
@@ -613,10 +618,10 @@ class Db
      *
      * @param string $prefix Specified table prefix
      * @param string $table  the table we want to convert datas from
+     * @deprecated 1.2.2
      */
     private function convertContentToUTF(string $prefix, string $table): void
     {
-
         try {
             $query = 'SET NAMES latin1';
             $this->db->query(

--- a/galette/lib/Galette/Core/Db.php
+++ b/galette/lib/Galette/Core/Db.php
@@ -516,9 +516,14 @@ class Db
      * Does a given table exists?
      *
      * @param string $name Table name
+     * @deprecated 1.2.2: performances are terrible.
      */
     public function tableExists(string $name): bool
     {
+        Analog::log(
+            __METHOD__ . ' should not be used because of very poor performances.',
+            Analog::WARNING
+        );
         $metadata = Factory::createSourceFromAdapter($this->db);
         try {
             $metadata->getTable(PREFIX_DB . $name);

--- a/galette/lib/Galette/Core/Db.php
+++ b/galette/lib/Galette/Core/Db.php
@@ -1006,6 +1006,21 @@ class Db
     }
 
     /**
+     * Check if current exception is related to a missing table or view
+     *
+     * @param Throwable $exception Exception to check
+     */
+    public function isMissingTableException(Throwable $exception): bool
+    {
+        return $exception instanceof \PDOException
+            && (
+                (!$this->isPostgres() && $exception->errorInfo[1] === 1146)
+                || ($this->isPostgres() && $exception->getCode() == '42P01')
+            )
+        ;
+    }
+
+    /**
      * Drops a table
      *
      * @param string $table   Table name, without prefix

--- a/galette/lib/Galette/Core/Db.php
+++ b/galette/lib/Galette/Core/Db.php
@@ -718,7 +718,7 @@ class Db
             );
         } else {
             return $this->sql->select(
-                //@phpstan-ignore-next-line
+                //@phpstan-ignore argument.type (laminas docs are wrong)
                 [
                     $alias => PREFIX_DB . $table
                 ]

--- a/galette/lib/Galette/Core/Galette.php
+++ b/galette/lib/Galette/Core/Galette.php
@@ -511,9 +511,13 @@ class Galette
         foreach (array_keys($plugins->getModules()) as $module_id) {
             //get plugins menus entries
             $plugin_class = $plugins->getClassName($module_id, true);
-            if (class_exists($plugin_class)) {
-                /** @var GalettePlugin $plugin */
-                $plugin = $container->get($plugin_class);
+            /** @var GalettePlugin $plugin */
+            $plugin = $container->get($plugin_class);
+            if (
+                ($plugin instanceof Plugins\MenuProviderInterface
+                || method_exists($plugin, 'getMenusContents')) //handle deprecated case
+                && $plugin->isInstalled()
+            ) {
                 $menus = array_merge_recursive(
                     $menus,
                     $plugin->getMenus()
@@ -636,9 +640,13 @@ class Galette
         foreach (array_keys($plugins->getModules()) as $module_id) {
             //get plugins public menus entries
             $plugin_class = $plugins->getClassName($module_id, true);
-            if (class_exists($plugin_class)) {
-                /** @var GalettePlugin $plugin */
-                $plugin = $container->get($plugin_class);
+            /** @var GalettePlugin $plugin */
+            $plugin = $container->get($plugin_class);
+            if (
+                ($plugin instanceof Plugins\MenuProviderInterface
+                || method_exists($plugin, 'getPublicMenusItemsList')) //handle deprecated case
+                && $plugin->isInstalled()
+            ) {
                 $items = array_merge(
                     $items,
                     $plugin->getPublicMenuItems()
@@ -710,9 +718,13 @@ class Galette
         foreach (array_keys($plugins->getModules()) as $module_id) {
             //get plugins menus entries
             $plugin_class = $plugins->getClassName($module_id, true);
-            if (class_exists($plugin_class) && method_exists($plugin_class, 'getMyDashboards')) {
-                /** @var GalettePlugin $plugin */
-                $plugin = $container->get($plugin_class);
+            /** @var GalettePlugin $plugin */
+            $plugin = $container->get($plugin_class);
+            if (
+                ($plugin instanceof Plugins\DashboardProviderInterface
+                || method_exists($plugin, 'getMyDashboardsContents')) //handle deprecated case
+                && $plugin->isInstalled()
+            ) {
                 $dashboards = array_merge_recursive(
                     $dashboards,
                     $plugin->getMyDashboards()
@@ -852,9 +864,13 @@ class Galette
         foreach (array_keys($plugins->getModules()) as $module_id) {
             //get plugins menus entries
             $plugin_class = $plugins->getClassName($module_id, true);
-            if (class_exists($plugin_class)) {
-                /** @var GalettePlugin $plugin */
-                $plugin = $container->get($plugin_class);
+            /** @var GalettePlugin $plugin */
+            $plugin = $container->get($plugin_class);
+            if (
+                ($plugin instanceof Plugins\DashboardProviderInterface
+                || method_exists($plugin, 'getDashboardsContents')) //handle deprecated case
+                && $plugin->isInstalled()
+            ) {
                 $dashboards = array_merge_recursive(
                     $dashboards,
                     $plugin->getDashboards()
@@ -974,9 +990,13 @@ class Galette
         foreach (array_keys($plugins->getModules()) as $module_id) {
             //get plugins menus entries
             $plugin_class = $plugins->getClassName($module_id, true);
-            if (class_exists($plugin_class)) {
-                /** @var GalettePlugin $plugin */
-                $plugin = $container->get($plugin_class);
+            /** @var GalettePlugin $plugin */
+            $plugin = $container->get($plugin_class);
+            if (
+                ($plugin instanceof Plugins\MemberActionProviderInterface
+                || method_exists($plugin, 'getListActionsContents')) //handle deprecated case
+                && $plugin->isInstalled()
+            ) {
                 $actions = array_merge_recursive(
                     $actions,
                     $plugin->getListActions($member)
@@ -1008,9 +1028,13 @@ class Galette
         foreach (array_keys($plugins->getModules()) as $module_id) {
             //get plugins menus entries
             $plugin_class = $plugins->getClassName($module_id, true);
-            if (class_exists($plugin_class)) {
-                /** @var GalettePlugin $plugin */
-                $plugin = $container->get($plugin_class);
+            /** @var GalettePlugin $plugin */
+            $plugin = $container->get($plugin_class);
+            if (
+                ($plugin instanceof Plugins\MemberActionProviderInterface
+                || method_exists($plugin, 'getDetailedActionsContents')) //handle deprecated case
+                && $plugin->isInstalled()
+            ) {
                 $actions = array_merge_recursive(
                     $actions,
                     $plugin->getDetailedActions($member)
@@ -1065,9 +1089,9 @@ class Galette
 
         if (
             ($login->isAdmin()
-            || $login->isStaff()
-            || $login->isGroupManager()
-            && $preferences->pref_bool_groupsmanagers_mailings)
+                || $login->isStaff()
+                || $login->isGroupManager()
+                && $preferences->pref_bool_groupsmanagers_mailings)
             && $preferences->pref_mail_method != \Galette\Core\GaletteMail::METHOD_DISABLED
         ) {
             $actions[] = [
@@ -1113,9 +1137,13 @@ class Galette
         foreach (array_keys($plugins->getModules()) as $module_id) {
             //get plugins menus entries
             $plugin_class = $plugins->getClassName($module_id, true);
-            if (class_exists($plugin_class)) {
-                /** @var GalettePlugin $plugin */
-                $plugin = $container->get($plugin_class);
+            /** @var GalettePlugin $plugin */
+            $plugin = $container->get($plugin_class);
+            if (
+                ($plugin instanceof Plugins\MemberActionProviderInterface
+                || method_exists($plugin, 'getBatchActionsContents')) //handle deprecated case
+                && $plugin->isInstalled()
+            ) {
                 $actions = array_merge_recursive(
                     $actions,
                     $plugin->getBatchActions()
@@ -1167,10 +1195,21 @@ class Galette
         foreach (array_keys($plugins->getModules()) as $module_id) {
             //get plugins menus entries
             $plugin_class = $plugins->getClassName($module_id, true);
-            if (class_exists($plugin_class)) {
-                /** @var GalettePlugin $plugin */
-                $plugin = $container->get($plugin_class);
-                if ($plugin->isInstalled() && $entry = $plugin->getNews()) {
+            /** @var GalettePlugin $plugin */
+            $plugin = $container->get($plugin_class);
+            if (
+                ($plugin instanceof Plugins\NewsProviderInterface
+                || method_exists($plugin, 'getNews')) //handle deprecated 1.2.2 case
+                && $plugin->isInstalled()
+            ) {
+                //display deprecation message - since 1.2.2
+                if (!($plugin instanceof Plugins\NewsProviderInterface)) {
+                    Analog::log(
+                        $plugin::class . '::getNews() is deprecated, please implement NewsProviderInterface',
+                        Analog::WARNING
+                    );
+                }
+                if ($entry = $plugin->getNews()) {
                     $position = $entry->getPosition();
                     while (isset($news[$position])) {
                         ++$position;

--- a/galette/lib/Galette/Core/GalettePlugin.php
+++ b/galette/lib/Galette/Core/GalettePlugin.php
@@ -23,35 +23,38 @@ declare(strict_types=1);
 
 namespace Galette\Core;
 
+use Analog\Analog;
 use Galette\Entity\Adherent;
-use Galette\IO\News\Entry;
 
 /**
  * Galette plugins
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>
+ *
+ * Designed to be extended by plugins; which can implement the following interfaces:
+ * - MenuProviderInterface: if the plugin provides extra menu entries (public or private menus)
+ * - DashboardProviderInterface: if the plugin provides extra dashboard entries
+ * - MemberActionProviderInterface: if the plugin provides extra member actions
+ * - NewsProviderInterface: if the plugin provides news to be displayed in the dashboard
+ *
+ * Note: a plugin can implement one or more of these interfaces, but it is not mandatory to implement all of them.
+ * Methods are kept in the base class for backward compatibility, they will throw a deprecation warning if used
  */
-abstract class GalettePlugin
+abstract class GalettePlugin implements Plugins\InstallableInterface
 {
-    /**
-     * Get all menus
-     *
-     * @return array<string, string|array<string,mixed>>
-     */
-    public static function getAllMenus(): array
-    {
-        return static::getMenus(true);
-    }
-
     /**
      * Get plugins menus
      *
-     * @param bool $public Include public menus. Defaults to false
-     *
      * @return array<string, string|array<string,mixed>>
+     * @deprecated 1.2.2
      */
-    public static function getMenus(bool $public = false): array
+    public function getMenus(): array
     {
+        Analog::log(
+            static::class . '::getMenusContents() is deprecated, please implement MenuProviderInterface',
+            Analog::WARNING
+        );
+        /** @phpstan-ignore staticMethod.notFound */
         return static::getMenusContents();
     }
 
@@ -60,13 +63,22 @@ abstract class GalettePlugin
      *
      * @return array<int, string|array<string,mixed>>
      */
-    public static function getPublicMenuItems(): array
+    public function getPublicMenuItems(): array
     {
         global $preferences, $login;
 
         $menus = [];
         if ($preferences->showPublicPage($login, 'pref_publicpages_visibility_plugins')) {
-            $menus = static::getPublicMenusItemsList();
+            if ($this instanceof Plugins\MenuProviderInterface) {
+                $menus = $this->getPublicMenus();
+            } elseif (method_exists($this, 'getPublicMenusItemsList')) {
+                Analog::log(
+                    static::class . '::getPublicMenusItemsList() is deprecated, please implement MenuProviderInterface',
+                    Analog::WARNING
+                );
+                /** @phpstan-ignore staticMethod.notFound */
+                $menus = static::getPublicMenusItemsList();
+            }
         }
 
         return $menus;
@@ -76,9 +88,15 @@ abstract class GalettePlugin
      * Get plugins dashboards
      *
      * @return array<int, string|array<string,mixed>>
+     * @deprecated 1.2.2
      */
-    public static function getDashboards(): array
+    public function getDashboards(): array
     {
+        Analog::log(
+            static::class . '::getDashboardsContents() is deprecated, please implement DashboardProviderInterface',
+            Analog::WARNING
+        );
+        /** @phpstan-ignore staticMethod.notFound */
         return static::getDashboardsContents();
     }
 
@@ -86,39 +104,17 @@ abstract class GalettePlugin
      * Get current logged-in user plugins dashboards
      *
      * @return array<int, string|array<string,mixed>>
+     * @deprecated 1.2.2
      */
-    public static function getMyDashboards(): array
+    public function getMyDashboards(): array
     {
+        Analog::log(
+            static::class . '::getMyDashboardsContents() is deprecated, please implement DashboardProviderInterface',
+            Analog::WARNING
+        );
+        /** @phpstan-ignore staticMethod.notFound */
         return static::getMyDashboardsContents();
     }
-
-    /**
-     * Extra menus entries
-     *
-     * @return array<string, string|array<string,mixed>>
-     */
-    abstract public static function getMenusContents(): array;
-
-    /**
-     * Extra public menus entries
-     *
-     * @return array<int, string|array<string,mixed>>
-     */
-    abstract public static function getPublicMenusItemsList(): array;
-
-    /**
-     * Get dashboards contents
-     *
-     * @return array<int, string|array<string,mixed>>
-     */
-    abstract public static function getDashboardsContents(): array;
-
-    /**
-     * Get current logged-in user dashboards contents
-     *
-     * @return array<int, string|array<string,mixed>>
-     */
-    abstract public static function getMyDashboardsContents(): array;
 
     /**
      * Get member actions
@@ -126,9 +122,15 @@ abstract class GalettePlugin
      * @param Adherent $member Current member
      *
      * @return array<int, string|array<string,mixed>>
+     * @deprecated 1.2.2
      */
-    public static function getListActions(Adherent $member): array
+    public function getListActions(Adherent $member): array
     {
+        Analog::log(
+            static::class . '::getListActionsContents() is deprecated, please implement MemberActionProviderInterface',
+            Analog::WARNING
+        );
+        /** @phpstan-ignore staticMethod.notFound */
         return static::getListActionsContents($member);
     }
 
@@ -138,9 +140,15 @@ abstract class GalettePlugin
      * @param Adherent $member Current member
      *
      * @return array<int, string|array<string,mixed>>
+     * @deprecated 1.2.2
      */
-    public static function getDetailedActions(Adherent $member): array
+    public function getDetailedActions(Adherent $member): array
     {
+        Analog::log(
+            static::class . '::getDetailedActionsContents() is deprecated, please implement MemberActionProviderInterface',
+            Analog::WARNING
+        );
+        /** @phpstan-ignore staticMethod.notFound */
         return static::getDetailedActionsContents($member);
     }
 
@@ -148,51 +156,27 @@ abstract class GalettePlugin
      * Get member batch actions
      *
      * @return array<int, string|array<string,mixed>>
+     * @deprecated 1.2.2
      */
-    public static function getBatchActions(): array
+    public function getBatchActions(): array
     {
+        Analog::log(
+            static::class . '::getBatchActionsContents() is deprecated, please implement MemberActionProviderInterface',
+            Analog::WARNING
+        );
+        /** @phpstan-ignore staticMethod.notFound */
         return static::getBatchActionsContents();
     }
 
     /**
-     * Get actions contents
-     *
-     * @param Adherent $member Current member
-     *
-     * @return array<int, string|array<string,mixed>>
-     */
-    abstract public static function getListActionsContents(Adherent $member): array;
-
-    /**
-     * Get batch actions contents
-     *
-     * @return array<int, string|array<string,mixed>>
-     */
-    abstract public static function getBatchActionsContents(): array;
-
-    /**
-     * Get detailed actions contents
-     *
-     * @param Adherent $member Current member
-     *
-     * @return array<int, string|array<string,mixed>>
-     */
-    abstract public static function getDetailedActionsContents(Adherent $member): array;
-
-    /**
-     * Get news for this plugin
-     */
-    public function getNews(): ?Entry
-    {
-        //per default, plugins do not have news to display.
-        return null;
-    }
-
-    /**
-     * Is the plugin fully installed (including database, extra configuration, etc)?
+     * Is the plugin fully installed (including database, extra configuration, etc.)?
      */
     public function isInstalled(): bool
     {
+        Analog::log(
+            static::class . '::isInstalled() is deprecated, please implement InstallableInterface',
+            Analog::WARNING
+        );
         return true;
     }
 }

--- a/galette/lib/Galette/Core/Plugins.php
+++ b/galette/lib/Galette/Core/Plugins.php
@@ -110,7 +110,7 @@ class Plugins
                             //plugin is not compatible with that version of galette.
                             Analog::log(
                                 sprintf('Plugin %s is missing a _define.php and/or _routes.php '
-                                . 'files that are required.', $entry),
+                                    . 'files that are required.', $entry),
                                 Analog::WARNING
                             );
                             $this->setDisabled(self::DISABLED_MISS);
@@ -122,17 +122,20 @@ class Plugins
                             $this->setDisabled(self::DISABLED_EXPLICIT);
                         } else {
                             include $full_entry . '/_define.php';
+                            if ($this->moduleExists($entry)) {
+                                if (file_exists($full_entry . '/lib')) {
+                                    //set autoloader to PluginName.
+                                    $varname = $entry . 'Loader';
+                                    ${$varname} = new ClassLoader(
+                                        $this->getNamespace($entry),
+                                        $full_entry . '/lib'
+                                    );
+                                    ${$varname}->register();
+                                }
+                                $this->check();
+                            }
                             $this->id = null;
                             $this->mroot = null;
-                            //set autoloader to PluginName.
-                            if (isset($this->modules[$entry]) && file_exists($full_entry . '/lib')) {
-                                $varname = $entry . 'Loader';
-                                ${$varname} = new ClassLoader(
-                                    $this->getNamespace($entry),
-                                    $full_entry . '/lib'
-                                );
-                                ${$varname}->register();
-                            }
                         }
                     }
                 }
@@ -205,7 +208,7 @@ class Plugins
         if ($compver === null) {
             //plugin compatibility missing!
             Analog::log(
-                'Plugin ' . $name . ' does not contains mandatory version '
+                'Plugin "' . $name . '" does not contain mandatory version '
                 . 'compatibility information. Please contact the author.',
                 Analog::ERROR
             );
@@ -213,8 +216,8 @@ class Plugins
         } elseif (version_compare($compver, GALETTE_COMPAT_VERSION, '<')) {
             //plugin is not compatible with that version of galette.
             Analog::log(
-                'Plugin ' . $name . ' is known to be compatible with Galette '
-                . $compver . ' only, but you current installation require a '
+                'Plugin "' . $name . '" is known to be compatible with Galette '
+                . $compver . ' only, but you current installation requires a '
                 . 'plugin compatible with at least ' . GALETTE_COMPAT_VERSION,
                 Analog::WARNING
             );
@@ -231,6 +234,30 @@ class Plugins
                 'priority'      => $priority ?? 1000,
                 'route'         => $route
             ];
+        }
+    }
+
+    /**
+     * Post plugin initialization checks
+     */
+    private function check(): void
+    {
+        $plugin_class = $this->getClassName($this->id, true);
+        if (
+            !class_exists($plugin_class)
+            || !is_subclass_of($plugin_class, GalettePlugin::class)
+        ) {
+            //plugin is missing its mandatory class or does not extend GalettePlugin
+            Analog::log(
+                sprintf(
+                    'Plugin "%s" class "%s" is missing or it does not extend GalettePlugin.',
+                    $this->modules[$this->id]['name'],
+                    $plugin_class
+                ),
+                Analog::ERROR
+            );
+            unset($this->modules[$this->id]);
+            $this->setDisabled(self::DISABLED_MISS);
         }
     }
 

--- a/galette/lib/Galette/Core/Plugins/DashboardProviderInterface.php
+++ b/galette/lib/Galette/Core/Plugins/DashboardProviderInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Copyright © 2003-2026 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Galette\Core\Plugins;
+
+/**
+ * Dashboard provider interface
+ *
+ * @author Johan Cwiklinski <johan@x-tnd.be>
+ */
+interface DashboardProviderInterface
+{
+    /**
+     * Get plugins dashboards
+     *
+     * @return array<int, string|array<string,mixed>>
+     */
+    public function getDashboards(): array;
+
+    /**
+     * Get current logged-in user plugins dashboards
+     *
+     * @return array<int, string|array<string,mixed>>
+     */
+    public function getMyDashboards(): array;
+}

--- a/galette/lib/Galette/Core/Plugins/InstallableInterface.php
+++ b/galette/lib/Galette/Core/Plugins/InstallableInterface.php
@@ -21,51 +21,17 @@
 
 declare(strict_types=1);
 
-namespace GaletteNews;
-
-use Galette\Core\GalettePlugin;
-use Galette\Core\Plugins\NewsProviderInterface;
-use Galette\IO\News\Entry;
-use Galette\IO\News\Post;
-
-use function Safe\strtotime;
+namespace Galette\Core\Plugins;
 
 /**
- * Galette News plugin
+ * Installable plugin interface
  *
  * @author Johan Cwiklinski <johan@x-tnd.be>
  */
-
-class PluginGaletteNews extends GalettePlugin implements NewsProviderInterface
+interface InstallableInterface
 {
-    /**
-     * Get plugin news
-     */
-    public function getNews(): ?Entry
-    {
-        $posts = [
-            new Post(
-                title: 'A news',
-                date: date('Y-m-d H:i:s'),
-            ),
-            new Post(
-                title: 'Older news',
-                date: date('Y-m-d H:i:s', strtotime('-1 day')),
-            ),
-        ];
-
-        return new Entry(
-            title: 'Test plugin news',
-            posts: $posts,
-            position: 42
-        );
-    }
-
     /**
      * Is the plugin fully installed (including database, extra configuration, etc.)?
      */
-    public function isInstalled(): bool
-    {
-        return false;
-    }
+    public function isInstalled(): bool;
 }

--- a/galette/lib/Galette/Core/Plugins/MemberActionProviderInterface.php
+++ b/galette/lib/Galette/Core/Plugins/MemberActionProviderInterface.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Copyright © 2003-2026 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Galette\Core\Plugins;
+
+use Galette\Entity\Adherent;
+
+/**
+ * Action provider interface
+ *
+ * @author Johan Cwiklinski <johan@x-tnd.be>
+ */
+interface MemberActionProviderInterface
+{
+    /**
+     * Get member actions
+     *
+     * @param Adherent $member Current member
+     *
+     * @return array<int, string|array<string,mixed>>
+     */
+    public function getListActions(Adherent $member): array;
+
+    /**
+     * Get detailed member actions
+     *
+     * @param Adherent $member Current member
+     *
+     * @return array<int, string|array<string,mixed>>
+     */
+    public function getDetailedActions(Adherent $member): array;
+
+    /**
+     * Get member batch actions
+     *
+     * @return array<int, string|array<string,mixed>>
+     */
+    public function getBatchActions(): array;
+}

--- a/galette/lib/Galette/Core/Plugins/MenuProviderInterface.php
+++ b/galette/lib/Galette/Core/Plugins/MenuProviderInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Copyright © 2003-2026 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Galette\Core\Plugins;
+
+/**
+ * Menu provider interface
+ *
+ * @author Johan Cwiklinski <johan@x-tnd.be>
+ */
+interface MenuProviderInterface
+{
+    /**
+     * Get plugins menus
+     *
+     * @return array<string, string|array<string,mixed>>
+     */
+    public function getMenus(): array;
+
+    /**
+     * Get plugins public menus
+     *
+     * @return array<int, string|array<string,mixed>>
+     */
+    public function getPublicMenus(): array;
+}

--- a/galette/lib/Galette/Core/Plugins/NewsProviderInterface.php
+++ b/galette/lib/Galette/Core/Plugins/NewsProviderInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Copyright © 2003-2026 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Galette\Core\Plugins;
+
+use Galette\IO\News\Entry;
+
+/**
+ * News provider interface
+ *
+ * @author Johan Cwiklinski <johan@x-tnd.be>
+ */
+interface NewsProviderInterface
+{
+    /**
+     * Get news for this plugin
+     */
+    public function getNews(): ?Entry;
+}

--- a/tests/Galette/Core/Db.php
+++ b/tests/Galette/Core/Db.php
@@ -580,6 +580,10 @@ class Db extends BaseGaletteTestCase
     {
         $db = new \Galette\Core\Db();
         $db->convertToUTF();
+        $this->expectLogEntry(
+            \Analog\Analog::WARNING,
+            'Upgrading from 0.6 will soon be discontinued.'
+        );
     }
 
     /**

--- a/tests/Galette/Core/Db.php
+++ b/tests/Galette/Core/Db.php
@@ -828,4 +828,52 @@ class Db extends BaseGaletteTestCase
         $zdb->method('isPostgres')->willReturn(false);
         $this->assertSame($expected, $zdb->willMysqlImplicitCommit($query));
     }
+
+    /**
+     * Test isMissingTableException method
+     */
+    public function testIsMissingTableException(): void
+    {
+        $exception_thrown = false;
+        try {
+            $this->zdb->execute($this->zdb->select('non_existing_table'));
+        } catch (\PDOException $e) {
+            $exception_thrown = true;
+            $this->assertTrue($this->zdb->isMissingTableException($e));
+        }
+        $this->assertTrue($exception_thrown);
+
+        $warning = new \ArrayObject([
+            'Level' => 'Error',
+            'Code'  => 1146,
+            'Message' => "regex:/.*non_existing_table.*/i"
+        ]);
+        $this->expected_mysql_warnings[] = $warning;
+        $this->expectLogEntry(
+            \Analog\Analog::ERROR,
+            "non_existing_table"
+        );
+
+        $exception_thrown = false;
+        try {
+            $select = $this->zdb->select(\Galette\Core\Preferences::TABLE);
+            $select->where(['does_not_exists' => 'does_not_exists']);
+            $this->zdb->execute($select);
+        } catch (\PDOException $e) {
+            $exception_thrown = true;
+            $this->assertFalse($this->zdb->isMissingTableException($e));
+        }
+        $this->assertTrue($exception_thrown);
+
+        $warning = new \ArrayObject([
+            'Level' => 'Error',
+            'Code'  => 1054,
+            'Message' => "regex:/.*does_not_exists.*/i"
+        ]);
+        $this->expected_mysql_warnings[] = $warning;
+        $this->expectLogEntry(
+            \Analog\Analog::ERROR,
+            "does_not_exists"
+        );
+    }
 }

--- a/tests/Galette/Core/Db.php
+++ b/tests/Galette/Core/Db.php
@@ -562,7 +562,15 @@ class Db extends BaseGaletteTestCase
     public function testTableExists(): void
     {
         $this->assertTrue($this->zdb->tableExists('preferences'));
+        $this->expectLogEntry(
+            \Analog\Analog::WARNING,
+            'Galette\Core\Db::tableExists should not be used because of very poor performances.'
+        );
         $this->assertFalse($this->zdb->tableExists('does_not_exists'));
+        $this->expectLogEntry(
+            \Analog\Analog::WARNING,
+            'Galette\Core\Db::tableExists should not be used because of very poor performances.'
+        );
     }
 
     /**

--- a/tests/Galette/Core/Galette.php
+++ b/tests/Galette/Core/Galette.php
@@ -37,6 +37,7 @@ use function Safe\realpath;
 class Galette extends GaletteTestCase
 {
     protected int $seed = 20230324120838;
+    protected bool $load_plugins = true;
 
     /**
      * Test gitVersion

--- a/tests/Galette/Core/Plugins.php
+++ b/tests/Galette/Core/Plugins.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Galette\Tests\Core;
 
 use Galette\Tests\GaletteTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Plugins tests class
@@ -94,14 +95,44 @@ class Plugins extends GaletteTestCase
     }
 
     /**
+     * Data provider for disabled modules test
+     *
+     * @return array<int, array{module: string, cause: int}>
+     */
+    public static function disabledModulesProvider(): array
+    {
+        return [
+            [
+                'module' => 'plugin-disabled',
+                'cause' => \Galette\Core\Plugins::DISABLED_EXPLICIT],
+            [
+                'module' => 'plugin-unversionned',
+                'cause' =>  \Galette\Core\Plugins::DISABLED_COMPAT
+            ],
+            [
+                'module' => 'plugin-oldversion',
+                'cause' =>  \Galette\Core\Plugins::DISABLED_COMPAT
+            ],
+            [
+                'module' => 'plugin-news',
+                'cause' =>  \Galette\Core\Plugins::DISABLED_EXPLICIT
+            ],
+            [
+                'module' => 'plugin-noclass',
+                'cause' =>  \Galette\Core\Plugins::DISABLED_MISS
+            ]
+        ];
+    }
+
+    /**
      * Test disabled plugin
      */
-    public function testDisabledModules(): void
+    #[DataProvider('disabledModulesProvider')]
+    public function testDisabledModules(string $module, int $cause): void
     {
         $disabled_modules = $this->plugins->getDisabledModules();
-        $this->assertTrue(isset($disabled_modules['plugin-disabled']));
-        $this->assertTrue(isset($disabled_modules['plugin-unversionned']));
-        $this->assertTrue(isset($disabled_modules['plugin-oldversion']));
+        $this->assertTrue(isset($disabled_modules[$module]));
+        $this->assertSame($cause, $disabled_modules[$module]['cause']);
     }
 
     /**

--- a/tests/GaletteUpdate/Core/Install.php
+++ b/tests/GaletteUpdate/Core/Install.php
@@ -86,6 +86,11 @@ class Install extends BaseGaletteTestCase
 
         $this->assertTrue($exec);
         $this->assertSame(GALETTE_DB_VERSION, $this->zdb->getDbVersion());
+
+        $this->expectLogEntry(
+            \Analog\Analog::WARNING,
+            'Upgrading from 0.6 will soon be discontinued.'
+        );
     }
 
     /**

--- a/tests/lib/BaseGaletteTestCase.php
+++ b/tests/lib/BaseGaletteTestCase.php
@@ -274,8 +274,9 @@ abstract class BaseGaletteTestCase extends TestCase
         $logs = explode("localhost - ", $galette_log_var ?? '');
 
         $excluded_logs = [
-            'WARNING - Plugin plugin-oldversion',
-            'ERROR - Plugin Galette Unversionned'
+            'WARNING - Plugin "Galette Old Plugin" is known to be compatible with Galette 0.7.0 only',
+            'ERROR - Plugin "Galette Unversionned Plugin" does not contain mandatory version compatibility information',
+            'ERROR - Plugin "Galette Noclass Plugin" class "GaletteNoclassPlugin\PluginGalettePluginnoclass" is missing '
         ];
 
         foreach ($logs as $i => $log) {

--- a/tests/plugins/plugin-db/lib/GaletteDbPlugin/PluginGalettePlugdb.php
+++ b/tests/plugins/plugin-db/lib/GaletteDbPlugin/PluginGalettePlugdb.php
@@ -21,51 +21,20 @@
 
 declare(strict_types=1);
 
-namespace GaletteNews;
+namespace GaletteDbPlugin;
 
 use Galette\Core\GalettePlugin;
-use Galette\Core\Plugins\NewsProviderInterface;
-use Galette\IO\News\Entry;
-use Galette\IO\News\Post;
-
-use function Safe\strtotime;
 
 /**
- * Galette News plugin
- *
  * @author Johan Cwiklinski <johan@x-tnd.be>
  */
-
-class PluginGaletteNews extends GalettePlugin implements NewsProviderInterface
+class PluginGalettePlugdb extends GalettePlugin
 {
-    /**
-     * Get plugin news
-     */
-    public function getNews(): ?Entry
-    {
-        $posts = [
-            new Post(
-                title: 'A news',
-                date: date('Y-m-d H:i:s'),
-            ),
-            new Post(
-                title: 'Older news',
-                date: date('Y-m-d H:i:s', strtotime('-1 day')),
-            ),
-        ];
-
-        return new Entry(
-            title: 'Test plugin news',
-            posts: $posts,
-            position: 42
-        );
-    }
-
     /**
      * Is the plugin fully installed (including database, extra configuration, etc.)?
      */
     public function isInstalled(): bool
     {
-        return false;
+        return true;
     }
 }

--- a/tests/plugins/plugin-noclass/_define.php
+++ b/tests/plugins/plugin-noclass/_define.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Copyright © 2003-2026 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+/** @var \Galette\Core\Plugins $this */
+$this->register(
+    name: 'Galette Noclass Plugin',   //Name
+    desc: 'Test plugin no class',    //Short description
+    author: 'Johan Cwiklinski',      //Author
+    version: '1.0',                  //Version
+    compver: GALETTE_COMPAT_VERSION, //Galette compatible version
+    route: 'pluginnoclass',          //routing name
+    date: '2026-03-04',              //Release date
+    acls: [                          //Permissions needed
+    ]
+);

--- a/tests/plugins/plugin-noclass/_routes.php
+++ b/tests/plugins/plugin-noclass/_routes.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Copyright © 2003-2026 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);

--- a/tests/plugins/plugin-oldversion/_routes.php
+++ b/tests/plugins/plugin-oldversion/_routes.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Copyright © 2003-2026 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);

--- a/tests/plugins/plugin-test1/lib/GaletteTest1Plugin/PluginGalettePlugin1.php
+++ b/tests/plugins/plugin-test1/lib/GaletteTest1Plugin/PluginGalettePlugin1.php
@@ -21,51 +21,20 @@
 
 declare(strict_types=1);
 
-namespace GaletteNews;
+namespace GaletteTest1Plugin;
 
 use Galette\Core\GalettePlugin;
-use Galette\Core\Plugins\NewsProviderInterface;
-use Galette\IO\News\Entry;
-use Galette\IO\News\Post;
-
-use function Safe\strtotime;
 
 /**
- * Galette News plugin
- *
  * @author Johan Cwiklinski <johan@x-tnd.be>
  */
-
-class PluginGaletteNews extends GalettePlugin implements NewsProviderInterface
+class PluginGalettePlugin1 extends GalettePlugin
 {
-    /**
-     * Get plugin news
-     */
-    public function getNews(): ?Entry
-    {
-        $posts = [
-            new Post(
-                title: 'A news',
-                date: date('Y-m-d H:i:s'),
-            ),
-            new Post(
-                title: 'Older news',
-                date: date('Y-m-d H:i:s', strtotime('-1 day')),
-            ),
-        ];
-
-        return new Entry(
-            title: 'Test plugin news',
-            posts: $posts,
-            position: 42
-        );
-    }
-
     /**
      * Is the plugin fully installed (including database, extra configuration, etc.)?
      */
     public function isInstalled(): bool
     {
-        return false;
+        return true;
     }
 }

--- a/tests/plugins/plugin-test2/lib/GaletteTest2Plugin/PluginGalettePlugin2.php
+++ b/tests/plugins/plugin-test2/lib/GaletteTest2Plugin/PluginGalettePlugin2.php
@@ -21,51 +21,20 @@
 
 declare(strict_types=1);
 
-namespace GaletteNews;
+namespace GaletteTest2Plugin;
 
 use Galette\Core\GalettePlugin;
-use Galette\Core\Plugins\NewsProviderInterface;
-use Galette\IO\News\Entry;
-use Galette\IO\News\Post;
-
-use function Safe\strtotime;
 
 /**
- * Galette News plugin
- *
  * @author Johan Cwiklinski <johan@x-tnd.be>
  */
-
-class PluginGaletteNews extends GalettePlugin implements NewsProviderInterface
+class PluginGalettePlugin2 extends GalettePlugin
 {
-    /**
-     * Get plugin news
-     */
-    public function getNews(): ?Entry
-    {
-        $posts = [
-            new Post(
-                title: 'A news',
-                date: date('Y-m-d H:i:s'),
-            ),
-            new Post(
-                title: 'Older news',
-                date: date('Y-m-d H:i:s', strtotime('-1 day')),
-            ),
-        ];
-
-        return new Entry(
-            title: 'Test plugin news',
-            posts: $posts,
-            position: 42
-        );
-    }
-
     /**
      * Is the plugin fully installed (including database, extra configuration, etc.)?
      */
     public function isInstalled(): bool
     {
-        return false;
+        return true;
     }
 }


### PR DESCRIPTION
I will certainly make the Plugin class mandatory, for several reasons.

Current abstract class was designed for plugins with brings menus and dashboards; therefore there are many abstract methods to implement. This is not very interesting for plugins which do not provide those kind of features.
Using interfaces is probably a better way, so plugins developers can just choose which interfaces they implement.