### PR TITLE
Add e2e tests (Playwright)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,148 @@
+name: Galette E2E Tests
+
+on:
+  push:
+  pull_request:
+  # Enable manual run
+  workflow_dispatch:
+  # Run once a month
+  schedule:
+    - cron: '0 0 1 * *'
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    name: "E2E Playwright — ${{ github.event_name == 'schedule' && 'all browsers' || 'chromium' }} (postgres:17)"
+    env:
+      DB: pgsql
+      GALETTE_TESTS: 1
+
+    services:
+      # Label used to access the service container
+      db:
+        image: postgres:17
+        env:
+          POSTGRES_USER: galette_tests
+          POSTGRES_PASSWORD: g@l3tte
+          POSTGRES_DB: galette_tests
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.5"
+          tools: composer, pecl
+          coverage: none
+          extensions: apcu, pdo_pgsql
+          ini-values: apc.enable_cli=1
+
+      - name: Show versions
+        run: |
+          php --version
+          composer --version
+          echo "node $(node --version)"
+          echo "npm $(npm --version)"
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config -f composer.json cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: "${{ runner.os }}-composer-8.5-${{ hashFiles('**/composer.lock') }}"
+          restore-keys: |
+            ${{ runner.os }}-composer-8.5-
+            ${{ runner.os }}-composer-
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.npm
+          key: "${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}"
+          restore-keys: |
+            ${{ runner.os }}-npm-
+
+      - name: Semantic hash (assets)
+        id: semantic-hash
+        run: echo "semantichash=$(tar cf - --sort=name ./ui --mtime='UTC 2025-01-01' | sha1sum | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+
+      - name: Cache Galette built assets
+        uses: actions/cache@v5
+        with:
+          path: galette/webroot/themes/
+          key: "${{ runner.os }}-galette-${{ steps.semantic-hash.outputs.semantichash }}"
+
+      - name: Install dependencies (Composer + npm assets)
+        run: bin/install_deps
+
+      - name: Initialize test data
+        run: php tests/init_test_data.php
+
+      - name: Initialize Galette database (PostgreSQL)
+        run: |
+          bin/console galette:install -v \
+            --dbtype=pgsql \
+            --dbhost=localhost \
+            --dbname=galette_tests \
+            --dbuser=galette_tests \
+            --dbpass=g@l3tte \
+            --admin=${{ secrets.E2E_ADMIN_USER || 'admin' }} \
+            --password=${{ secrets.E2E_ADMIN_PASS || 'admin' }} \
+            --no-interaction
+        env:
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: 5432
+
+      - name: Start PHP built-in server
+        run: |
+          php -S 0.0.0.0:8080 -t galette/webroot tests/router_e2e.php &
+          # Wait for service being up
+          timeout 15 bash -c 'until curl -sf http://127.0.0.1:8080/login > /dev/null; do sleep 1; done'
+          echo "PHP server started"
+
+
+      - name: Install Playwright browsers
+        run: |
+          if [ "${{ github.event_name }}" == "schedule" ]; then
+            npx playwright install --with-deps chromium firefox
+          else
+            npx playwright install --with-deps chromium
+          fi
+
+      - name: Run E2E tests
+        run: |
+          if [ "${{ github.event_name }}" == "schedule" ]; then
+            npm run test:full
+          else
+            npm run test:chromium
+          fi
+        env:
+          E2E_BASE_URL: http://127.0.0.1:8080
+          E2E_ADMIN_USER: ${{ secrets.E2E_ADMIN_USER || 'admin' }}
+          E2E_ADMIN_PASS: ${{ secrets.E2E_ADMIN_PASS || 'admin' }}
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ dist/
 
 #local CS configuration files
 .php-cs-fixer.php
+
+playwright-report/
+test-results/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,26 @@ DB=mysql galette/vendor/bin/phpunit --test-suffix=.php \
   tests/Galette/
 ```
 
+### E2E Testing (Playwright)
+
+E2E tests use Playwright and require a running PHP built-in server.
+
+```bash
+# 1. Initialize test data
+php tests/init_test_data.php
+
+# 2. Set up test database (once)
+GALETTE_TESTS=1 DB=mysql bin/console galette:install ...
+
+# 3. Start the server (in a separate terminal or background)
+DB=mysql php -S 0.0.0.0:8080 -t galette/webroot tests/router_e2e.php
+
+# 4. Run tests
+npm run test:chromium
+```
+
+**CRITICAL:** Always use the `tests/router_e2e.php` router with `php -S` to ensure the correct test environment is loaded (session path, data path, etc.).
+
 ### Test Requirements
 
 - Database must be installed via `bin/console galette:install`

--- a/README.tests.md
+++ b/README.tests.md
@@ -1,0 +1,97 @@
+# Galette Testing Guide
+
+This document explains how to set up and run tests for Galette.
+
+## Setup
+
+1. **Install dependencies**:
+   ```bash
+   bin/install_deps
+   ```
+   This handles both PHP (Composer) and JavaScript (npm) dependencies and builds the initial assets.
+
+2. **Initialize test data (e2e)**:
+   ```bash
+   php tests/init_test_data.php
+   ```
+   This prepares the `tests/tests-data/` directory with necessary subfolders and permissions.
+
+   This is only required for e2e tests; PHPunit bootstrap file automatically call it.
+
+3. **Install Galette for testing**:
+   You must install Galette into the test configuration folder. Use the `GALETTE_TESTS=1` environment variable to target `tests/config/`.
+
+   **MySQL Example:**
+   ```bash
+   GALETTE_TESTS=1 DB=mysql bin/console galette:install \
+     --dbtype=mysql --dbhost=localhost --dbname=galette_tests \
+     --dbuser=galette_tests --dbpass=g@l3tte \
+     --admin=admin --password=admin --no-interaction
+   ```
+
+   **PostgreSQL Example:**
+   ```bash
+   GALETTE_TESTS=1 DB=pgsql bin/console galette:install \
+     --dbtype=pgsql --dbhost=localhost --dbname=galette_tests \
+     --dbuser=galette_tests --dbpass=g@l3tte \
+     --admin=admin --password=admin --no-interaction
+   ```
+
+Configuration is stored in `tests/config/<db>/config.inc.php`. You can use a `tests/config/<db>/local_config.inc.php` file to override settings.
+
+## Running PHPUnit Tests (Unit & Integration)
+
+PHPUnit tests require the `DB` environment variable.
+
+```bash
+# Run with MySQL
+DB=mysql galette/vendor/bin/phpunit --test-suffix=.php tests/Galette/
+
+# Run with PostgreSQL
+DB=pgsql galette/vendor/bin/phpunit --test-suffix=.php tests/Galette/
+```
+
+## Running E2E Tests (Playwright)
+
+See https://playwright.dev/docs/running-tests
+E2E tests require a running PHP built-in server configured for the test environment.
+
+1. **Start the PHP server**:
+   In a separate terminal (or in background), run:
+   ```bash
+   DB=pgsql php -S 0.0.0.0:8080 -t galette/webroot tests/router_e2e.php
+   ```
+   *Note: Use `DB=mysql` if you initialized a MySQL test database.*
+
+2. **Run Playwright tests**:
+   ```bash
+   # Install browsers (first time only)
+   npx playwright install --with-deps
+
+   # Run tests on Chromium only
+   npx playwright test --project=chromium
+   # Run tests on Firefox only
+   npx playwright test --project=firefox
+   # Run tests on all browsers
+   npm run test:full
+
+   # Run with UI mode (recommended for debugging)
+   npx playwright test --ui
+   ```
+
+## Cleanup
+
+To remove all generated test data (logs, sessions, uploads):
+```bash
+npm run test:clean
+```
+
+## Troubleshooting
+
+Ensure `tests/tests-data/` is writable.
+
+You can download Playwright test results and screenshots from GitHub Actions for debugging failed tests. 
+Extract the `test-results.zip` artifact from the latest CI run in a directory (say `/tmp/playwright-results`) and open the Playwright UI:
+```bash
+npx playwright show-report /tmp/playwright-results
+```

--- a/bin/console
+++ b/bin/console
@@ -33,6 +33,9 @@ if (!isset($basepath)) {
 }
 
 define('GALETTE_ENV', 'CLI');
+if (getenv('GALETTE_TESTS')) {
+    require_once __DIR__ . '/../tests/test_env.inc.php';
+}
 define('GALETTE_ROOT', realpath(__DIR__ . '/../galette/') . '/');
 
 //specific logfile for console

--- a/bin/install_deps
+++ b/bin/install_deps
@@ -2,6 +2,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../galette"
 composer install --prefer-dist --no-progress --optimize-autoloader --ignore-platform-reqs
 npm ci --prefer-offline --no-audit
-if [[ ! -d $DIR/webroot/themes ]]; then
+# Check if themes directory and main JS bundle exist
+if [[ ! -f $DIR/webroot/themes/default/ui/semantic.min.js ]] || [[ ! -f $DIR/webroot/assets/js/galette-main.bundle.min.js ]]; then
     npm run first-build
 fi

--- a/galette/includes/galette.inc.php
+++ b/galette/includes/galette.inc.php
@@ -189,10 +189,12 @@ if (!$installer && !defined('GALETTE_TESTS')) {
         /**
          * Set the path to the current theme templates
          */
-        define(
-            '_CURRENT_THEME_PATH',
-            GALETTE_THEMES_PATH . $preferences->pref_theme . '/'
-        );
+        if (!defined('_CURRENT_THEME_PATH')) {
+            define(
+                '_CURRENT_THEME_PATH',
+                GALETTE_THEMES_PATH . $preferences->pref_theme . '/'
+            );
+        }
 
         if (!defined('GALETTE_THEME')) {
             define(

--- a/galette/includes/galette.inc.php
+++ b/galette/includes/galette.inc.php
@@ -107,7 +107,7 @@ if (!defined('GALETTE_ADAPTATIVE_CARDS')) {
 if (!isset($_COOKIE['show_galette_dashboard'])) {
     setcookie(
         'show_galette_dashboard',
-        'true',
+        '1',
         [
             'expires'   => time() + 31536000, //valid for a year
             'path'      => '/'

--- a/galette/webroot/index.php
+++ b/galette/webroot/index.php
@@ -26,7 +26,9 @@ if (!defined('GALETTE_BASE_PATH')) {
     define('GALETTE_BASE_PATH', '../'); //@phpstan-ignore theCodingMachineSafe.function
 }
 
-define('GALETTE_ROOT', __DIR__ . '/../'); //@phpstan-ignore theCodingMachineSafe.function
+if (!defined('GALETTE_ROOT')) {
+    define('GALETTE_ROOT', __DIR__ . '/../'); //@phpstan-ignore theCodingMachineSafe.function
+}
 
 // check PHP version
 require_once GALETTE_ROOT . 'includes/sys_config/versions.inc.php';

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "twemoji-emojis": "^14.1.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "browser-sync": "^3.0.4",
         "clean-css": "^5.3.3",
         "css-loader": "^7.1.4",
@@ -698,6 +699,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
@@ -6038,6 +6055,53 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/plugin-error": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
@@ -9027,6 +9091,15 @@
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "optional": true
+    },
+    "@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "requires": {
+        "playwright": "1.58.2"
+      }
     },
     "@rollup/rollup-linux-x64-gnu": {
       "version": "4.56.0",
@@ -13035,6 +13108,31 @@
       "requires": {
         "pinkie": "^2.0.0"
       }
+    },
+    "playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "requires": {
+        "fsevents": "2.3.2",
+        "playwright-core": "1.58.2"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true
     },
     "plugin-error": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "twemoji-emojis": "^14.1.0"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.1",
         "@playwright/test": "^1.58.2",
         "browser-sync": "^3.0.4",
         "clean-css": "^5.3.3",
@@ -61,6 +62,19 @@
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.2.0.tgz",
       "integrity": "sha512-E09FiIft46CmH5Qnjb0wsW54/YQd69LsxeKUOWawmws1XWvyFGURnAChH0mlr7YPFR1ofwvUQfcL0J3lMxXqPA==",
       "license": "MIT"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.1.tgz",
+      "integrity": "sha512-mKEfoUIB1MkVTht0BGZFXtSAEKXMJoDkyV5YZ9jbBmZCcWDz71tegNsdTkIN8zc/yMi5Gm2kx7Z5YQ9PfWNAWw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@fastify/busboy": {
       "version": "2.0.0",
@@ -1400,6 +1414,16 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.2.tgz",
+      "integrity": "sha512-byD6KPdvo72y/wj2T/4zGEvvlis+PsZsn/yPS3pEO+sFpcrqRpX/TJCxvVaEsNeMrfQbCr7w163YqoD9IYwHXw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/b4a": {
@@ -8581,6 +8605,15 @@
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.2.0.tgz",
       "integrity": "sha512-E09FiIft46CmH5Qnjb0wsW54/YQd69LsxeKUOWawmws1XWvyFGURnAChH0mlr7YPFR1ofwvUQfcL0J3lMxXqPA=="
     },
+    "@axe-core/playwright": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.1.tgz",
+      "integrity": "sha512-mKEfoUIB1MkVTht0BGZFXtSAEKXMJoDkyV5YZ9jbBmZCcWDz71tegNsdTkIN8zc/yMi5Gm2kx7Z5YQ9PfWNAWw==",
+      "dev": true,
+      "requires": {
+        "axe-core": "~4.11.1"
+      }
+    },
     "@fastify/busboy": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
@@ -9638,6 +9671,12 @@
         "picocolors": "^1.0.0",
         "postcss-value-parser": "^4.2.0"
       }
+    },
+    "axe-core": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.2.tgz",
+      "integrity": "sha512-byD6KPdvo72y/wj2T/4zGEvvlis+PsZsn/yPS3pEO+sFpcrqRpX/TJCxvVaEsNeMrfQbCr7w163YqoD9IYwHXw==",
+      "dev": true
     },
     "b4a": {
       "version": "1.6.7",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "author": "Johan Cwiklinski <johan AT x-tnd DOT be>",
   "license": "GPL-3.0-or-later",
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.1",
     "@playwright/test": "^1.58.2",
     "browser-sync": "^3.0.4",
     "clean-css": "^5.3.3",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,15 @@
     "first-build": "npm run fomantic-install && npx gulp",
     "build": "npx gulp",
     "rebuild": "npm run install-deps && npx gulp",
-    "watch": "npx gulp watch"
+    "watch": "npx gulp watch",
+    "test": "playwright test --project \"chromium\"",
+    "test:full": "playwright test",
+    "test:chromium": "playwright test --project \"chromium\"",
+    "test:firefox": "playwright test --project \"firefox\"",
+    "test:headed": "playwright test --headed",
+    "test:debug": "playwright test --debug",
+    "test:clean": "rm -rf tests/tests-data/*",
+    "report": "playwright show-report"
   },
   "repository": {
     "type": "git",
@@ -22,6 +30,7 @@
   "author": "Johan Cwiklinski <johan AT x-tnd DOT be>",
   "license": "GPL-3.0-or-later",
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "browser-sync": "^3.0.4",
     "clean-css": "^5.3.3",
     "css-loader": "^7.1.4",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e/specs',
+
+  // Timeout per test
+  timeout: 30_000,
+
+  // Report: generated HTML in playwright-report/
+  reporter: [['html', { open: 'never' }], ['list']],
+
+  use: {
+    // Priority: --base-url (CLI) > E2E_BASE_URL (env) > default value
+    baseURL: process.env.E2E_BASE_URL ?? 'http://127.0.0.1:8080',
+
+    // Screenshot and trace only on failure
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+
+    // Capture console logs for better debugging on CI
+    // video: 'on-first-retry',
+
+    // Browser lang aligned with default Galette lang
+    locale: 'fr-FR',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+  ],
+});

--- a/tests/Galette/Controllers/GaletteController.php
+++ b/tests/Galette/Controllers/GaletteController.php
@@ -110,7 +110,7 @@ class GaletteController extends GaletteRoutingTestCase
     public function testDashboard(): void
     {
         $request = $this->createRequest('dashboard');
-        $request = $request->withCookieParams(['show_galette_dashboard' => 'true']);
+        $request = $request->withCookieParams(['show_galette_dashboard' => '1']);
 
         //Refused from authenticate middleware
         $test_response = $this->app->handle($request);

--- a/tests/TestsBootstrap.php
+++ b/tests/TestsBootstrap.php
@@ -28,76 +28,8 @@ declare(strict_types=1);
  */
 
 
-if (!isset($basepath)) {
-    if (file_exists('../galette/index.php')) {
-        $basepath = '../galette/';
-    } elseif (file_exists('galette/index.php')) {
-        $basepath = 'galette/';
-    } else {
-        die('Unable to define GALETTE_BASE_PATH :\'(');
-    }
-}
-
-$db = 'mysql';
-$dbenv = (string)getenv('DB');
-if (
-    $dbenv === 'pgsql'
-    || str_starts_with($dbenv, 'postgres')
-) {
-    $db = 'pgsql';
-}
-
-$testenv = getenv('TESTENV');
-$fail_env = $testenv === 'FAIL';
-if ($fail_env !== false) {
-    $db .= '_fail';
-}
-
-define('GALETTE_CONFIG_PATH', __DIR__ . '/config/' . $db . '/');
-define('GALETTE_BASE_PATH', $basepath);
-define('GALETTE_TESTS', true);
-define('GALETTE_TESTS_PATH', __DIR__);
-define('GALETTE_MODE', 'PROD');
-if (!defined('GALETTE_PLUGINS_PATH')) {
-    define('GALETTE_PLUGINS_PATH', GALETTE_TESTS_PATH . '/plugins/');
-}
-define('GALETTE_TPL_SUBDIR', 'templates/default/');
-define('GALETTE_THEME', 'themes/default/');
-define('GALETTE_DATA_PATH', GALETTE_TESTS_PATH . '/tests-data/');
-define('GALETTE_CACHE_DIR', GALETTE_DATA_PATH . 'cache/');
-if (is_dir(GALETTE_DATA_PATH)) {
-    $files = new RecursiveIteratorIterator(
-        new RecursiveDirectoryIterator(
-            GALETTE_DATA_PATH,
-            RecursiveDirectoryIterator::SKIP_DOTS
-        ),
-        RecursiveIteratorIterator::CHILD_FIRST
-    );
-
-    foreach ($files as $fileinfo) {
-        $todo = ($fileinfo->isDir() ? 'rmdir' : 'unlink');
-        $todo($fileinfo->getRealPath());
-    }
-    rmdir(GALETTE_DATA_PATH);
-}
-
-mkdir(GALETTE_DATA_PATH);
-$directories = [
-    'logs',
-    'templates_c',
-    'cache',
-    'exports',
-    'imports',
-    'photos',
-    'attachments',
-    'files',
-    'tempimages',
-    'plugins',
-    'documents'
-];
-foreach ($directories as $directory) {
-    mkdir(GALETTE_DATA_PATH . $directory);
-}
+require_once __DIR__ . '/test_env.inc.php';
+require_once __DIR__ . '/init_test_data.php';
 
 //TODO: maybe is there a better way to do
 $logfile = 'galette_tests'; //phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable -- used in galette.inc.php
@@ -135,6 +67,7 @@ $emitter = $container->get(\League\Event\EventDispatcher::class);
 /** @var \Galette\Core\I18n $i18n */
 $i18n->changeLanguage('en_US');
 
+/** @var string $testenv - declared in test_env.inc.php */
 if (
     $testenv !== 'UPDATE'
     && $testenv !== 'FAIL'

--- a/tests/e2e/fixtures/a11y.fixture.ts
+++ b/tests/e2e/fixtures/a11y.fixture.ts
@@ -1,0 +1,55 @@
+/*!
+ * Copyright © 2007-2024 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @category  Javascript
+ * @package   Galette
+ *
+ * @author Johan Cwiklinski <johan@x-tnd.be>
+ * @copyright 2007-2024 The Galette Team
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GPL License 3.0 or (at your option) any later version
+ * @link      https://galette.eu
+ */
+
+import AxeBuilder from '@axe-core/playwright';
+import type { Page } from '@playwright/test';
+
+/**
+ * Builds a pre-configured AxeBuilder instance for WCAG 2.0 A/AA audits.
+ *
+ * To suppress a known false positive, call .disableRules(['rule-id']) on the
+ * returned builder and document the reason in a comment at the call site.
+ */
+export function axeBuilder(page: Page): AxeBuilder {
+  return new AxeBuilder({ page }).withTags(['wcag21a', 'wcag21aa', 'RGAAv4']);
+}
+
+/**
+ * Formats axe violations into a readable one-line-per-violation summary,
+ * used as the assertion failure message so the developer can triage quickly
+ * without parsing raw JSON.
+ */
+export function formatViolations(
+  violations: Array<{ id: string; description: string; nodes: unknown[] }>
+): string {
+  if (violations.length === 0) {
+    return 'No violations';
+  }
+  return violations
+    .map(v => `[${v.id}] ${v.description} — ${v.nodes.length} node(s)`)
+    .join('\n');
+}

--- a/tests/e2e/fixtures/auth.fixture.ts
+++ b/tests/e2e/fixtures/auth.fixture.ts
@@ -1,0 +1,62 @@
+/*!
+ * Copyright © 2007-2024 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @category  Javascript
+ * @package   Galette
+ *
+ * @author Johan Cwiklinski <johan@x-tnd.be>
+ * @copyright 2007-2024 The Galette Team
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GPL License 3.0 or (at your option) any later version
+ * @link      https://galette.eu
+ * @since     Available since 0.7dev - 2007-10-06
+ */
+
+import { test as base, Page } from '@playwright/test';
+
+/**
+ * Login fixture for E2E tests.
+ * Reusable login fixture for all test suites.
+ *
+ * Usage in a spec:
+ *   import { test } from '../fixtures/auth.fixture';
+ *   test('my test', async ({ loggedInPage }) => { ... });
+ */
+
+type AuthFixtures = {
+  loggedInPage: Page;
+};
+
+export const test = base.extend<AuthFixtures>({
+  loggedInPage: async ({ page }, use) => {
+    const login    = process.env.E2E_ADMIN_USER ?? 'admin';
+    const password = process.env.E2E_ADMIN_PASS ?? 'admin';
+
+    await page.goto('/login');
+    await page.locator('input#login').fill(login);
+    await page.locator('input#password').fill(password);
+    await page.locator('input[type="submit"]').click();
+
+    // Wait for dashboard redirection
+    await page.waitForURL('/dashboard');
+
+    // Provide the authenticated page to test
+    await use(page);
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/tests/e2e/specs/a11y.spec.ts
+++ b/tests/e2e/specs/a11y.spec.ts
@@ -1,0 +1,70 @@
+/*!
+ * Copyright © 2007-2024 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @category  Javascript
+ * @package   Galette
+ *
+ * @author Johan Cwiklinski <johan@x-tnd.be>
+ * @copyright 2007-2024 The Galette Team
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GPL License 3.0 or (at your option) any later version
+ * @link      https://galette.eu
+ */
+
+import { test as base, expect } from '@playwright/test';
+import { test } from '../fixtures/auth.fixture';
+import { axeBuilder, formatViolations } from '../fixtures/a11y.fixture';
+
+/**
+ * Suite: Accessibility (axe-core, WCAG 2.0 A + AA)
+ */
+test.describe('Accessibility', () => {
+
+  base.describe('Login page', () => {
+
+    base.test('Login page should have no WCAG 2.x A/AA violations', async ({ page }) => {
+      await page.goto('/login');
+      await page.locator('form.ui.form').waitFor({ state: 'visible' });
+
+      const results = await axeBuilder(page).analyze();
+
+      expect(results.violations, formatViolations(results.violations)).toEqual([]);
+    });
+
+  });
+
+  test.describe('Dashboard page', () => {
+
+    test('Dashboard page should have no WCAG 2.x A/AA violations', async ({ loggedInPage: page }) => {
+      await page.locator('#main-activities').waitFor({ state: 'visible' });
+
+      // Dismiss the "admin password" warning toast before scanning to avoid
+      // flakiness caused by animation-phase contrast readings.
+      const warningToast = page.locator('.ui.toast.warning');
+      if (await warningToast.isVisible()) {
+        await page.locator('.ui.toast.warning i[role="button"]').click();
+        await warningToast.waitFor({ state: 'hidden' });
+      }
+
+      const results = await axeBuilder(page).analyze();
+
+      expect(results.violations, formatViolations(results.violations)).toEqual([]);
+    });
+
+  });
+
+});

--- a/tests/e2e/specs/auth.spec.ts
+++ b/tests/e2e/specs/auth.spec.ts
@@ -1,0 +1,93 @@
+/*!
+ * Copyright © 2007-2024 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @category  Javascript
+ * @package   Galette
+ *
+ * @author Johan Cwiklinski <johan@x-tnd.be>
+ * @copyright 2007-2024 The Galette Team
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GPL License 3.0 or (at your option) any later version
+ * @link      https://galette.eu
+ * @since     Available since 0.7dev - 2007-10-06
+ */
+
+import { test as base, expect } from '@playwright/test';
+import { test } from '../fixtures/auth.fixture';
+
+/**
+ * Suite: Authentication
+ */
+test.describe('Login page', () => {
+
+  base.describe('Display', () => {
+    base.test('Login page display', async ({ page }) => {
+      await page.goto('/login');
+
+      await expect(page).toHaveURL(/\/login/);
+      await expect(page).toHaveTitle(/Galette/i);
+      await expect(page.locator('form.ui.form')).toBeVisible();
+      await expect(page.locator('input#login')).toBeVisible();
+      await expect(page.locator('input#password')).toBeVisible();
+      await expect(page.locator('input[type="submit"]')).toBeVisible();
+    });
+
+    base.test('Shows an error message if credentials are invalid', async ({ page }) => {
+      await page.goto('/login');
+
+      await page.locator('input#login').fill('non_existing_user');
+      await page.locator('input#password').fill('wrong_password');
+      await page.locator('input[type="submit"]').click();
+
+      await expect(page).toHaveURL(/\/login/);
+      // Wait for the error toast to appear. It can take some time in CI.
+      await expect(page.locator('.ui.toast.error')).toBeVisible({ timeout: 10000 });
+    });
+  });
+
+  test.describe('Login/Logout', () => {
+
+    test('Redirects to dashboard when logged-in', async ({ loggedInPage: page }) => {
+      // Fixture already proceeds login
+      await expect(page).toHaveURL('/dashboard');
+
+      // User password is 'admin', so the warning toast should be displayed.
+      // Increase timeout for slow CI environments.
+      await expect(page.locator('.ui.toast.warning')).toBeVisible({ timeout: 10000 });
+
+      // Dashboard shows "Activities" section
+      await expect(page.locator('#main-activities')).toBeVisible();
+    });
+
+    test('Logout and redirect to login page', async ({ loggedInPage: page }) => {
+      //hide toast
+      await expect(page.locator('.ui.toast.warning')).toBeVisible();
+      await page.locator('.ui.toast.warning i[role="button"]').click();
+      await expect(page.locator('.ui.toast.warning')).toBeHidden();
+
+      // /!\ There are 2 logout links in the page, one is visible, the other is not (mobile menu).
+      const logoutLink = page.locator('[href*="/logout"]')
+      await logoutLink.last().click();
+
+      // After logout, return to login page
+      await expect(page).toHaveURL('/login');
+      await expect(page.locator('input#login')).toBeVisible();
+    });
+
+  });
+
+});

--- a/tests/init_test_data.php
+++ b/tests/init_test_data.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Copyright © 2003-2026 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Initialize tests-data directory
+ */
+
+require_once __DIR__ . '/test_env.inc.php';
+
+if (is_dir(GALETTE_DATA_PATH)) {
+    $files = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator(
+            GALETTE_DATA_PATH,
+            RecursiveDirectoryIterator::SKIP_DOTS
+        ),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+
+    foreach ($files as $fileinfo) {
+        $todo = ($fileinfo->isDir() ? 'rmdir' : 'unlink');
+        $todo($fileinfo->getRealPath());
+    }
+    rmdir(GALETTE_DATA_PATH); //@phpstan-ignore theCodingMachineSafe.function
+}
+
+mkdir(GALETTE_DATA_PATH); //@phpstan-ignore theCodingMachineSafe.function
+$directories = [
+    'logs',
+    'templates_c',
+    'cache',
+    'exports',
+    'imports',
+    'photos',
+    'attachments',
+    'files',
+    'tempimages',
+    'plugins',
+    'documents'
+];
+foreach ($directories as $directory) {
+    mkdir(GALETTE_DATA_PATH . $directory); //@phpstan-ignore theCodingMachineSafe.function
+}

--- a/tests/router_e2e.php
+++ b/tests/router_e2e.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Copyright © 2003-2026 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Router script for the built-in PHP server in e2e testing context.
+ *
+ * Usage:
+ *   php -S 0.0.0.0:8080 -t galette/webroot tests/router_e2e.php
+ *
+ * Role:
+ *   - Defines the test environment before Galette bootstrap
+ *   - Handles clean URLs by delegating to index.php when the requested URI doesn't match an existing file in the webroot
+ */
+
+require_once __DIR__ . '/test_env.inc.php';
+
+// Galette root
+$docRoot = realpath(__DIR__ . '/../galette/webroot'); //@phpstan-ignore theCodingMachineSafe.function
+
+// Requested path, without query string
+$uri = urldecode(parse_url((string)$_SERVER['REQUEST_URI'], PHP_URL_PATH)); //@phpstan-ignore theCodingMachineSafe.function
+
+// If the file exists in the webroot (static or specific PHP like installer.php)
+if ($uri !== '/' && file_exists($docRoot . $uri)) {
+    if (str_ends_with($uri, '.php')) {
+        require $docRoot . $uri;
+        exit;
+    }
+    // Let the PHP server serve the static file
+    return false;
+}
+
+// Everything else (Slim routes) → Galette entry point
+require $docRoot . '/index.php';

--- a/tests/test_env.inc.php
+++ b/tests/test_env.inc.php
@@ -1,0 +1,145 @@
+<?php
+
+/**
+ * Copyright © 2003-2026 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Shared test environment configuration
+ */
+//@phpstan-ignore theCodingMachineSafe.function
+if (!defined('GALETTE_ROOT')) {
+    define('GALETTE_ROOT', realpath(__DIR__ . '/../galette') . '/'); //@phpstan-ignore theCodingMachineSafe.function,theCodingMachineSafe.function
+}
+
+// Determine database type
+$db = 'mysql';
+$dbenv = (string)getenv('DB');
+if (
+    $dbenv === 'pgsql'
+    || str_starts_with($dbenv, 'postgres')
+) {
+    $db = 'pgsql';
+}
+
+$testenv = getenv('TESTENV');
+$fail_env = $testenv === 'FAIL';
+if ($fail_env !== false) {
+    $db .= '_fail';
+}
+
+// Base path
+if (!isset($basepath)) {
+    if (file_exists('../galette/index.php')) {
+        $basepath = '../galette/';
+    } elseif (file_exists('galette/index.php')) {
+        $basepath = 'galette/';
+    } elseif (file_exists(__DIR__ . '/../galette/index.php')) {
+        $basepath = __DIR__ . '/../galette/';
+    } else {
+        $basepath = './galette/';
+    }
+}
+
+if (!defined('GALETTE_BASE_PATH')) {
+    // Force current dir if we are served via php built-in server (e2e context)
+    if (php_sapi_name() === 'cli-server') { //@phpstan-ignore theCodingMachineSafe.function
+        define('GALETTE_BASE_PATH', './'); //@phpstan-ignore theCodingMachineSafe.function
+    } else {
+        define('GALETTE_BASE_PATH', $basepath); //@phpstan-ignore theCodingMachineSafe.function
+    }
+}
+
+// DO NOT define GALETTE_TESTS if we are in a web context (e2e)
+// as it prevents the application from initializing and running Slim.
+if (php_sapi_name() !== 'cli-server' && !defined('GALETTE_TESTS')) { //@phpstan-ignore theCodingMachineSafe.function
+    define('GALETTE_TESTS', true); //@phpstan-ignore theCodingMachineSafe.function
+}
+
+if (!defined('GALETTE_TESTS_PATH')) {
+    define('GALETTE_TESTS_PATH', __DIR__); //@phpstan-ignore theCodingMachineSafe.function
+}
+
+if (!defined('GALETTE_CONFIG_PATH')) {
+    define('GALETTE_CONFIG_PATH', GALETTE_TESTS_PATH . '/config/' . $db . '/'); //@phpstan-ignore theCodingMachineSafe.function
+}
+
+if (!defined('GALETTE_DATA_PATH')) {
+    define('GALETTE_DATA_PATH', GALETTE_TESTS_PATH . '/tests-data/'); //@phpstan-ignore theCodingMachineSafe.function
+}
+
+// Ensure tests-data directory exists
+if (!is_dir(GALETTE_DATA_PATH)) {
+    mkdir(GALETTE_DATA_PATH, 0o777, true); //@phpstan-ignore theCodingMachineSafe.function
+}
+
+// Map of directories to ensure they exist (as they might be used in realpath())
+$test_directories = [
+    'GALETTE_LOGS_PATH'         => 'logs/',
+    'GALETTE_CACHE_DIR'         => 'cache/',
+    'GALETTE_EXPORTS_PATH'       => 'exports/',
+    'GALETTE_IMPORTS_PATH'       => 'imports/',
+    'GALETTE_PHOTOS_PATH'        => 'photos/',
+    'GALETTE_DOCUMENTS_PATH'     => 'documents/',
+    'GALETTE_ATTACHMENTS_PATH'   => 'attachments/',
+    'GALETTE_FILES_PATH'         => 'files/',
+    'GALETTE_TEMPIMAGES_PATH'    => 'tempimages/',
+    'GALETTE_PLUGINS_DATA_PATH'  => 'plugins/',
+    'GALETTE_TPL_CACHE_DIR'      => 'templates_c/',
+    'GALETTE_SESSIONS_PATH'     => 'sessions/'
+];
+
+foreach ($test_directories as $constant => $suffix) {
+    $path = GALETTE_DATA_PATH . $suffix;
+    if (!defined($constant)) {
+        define($constant, $path); //@phpstan-ignore theCodingMachineSafe.function
+    }
+    if (!is_dir($path)) {
+        mkdir($path, 0o777, true); //@phpstan-ignore theCodingMachineSafe.function
+    }
+}
+
+// Force session path to be local for tests to avoid issues on CI
+if (php_sapi_name() === 'cli-server') { //@phpstan-ignore theCodingMachineSafe.function
+    ini_set('session.save_path', GALETTE_SESSIONS_PATH); //@phpstan-ignore theCodingMachineSafe.function,constant.notFound
+}
+
+if (!defined('GALETTE_PLUGINS_PATH')) {
+    define('GALETTE_PLUGINS_PATH', GALETTE_TESTS_PATH . '/plugins/'); //@phpstan-ignore theCodingMachineSafe.function
+}
+
+if (!defined('GALETTE_MODE')) {
+    define('GALETTE_MODE', 'PROD'); //@phpstan-ignore theCodingMachineSafe.function
+}
+
+if (!defined('GALETTE_TPL_SUBDIR')) {
+    define('GALETTE_TPL_SUBDIR', 'templates/default/'); //@phpstan-ignore theCodingMachineSafe.function
+}
+
+if (!defined('GALETTE_THEME')) {
+    define('GALETTE_THEME', 'themes/default/'); //@phpstan-ignore theCodingMachineSafe.function
+}
+
+if (!defined('_CURRENT_THEME_PATH')) {
+    define( //@phpstan-ignore theCodingMachineSafe.function
+        '_CURRENT_THEME_PATH',
+        GALETTE_ROOT . 'webroot/themes/default/'
+    );
+}


### PR DESCRIPTION
Add the base, and CI for E2E tests, with [Playwright](https://playwright.dev/).

Tests are designed to be ran on firefox and chromium; there is a crontab once per month. 
On every PR, only the chromium tests are ran (because I use Firefox :)).