### PR TITLE
Add Playwright accessibility tests (axe-core, WCAG 2.2 A/AA, RGAA)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "twemoji-emojis": "^14.1.0"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.1",
         "@playwright/test": "^1.58.2",
         "browser-sync": "^3.0.4",
         "clean-css": "^5.3.3",
@@ -61,6 +62,19 @@
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.2.0.tgz",
       "integrity": "sha512-E09FiIft46CmH5Qnjb0wsW54/YQd69LsxeKUOWawmws1XWvyFGURnAChH0mlr7YPFR1ofwvUQfcL0J3lMxXqPA==",
       "license": "MIT"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.1.tgz",
+      "integrity": "sha512-mKEfoUIB1MkVTht0BGZFXtSAEKXMJoDkyV5YZ9jbBmZCcWDz71tegNsdTkIN8zc/yMi5Gm2kx7Z5YQ9PfWNAWw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@fastify/busboy": {
       "version": "2.0.0",
@@ -1400,6 +1414,16 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.2.tgz",
+      "integrity": "sha512-byD6KPdvo72y/wj2T/4zGEvvlis+PsZsn/yPS3pEO+sFpcrqRpX/TJCxvVaEsNeMrfQbCr7w163YqoD9IYwHXw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/b4a": {
@@ -8581,6 +8605,15 @@
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.2.0.tgz",
       "integrity": "sha512-E09FiIft46CmH5Qnjb0wsW54/YQd69LsxeKUOWawmws1XWvyFGURnAChH0mlr7YPFR1ofwvUQfcL0J3lMxXqPA=="
     },
+    "@axe-core/playwright": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.1.tgz",
+      "integrity": "sha512-mKEfoUIB1MkVTht0BGZFXtSAEKXMJoDkyV5YZ9jbBmZCcWDz71tegNsdTkIN8zc/yMi5Gm2kx7Z5YQ9PfWNAWw==",
+      "dev": true,
+      "requires": {
+        "axe-core": "~4.11.1"
+      }
+    },
     "@fastify/busboy": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
@@ -9638,6 +9671,12 @@
         "picocolors": "^1.0.0",
         "postcss-value-parser": "^4.2.0"
       }
+    },
+    "axe-core": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.2.tgz",
+      "integrity": "sha512-byD6KPdvo72y/wj2T/4zGEvvlis+PsZsn/yPS3pEO+sFpcrqRpX/TJCxvVaEsNeMrfQbCr7w163YqoD9IYwHXw==",
+      "dev": true
     },
     "b4a": {
       "version": "1.6.7",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "author": "Johan Cwiklinski <johan AT x-tnd DOT be>",
   "license": "GPL-3.0-or-later",
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.1",
     "@playwright/test": "^1.58.2",
     "browser-sync": "^3.0.4",
     "clean-css": "^5.3.3",

--- a/tests/e2e/fixtures/a11y.fixture.ts
+++ b/tests/e2e/fixtures/a11y.fixture.ts
@@ -1,0 +1,55 @@
+/*!
+ * Copyright © 2007-2024 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @category  Javascript
+ * @package   Galette
+ *
+ * @author Johan Cwiklinski <johan@x-tnd.be>
+ * @copyright 2007-2024 The Galette Team
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GPL License 3.0 or (at your option) any later version
+ * @link      https://galette.eu
+ */
+
+import AxeBuilder from '@axe-core/playwright';
+import type { Page } from '@playwright/test';
+
+/**
+ * Builds a pre-configured AxeBuilder instance for WCAG 2.0 A/AA audits.
+ *
+ * To suppress a known false positive, call .disableRules(['rule-id']) on the
+ * returned builder and document the reason in a comment at the call site.
+ */
+export function axeBuilder(page: Page): AxeBuilder {
+  return new AxeBuilder({ page }).withTags(['wcag21a', 'wcag21aa', 'RGAAv4']);
+}
+
+/**
+ * Formats axe violations into a readable one-line-per-violation summary,
+ * used as the assertion failure message so the developer can triage quickly
+ * without parsing raw JSON.
+ */
+export function formatViolations(
+  violations: Array<{ id: string; description: string; nodes: unknown[] }>
+): string {
+  if (violations.length === 0) {
+    return 'No violations';
+  }
+  return violations
+    .map(v => `[${v.id}] ${v.description} — ${v.nodes.length} node(s)`)
+    .join('\n');
+}

--- a/tests/e2e/specs/a11y.spec.ts
+++ b/tests/e2e/specs/a11y.spec.ts
@@ -1,0 +1,70 @@
+/*!
+ * Copyright © 2007-2024 The Galette Team
+ *
+ * This file is part of Galette (https://galette.eu).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @category  Javascript
+ * @package   Galette
+ *
+ * @author Johan Cwiklinski <johan@x-tnd.be>
+ * @copyright 2007-2024 The Galette Team
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GPL License 3.0 or (at your option) any later version
+ * @link      https://galette.eu
+ */
+
+import { test as base, expect } from '@playwright/test';
+import { test } from '../fixtures/auth.fixture';
+import { axeBuilder, formatViolations } from '../fixtures/a11y.fixture';
+
+/**
+ * Suite: Accessibility (axe-core, WCAG 2.0 A + AA)
+ */
+test.describe('Accessibility', () => {
+
+  base.describe('Login page', () => {
+
+    base.test('Login page should have no WCAG 2.x A/AA violations', async ({ page }) => {
+      await page.goto('/login');
+      await page.locator('form.ui.form').waitFor({ state: 'visible' });
+
+      const results = await axeBuilder(page).analyze();
+
+      expect(results.violations, formatViolations(results.violations)).toEqual([]);
+    });
+
+  });
+
+  test.describe('Dashboard page', () => {
+
+    test('Dashboard page should have no WCAG 2.x A/AA violations', async ({ loggedInPage: page }) => {
+      await page.locator('#main-activities').waitFor({ state: 'visible' });
+
+      // Dismiss the "admin password" warning toast before scanning to avoid
+      // flakiness caused by animation-phase contrast readings.
+      const warningToast = page.locator('.ui.toast.warning');
+      if (await warningToast.isVisible()) {
+        await page.locator('.ui.toast.warning i[role="button"]').click();
+        await warningToast.waitFor({ state: 'hidden' });
+      }
+
+      const results = await axeBuilder(page).analyze();
+
+      expect(results.violations, formatViolations(results.violations)).toEqual([]);
+    });
+
+  });
+
+});


### PR DESCRIPTION
Introduce @axe-core/playwright to audit the login and dashboard pages against WCAG 2.0 A/AA rules. Violations are reported with a readable summary (rule ID, description, node count) to ease triage.

A shared a11y.fixture.ts provides the pre-configured AxeBuilder and the formatViolations helper for reuse in future specs.