### PR TITLE
Enable wcag21aa & RGAAv4 A11y checks

### DIFF
--- a/galette/lib/Galette/Controllers/Crud/ContributionsController.php
+++ b/galette/lib/Galette/Controllers/Crud/ContributionsController.php
@@ -130,7 +130,7 @@ class ContributionsController extends CrudController
             $ext_membership = $this->preferences->pref_membership_ext;
         }
         $params['pref_membership_ext'] = $ext_membership;
-        $params['autocomplete'] = true;
+        $params['autocomplete_options'] = true;
         $params['mode'] = ($ajax ? 'ajax' : '');
 
         // display page

--- a/galette/lib/Galette/Controllers/Crud/MembersController.php
+++ b/galette/lib/Galette/Controllers/Crud/MembersController.php
@@ -141,19 +141,19 @@ class MembersController extends CrudController
             $response,
             'pages/member_form.html.twig',
             [
-                'page_title'        => _T("Subscription"),
-                'parent_tpl'        => 'public_page.html.twig',
-                'member'            => $member,
-                'self_adh'          => true,
-                'autocomplete'      => true,
-                'osocials'          => new Social($this->zdb),
+                'page_title'           => _T("Subscription"),
+                'parent_tpl'           => 'public_page.html.twig',
+                'member'               => $member,
+                'self_adh'             => true,
+                'autocomplete_options' => true,
+                'osocials'             => new Social($this->zdb),
                 // pseudo random int
-                'time'              => time(),
-                'titles_list'       => $titles->getList(),
-                'fieldsets'         => $form_elements['fieldsets'],
-                'hidden_elements'   => $form_elements['hiddens'],
+                'time'                 => time(),
+                'titles_list'          => $titles->getList(),
+                'fieldsets'            => $form_elements['fieldsets'],
+                'hidden_elements'      => $form_elements['hiddens'],
                 //self_adh specific
-                'gaptcha'           => $gaptcha
+                'gaptcha'              => $gaptcha
             ] + $params
         );
         return $response;
@@ -1095,7 +1095,7 @@ class MembersController extends CrudController
             'pages/member_form.html.twig',
             [
                 'parent_tpl'        => 'page.html.twig',
-                'autocomplete'      => true,
+                'autocomplete_options'      => true,
                 'page_title'        => $title,
                 'member'            => $member,
                 'self_adh'          => false,

--- a/galette/lib/Galette/Controllers/Crud/TransactionsController.php
+++ b/galette/lib/Galette/Controllers/Crud/TransactionsController.php
@@ -185,7 +185,6 @@ class TransactionsController extends ContributionsController
             'filters'   => $m->getFilters(),
             'count'     => $m->getCount()
         ];
-        $params['autocomplete'] = true;
 
         if (count($members)) {
             $params['members']['list'] = $members;

--- a/galette/templates/default/components/form.html.twig
+++ b/galette/templates/default/components/form.html.twig
@@ -106,7 +106,6 @@
                         {% endif %}
                         {% if entry.field_id == 'email_adh' %}
                             {% set size = "30" %}
-                            {% set autocomplete = "new-password" %}
                         {% endif %}
                         {% if entry.field_id == 'fingerprint' %}
                             {% set size = "40" %}

--- a/galette/templates/default/components/form.html.twig
+++ b/galette/templates/default/components/form.html.twig
@@ -106,6 +106,7 @@
                         {% endif %}
                         {% if entry.field_id == 'email_adh' %}
                             {% set size = "30" %}
+                            {% set autocomplete = "new-password" %}
                         {% endif %}
                         {% if entry.field_id == 'fingerprint' %}
                             {% set size = "40" %}

--- a/galette/templates/default/components/forms/captcha.html.twig
+++ b/galette/templates/default/components/forms/captcha.html.twig
@@ -30,7 +30,6 @@
     {% set tip = _T("This field is required trying to avoid registration spam. We are sorry for the inconvennience.") %}
     {% set component_class = "field" %}
     {% set elt_class = "required" %}
-    {% set autocomplete = "new-password" %}
     {{ parent() }}
 {% endblock %}
 

--- a/galette/templates/default/components/forms/captcha.html.twig
+++ b/galette/templates/default/components/forms/captcha.html.twig
@@ -30,6 +30,7 @@
     {% set tip = _T("This field is required trying to avoid registration spam. We are sorry for the inconvennience.") %}
     {% set component_class = "field" %}
     {% set elt_class = "required" %}
+    {% set autocomplete = "new-password" %}
     {{ parent() }}
 {% endblock %}
 

--- a/galette/templates/default/components/forms/input.html.twig
+++ b/galette/templates/default/components/forms/input.html.twig
@@ -68,10 +68,10 @@
                     {% if required is defined and required == true %} required="required"{% endif %}
                     {% if readonly is defined and readonly == true %} readonly="readonly"{% endif %}
                     {% if disabled is defined and disabled == true %} disabled="disabled"{% endif %}
-                    {% if title is defined %} title="{{ title }}"{% endif %}
+                    {% if title is defined and title is not empty %} title="{{ title }}"{% endif %}
                     {% if maxlength is defined %} maxlength="{{ maxlength }}"{% endif %}
                     {% if elt_class is defined %} class="{{ elt_class }}"{% endif %}
-                    {% if autocomplete is defined %} autocomplete="{{ autocomplete }}"{% endif %}
+                    {% if autocomplete is defined and autocomplete is not empty %} autocomplete="{{ autocomplete }}"{% endif %}
                     {% if autofocus is defined %} autofocus{% endif %}
                     {% if size is defined %} size="{{ size }}"{% endif %}
                     {% if checked is defined and checked == true %} checked{% endif %}

--- a/galette/templates/default/components/forms/password.html.twig
+++ b/galette/templates/default/components/forms/password.html.twig
@@ -37,7 +37,7 @@
         required: entry.required,
         disabled: entry.disabled,
         label: _T("Password confirmation:"),
-        autocomplete: "off",
+        autocomplete: "new-password",
         elt_class: "labelalign",
         value: null,
     }

--- a/galette/templates/default/components/forms/search.html.twig
+++ b/galette/templates/default/components/forms/search.html.twig
@@ -25,7 +25,6 @@
         required: entry.required,
         disabled: entry.disabled,
         label: entry.label,
-        autocomplete: "off",
         search_id: entry.field_id ~ '_field',
         elt_class: 'prompt'
     }

--- a/galette/templates/default/components/forms/search.html.twig
+++ b/galette/templates/default/components/forms/search.html.twig
@@ -25,6 +25,7 @@
         required: entry.required,
         disabled: entry.disabled,
         label: entry.label,
+        autocomplete: "off",
         search_id: entry.field_id ~ '_field',
         elt_class: 'prompt'
     }

--- a/galette/templates/default/components/forms/textarea.html.twig
+++ b/galette/templates/default/components/forms/textarea.html.twig
@@ -32,10 +32,10 @@
         rows="{{ rows ?? 6 }}"
         {% if required is defined and required == true %} required="required"{% endif %}
         {% if disabled is defined and disabled == true %} disabled="disabled"{% endif %}
-        {% if title is defined %} title="{{ title }}"{% endif %}
+        {% if title is defined and title is not empty %} title="{{ title }}"{% endif %}
         {% if maxlength is defined %} maxlength="{{ maxlength }}"{% endif %}
         {% if elt_class is defined %} class="{{ elt_class }}"{% endif %}
-        {% if autocomplete is defined %} autocomplete="{{ autocomplete }}"{% endif %}
-        {% if size is defined %} size="{{ size }}"{% endif %}
+        {% if autocomplete is defined and autocomplete is not empty %} autocomplete="{{ autocomplete }}"{% endif %}
+        {% if size is defined and size is not empty %} size="{{ size }}"{% endif %}
         >{% if value is not same as(null) %}{{ value }}{% endif %}</textarea><br/>
 {% endblock %}

--- a/galette/templates/default/elements/edit_dynamic_fields.html.twig
+++ b/galette/templates/default/elements/edit_dynamic_fields.html.twig
@@ -68,33 +68,34 @@
                     <td class="center actions_row collapsing">
                         <a
                             href="{{ url_for('editDynamicField', {'form_name': form_name, 'id': field.getId()}) }}"
-                            class="action single-edit"
+                            class="action single-edit icon-only"
                         >
-                            <i class="ui user edit blue icon tooltip" aria-hidden="true"></i>
-                            <span class="ui special popup">{{ _T("Edit '%s' field")|replace({'%s': field.getName()}) }}</span>
+                            <i class="ui user edit blue icon" aria-hidden="true"></i>
+                            <span class="visually-hidden">{{ _T("Edit '%s' field")|replace({'%s': field.getName()}) }}</span>
                         </a>
                         <a
                             href="{{ url_for('dynamicTranslations', {'text_orig': field.getName(false)}) }}"
-                            class="action single-translate"
+                            class="action single-translate icon-only"
                         >
-                            <i class="ui language grey icon tooltip" aria-hidden="true"></i>
-                            <span class="ui special popup">{{ _T("Translate '%s' field")|replace({'%s': field.getName()}) }}</span>
+                            <i class="ui language grey icon" aria-hidden="true"></i>
+                            <span class="visually-hidden">{{ _T("Translate '%s' field")|replace({'%s': field.getName()}) }}</span>
                         </a>
                         <a
                             href="{{ url_for('removeDynamicField', {'form_name': form_name, 'id': field.getId()}) }}"
-                            class="delete"
+                            class="delete icon-only"
                         >
-                            <i class="ui trash red icon tooltip" aria-hidden="true"></i>
-                            <span class="ui special popup">{{ _T("Delete '%s' field")|replace({'%s': field.getName()}) }}</span>
+                            <i class="ui trash red icon" aria-hidden="true"></i>
+                            <span class="visually-hidden">{{ _T("Delete '%s' field")|replace({'%s': field.getName()}) }}</span>
                         </a>
     {% if field.getIndex() == 1 %}
                         <i class="ui icon">&nbsp;</i>
     {% else %}
                         <a
                             href="{{ url_for('moveDynamicField', {'form_name': form_name, 'direction': 'up', 'id': field.getId()}) }}"
+                            class="icon-only"
                         >
-                            <i class="ui caret up grey icon tooltip" aria-hidden="true"></i>
-                            <span class="ui special popup">{{ _T("Move up '%s' field")|replace({'%s': field.getName()}) }}</span>
+                            <i class="ui caret up grey icon" aria-hidden="true"></i>
+                            <span class="visually-hidden">{{ _T("Move up '%s' field")|replace({'%s': field.getName()}) }}</span>
                         </a>
     {% endif %}
     {% if field.getIndex() == fields_list|length %}
@@ -102,9 +103,10 @@
     {% else %}
                         <a
                             href="{{ url_for('moveDynamicField', {'form_name': form_name, 'direction': 'down', 'id': field.getId()}) }}"
+                            class="icon-only"
                         >
-                            <i class="ui caret down grey icon tooltip" aria-hidden="true"></i>
-                            <span class="ui special popup">{{ _T("Move down '%s' field")|replace({'%s': field.getName()}) }}</span>
+                            <i class="ui caret down grey icon" aria-hidden="true"></i>
+                            <span class="visually-hidden">{{ _T("Move down '%s' field")|replace({'%s': field.getName()}) }}</span>
                         </a>
     {% endif %}
                     </td>

--- a/galette/templates/default/elements/edit_socials.html.twig
+++ b/galette/templates/default/elements/edit_socials.html.twig
@@ -52,6 +52,7 @@
                         </div>
                     </div>
                     <div class="field">
+                        <label for="social_new_value_1" class="visually-hidden">{{ _T("Social network") }}</label>
                         <input type="text" name="social_new_value_1" id="social_new_value_1" value="" size="50" class="value"/>
                     </div>
                 </div>

--- a/galette/templates/default/elements/edit_socials.html.twig
+++ b/galette/templates/default/elements/edit_socials.html.twig
@@ -37,9 +37,9 @@
         {% endfor %}
             {% if socials|length() > 0 %}<div class="ui divider"></div>{% endif %}
             <div class="field addsocial">
-                <label>{{ _T("Add new social network") }}</label>
                 <div class="combo-social fields">
                     <div class="field">
+                        <label for="social_new_type_1">{{ _T("Add new social network") }}</label>
                         <div id="social_new_type_1" class="jsonly search-dropdown socials-dropdown ui input">
                             <input id="social_new_type_input_1" type="hidden" name="social_new_type_1" value="">
                             <i class="jsonly displaynone dropdown icon" aria-hidden="true"></i>

--- a/galette/templates/default/elements/group.html.twig
+++ b/galette/templates/default/elements/group.html.twig
@@ -89,7 +89,7 @@
             <div class="active content field">
                 {% if group %}
                     {% if login.isAdmin() or login.isStaff() %}
-                    <a href="#" class="jsonly disabled ui labeled icon button" id="btnmanagers_small">
+                    <a href="#" class="jsonly ui labeled icon button" id="btnmanagers_small">
                         <i class="user shield icon" aria-hidden="true"></i>
                         {{ _T("Manage managers") }}
                     </a>
@@ -109,7 +109,7 @@
             <div class="active content field">
                 {% if group %}
                     {% if login.isAdmin() or login.isStaff() %}
-                    <a href="#" class="jsonly disabled ui labeled icon button" id="btnusers_small">
+                    <a href="#" class="jsonly ui labeled icon button" id="btnusers_small">
                         <i class="user icon" aria-hidden="true"></i>
                         {{ _T("Manage members") }}
                     </a>

--- a/galette/templates/default/elements/group.html.twig
+++ b/galette/templates/default/elements/group.html.twig
@@ -89,7 +89,7 @@
             <div class="active content field">
                 {% if group %}
                     {% if login.isAdmin() or login.isStaff() %}
-                    <a href="#" class="jsonly ui labeled icon button" id="btnmanagers_small">
+                    <a href="#" class="jsonly disabled ui labeled icon button" id="btnmanagers_small">
                         <i class="user shield icon" aria-hidden="true"></i>
                         {{ _T("Manage managers") }}
                     </a>
@@ -109,7 +109,7 @@
             <div class="active content field">
                 {% if group %}
                     {% if login.isAdmin() or login.isStaff() %}
-                    <a href="#" class="jsonly ui labeled icon button" id="btnusers_small">
+                    <a href="#" class="jsonly disabled ui labeled icon button" id="btnusers_small">
                         <i class="user icon" aria-hidden="true"></i>
                         {{ _T("Manage members") }}
                     </a>

--- a/galette/templates/default/elements/group_persons.html.twig
+++ b/galette/templates/default/elements/group_persons.html.twig
@@ -81,9 +81,10 @@
                                 <td class="actions_row">
                                     <a
                                             href="{{ url_for("impersonate", {"id": person.id}) }}"
+                                            class="icon-only"
                                     >
                                         <i class="ui user secret grey icon tooltip" aria-hidden="true"></i>
-                                        <span class="ui special popup">{{ _T("Log in as %membername")|replace({"%membername": person.sname}) }}</span>
+                                        <span class="visually-hidden">{{ _T("Log in as %membername")|replace({"%membername": person.sname}) }}</span>
                                     </a>
                                 </td>
                             </tr>

--- a/galette/templates/default/elements/group_persons.html.twig
+++ b/galette/templates/default/elements/group_persons.html.twig
@@ -29,7 +29,9 @@
                                     {{ _T("Nickname") }}
                                 </th>
                                 {% if login.isSuperAdmin() %}
-                                <th>&nbsp;</th>
+                                <th class="collapsing">
+                                    {{ _T("Actions") }}
+                                </th>
                                 {% endif %}
                             </tr>
                         </thead>
@@ -78,7 +80,7 @@
                                 </td>
                                 <td data-col-label="{{ _T("Nickname") }}">{{ person.nickname|escape }}</td>
     {% if login.isSuperAdmin() %}
-                                <td class="actions_row">
+                                <td class="actions_row collapsing">
                                     <a
                                             href="{{ url_for("impersonate", {"id": person.id}) }}"
                                             class="icon-only"

--- a/galette/templates/default/elements/js/choose_social.js.twig
+++ b/galette/templates/default/elements/js/choose_social.js.twig
@@ -50,9 +50,12 @@ $(function(){
         $(this).parents('.addsocial').find ('.combo-social:last')
             .clone() // copy
             .insertAfter('#social .combo-social:last') // where
-            .find('.socials-dropdown').attr('id', 'social_new_type_' + _newindex).dropdown('clear')
+            .find("[id$='_formLabel']").attr('id', 'social_new_type_' + _newindex + '_formLabel').attr('for', 'social_new_type_' + _newindex).addClass('visually-hidden')
+            .parent().find('.socials-dropdown').attr('id', 'social_new_type_' + _newindex).dropdown('clear')
             .find('input:not(.search)').attr('id', 'social_new_type_input_' + _newindex).attr('name', 'social_new_type_' + _newindex)
+            .parent().find('input.search').attr('aria-labelledby', 'social_new_type_' + _newindex + '_formLabel')
             .parent().parent().parent().find('input.value').attr('id', 'social_new_value_' + _newindex).attr('name', 'social_new_value_' + _newindex).val('')
+            .parent().find('label.visually-hidden').attr('for', 'social_new_value_' + _newindex)
         ;
 
         _dropdownSocials();

--- a/galette/templates/default/elements/navigation/navigation_aside.html.twig
+++ b/galette/templates/default/elements/navigation/navigation_aside.html.twig
@@ -47,10 +47,10 @@
     </nav>
 
     <div class="ui basic fitted segment">
-        <div class="ui toggle mini checkbox">
+        <div class="ui toggle mini checkbox icon-only">
             <input type="checkbox" name="compactmenu" id="compactmenu" class="hidden"{% if login.getCompactMenu() %} checked="checked"{% endif %}>
-            <label for="compactmenu"{% if login.getCompactMenu() %} class="tooltip" data-html="{{ _T("Compact menu") }}"{% endif %}>
-                {% if not login.getCompactMenu() %}{{ _T("Compact menu") }}{% endif %}
+            <label for="compactmenu">
+                <span{% if login.getCompactMenu() %} class="visually-hidden"{% endif %}>{{ _T("Compact menu") }}</span>
             </label>
         </div>
     </div>

--- a/galette/templates/default/elements/scripts.html.twig
+++ b/galette/templates/default/elements/scripts.html.twig
@@ -134,7 +134,7 @@
                 _compactMenu();
     {% endif %}
 
-    {% if autocomplete_options %}
+    {% if autocomplete is defined %}
                 $('#ville_adh_field, #lieu_naissance_field').search({
                     apiSettings: {
                         url: '{{ url_for('suggestTown', {'term': '{query}'}) }}',

--- a/galette/templates/default/elements/scripts.html.twig
+++ b/galette/templates/default/elements/scripts.html.twig
@@ -134,7 +134,7 @@
                 _compactMenu();
     {% endif %}
 
-    {% if autocomplete is defined %}
+    {% if autocomplete_options is defined %}
                 $('#ville_adh_field, #lieu_naissance_field').search({
                     apiSettings: {
                         url: '{{ url_for('suggestTown', {'term': '{query}'}) }}',

--- a/galette/templates/default/elements/scripts.html.twig
+++ b/galette/templates/default/elements/scripts.html.twig
@@ -134,7 +134,7 @@
                 _compactMenu();
     {% endif %}
 
-    {% if autocomplete %}
+    {% if autocomplete_options %}
                 $('#ville_adh_field, #lieu_naissance_field').search({
                     apiSettings: {
                         url: '{{ url_for('suggestTown', {'term': '{query}'}) }}',

--- a/galette/templates/default/macros.twig
+++ b/galette/templates/default/macros.twig
@@ -131,8 +131,7 @@
 {% macro drawListAction(title, route, icon, extra_class) %}
     <a
             href="{{ url_for(route.name, route.args|default([])) }}"
-            class="{{ extra_class|default('') }} tooltip"
-            title="{{ title }}"
+            class="{{ extra_class|default('') }} icon-only"
     >
         <i class="ui {{ icon }} icon" aria-hidden="true"></i>
         <span class="visually-hidden">{{ title }}</span>

--- a/galette/templates/default/pages/404.html.twig
+++ b/galette/templates/default/pages/404.html.twig
@@ -28,13 +28,15 @@
             <header class="ui basic center aligned segment">
                 <img src="{{ url_for('logo') }}" width="{{ logo.getOptimalWidth() }}" height="{{ logo.getOptimalHeight() }}" alt="[ Galette ]" />
             </header>
-            <div class="ui red message">
-                <h2 class="ui center aligned header">{{ _T("Page not found") }}</h2>
-            </div>
-            <div class="ui basic fitted center aligned segment">
-                <p class="ui large text">{{ _T("Sorry, the page you are looking for could not be found.") }}</p>
-            </div>
-            <nav class="ui basic center aligned segment">
+            <main>
+                <div class="ui red message">
+                    <h1 class="ui center aligned header">{{ _T("Page not found") }}</h1>
+                </div>
+                <div class="ui basic fitted center aligned segment">
+                    <p class="ui large text">{{ _T("Sorry, the page you are looking for could not be found.") }}</p>
+                </div>
+            </main>
+            <nav class="ui basic center aligned segment" role="navigation">
                 <a href="{{ url_for('slash') }}" class="ui labeled icon primary button">
                     <i class="home icon" aria-hidden="true"></i>
                     {{ _T("Home") }}

--- a/galette/templates/default/pages/advanced_search.html.twig
+++ b/galette/templates/default/pages/advanced_search.html.twig
@@ -236,8 +236,7 @@
                     <a
                         href="#"
                         id="addbutton_g"
-                        class="ui tiny compact icon green button tooltip"
-                        title="{{ _T('Add new group search criteria') }}"
+                        class="ui tiny compact icon green button icon-only"
                     >
                         <i class="plus icon" aria-hidden="true"></i>
                         <span class="visually-hidden">{{ _T('Add new group search criteria') }}</span>
@@ -245,7 +244,8 @@
                 </div>
                 <div class="active content">
                     <div class="field">
-                        <select name="groups_logical_operator" class="operator_selector ui search dropdown">
+                        <label for="groups_logical_operator" class="visually-hidden">{{ _T('Logical operator') }}</label>
+                        <select id="groups_logical_operator" name="groups_logical_operator" class="operator_selector ui search dropdown">
                           <option value="{{ constant("Galette\\Filters\\AdvancedMembersList::OP_AND") }}"{% if filters.groups_search_log_op == constant("Galette\\Filters\\AdvancedMembersList::OP_AND") %} selected="selected"{% endif %}>{{ _T('In all selected groups') }}</option>
                           <option value="{{ constant("Galette\\Filters\\AdvancedMembersList::OP_OR") }}"{% if filters.groups_search_log_op == constant("Galette\\Filters\\AdvancedMembersList::OP_OR") %} selected="selected"{% endif %}>{{ _T('In any of selected groups') }}</option>
                         </select>
@@ -258,7 +258,8 @@
                                     <i class="arrows alternate icon" aria-hidden="true"></i>
                                 </div>
                                 <div>
-                                    <select name="groups_search[]" class="group_selector ui search dropdown">
+                                    <label for="groups_search_{{ loop.index }}" class="visually-hidden">{{ _T('Group') }}</label>
+                                    <select id="groups_search_{{ loop.index }}" name="groups_search[]" class="group_selector ui search dropdown">
                                         <option value="">{{ _T('Select a group') }}</option>
                         {% for group in filter_groups_options %}
                                         <option value="{{ group.getId() }}"{% if gs.group == group.getId() %} selected="selected"{% endif %}>{{ group.getName() }}</option>
@@ -266,8 +267,7 @@
                                     </select>
                                     <a
                                         href="#"
-                                        class="ui small compact red icon button filtered fright tooltip delete delcriteria"
-                                        title="{{ _T('Remove criteria') }}"
+                                        class="ui small compact red icon button filtered fright delete delcriteria icon-only"
                                     >
                                         <i class="trash alt icon" aria-hidden="true"></i>
                                         <span class="visually-hidden">{{ _T('Remove criteria') }}</span>
@@ -439,8 +439,7 @@
                         <a
                             href="#"
                             id="addbutton"
-                            class="ui tiny compact icon green button tooltip"
-                            title="{{ _T('Add new free search criteria') }}"
+                            class="ui tiny compact icon green button icon-only"
                         >
                             <i class="plus icon" aria-hidden="true"></i>
                             <span class="visually-hidden">{{ _T('Add new free search criteria') }}</span>
@@ -455,11 +454,13 @@
                                         <i class="arrows alternate icon" aria-hidden="true"></i>
                                     </div>
                                     <div class="inline fields">
-                                        <select name="free_logical_operator[]" class="operator_selector ui selection dropdown">
+                                        <label for="free_logical_operator_{{ loop.index }}" class="visually-hidden">{{ _T('Logical operator') }}</label>
+                                        <select id="free_logical_operator_{{ loop.index }}" name="free_logical_operator[]" class="operator_selector ui selection dropdown">
                                             <option value="{{ constant("Galette\\Filters\\AdvancedMembersList::OP_AND") }}"{% if fs.log_op == constant("Galette\\Filters\\AdvancedMembersList::OP_AND") %} selected="selected"{% endif %}>{{ _T('and') }}</option>
                                             <option value="{{ constant("Galette\\Filters\\AdvancedMembersList::OP_OR") }}"{% if fs.log_op == constant("Galette\\Filters\\AdvancedMembersList::OP_OR") %} selected="selected"{% endif %}>{{ _T('or') }}</option>
                                         </select>
-                                        <div class="field_selector ui search selection dropdown origselect">
+                                        <label for="free_field_selector_{{ loop.index }}" class="visually-hidden">{{ _T('Logical operator') }}</label>
+                                        <div id="free_field_selector_{{ loop.index }}" class="field_selector ui search selection dropdown origselect">
                                             <input type="hidden" name="free_field[]" value="{{ fs.field }}">
                                             <i class="dropdown icon"></i>
                                             <div class="text">{{ _T('Select a field') }}</div>
@@ -509,12 +510,14 @@
                                         </div>
                                         <div class="data inline fields">
                                             <input type="hidden" name="free_type[]" value="{% if cur_field is not null %}{{ cur_field.getType() }}{% endif %}"/>
+                                            <label for="free_query_operator_{{ loop.index }}" class="visually-hidden">{{ _T('Query operator') }}</label>
     {% if cur_field is not null and (get_class(cur_field) == "Galette\\DynamicFields\\Choice" or type == constant("Galette\\DynamicFields\\DynamicField::CHOICE")) %}
-                                            <select name="free_query_operator[]" class="free_operator ui selection dropdown">
+                                            <select id="free_query_operator_{{ loop.index }}" name="free_query_operator[]" class="free_operator ui selection dropdown">
                                                 <option value="{{ constant("Galette\\Filters\\AdvancedMembersList::OP_EQUALS") }}"{% if fs.qry_op == constant("Galette\\Filters\\AdvancedMembersList::OP_EQUALS") %} selected="selected"{% endif %}>{{ _T('is') }}</option>
                                                 <option value="{{ constant("Galette\\Filters\\AdvancedMembersList::OP_NOT_EQUALS") }}"{% if fs.qry_op == constant("Galette\\Filters\\AdvancedMembersList::OP_NOT_EQUALS") %} selected="selected"{% endif %}>{{ _T('is not') }}</option>
                                             </select>
-                                            <select name="free_text[]" class="free_text ui search dropdown">
+                                            <label for="free_text_{{ loop.index }}" class="visually-hidden">{{ _T('Value') }}</label>
+                                            <select id="free_text_{{ loop.index }}" name="free_text[]" class="free_text ui search dropdown">
         {% if cur_field is not null and get_class(cur_field) == "Galette\\DynamicFields\\Choice" %}
             {% for key, value in cur_field.getValues() %}
                                                 <option value="{{ key }}"{% if key == fs.search %} selected="selected"{% endif %}>{{ value }}</option>
@@ -526,20 +529,21 @@
         {% endif %}
                                             </select>
     {% elseif cur_field is not null and (get_class(cur_field) == "Galette\\DynamicFields\\Date" or type == constant("Galette\\DynamicFields\\DynamicField::DATE")) %}
-                                            <select name="free_query_operator[]" class="free_operator ui selection dropdown">
+                                            <select id="free_query_operator_{{ loop.index }}" name="free_query_operator[]" class="free_operator ui selection dropdown">
                                                 <option value="{{ constant("Galette\\Filters\\AdvancedMembersList::OP_EQUALS") }}"{% if fs.qry_op == constant("Galette\\Filters\\AdvancedMembersList::OP_EQUALS") %} selected="selected"{% endif %}>{{ _T('is') }}</option>
                                                 <option value="{{ constant("Galette\\Filters\\AdvancedMembersList::OP_BEFORE") }}"{% if fs.qry_op == constant("Galette\\Filters\\AdvancedMembersList::OP_BEFORE") %} selected="selected"{% endif %}>{{ _T('before') }}</option>
                                                 <option value="{{ constant("Galette\\Filters\\AdvancedMembersList::OP_AFTER") }}"{% if fs.qry_op == constant("Galette\\Filters\\AdvancedMembersList::OP_AFTER") %} selected="selected"{% endif %}>{{ _T('after') }}</option>
                                             </select>
-                                            <input type="text" name="free_text[]" value="{{ fs.search|date(_T('Y-m-d')) }}" class="modif_date" maxlength="10" size="10" placeholder="{{ _T('yyyy-mm-dd format') }}"/>
+                                            <label for="free_text_{{ loop.index }}" class="visually-hidden">{{ _T('Date') }}</label>
+                                            <input id="free_text_{{ loop.index }}" type="text" name="free_text[]" value="{{ fs.search|date(_T('Y-m-d')) }}" class="modif_date" maxlength="10" size="10" placeholder="{{ _T('yyyy-mm-dd format') }}"/>
     {% elseif cur_field is not null and (get_class(cur_field) == "Galette\\DynamicFields\\Boolean" or type == constant("Galette\\DynamicFields\\DynamicField::BOOLEAN")) %}
-                                            <select name="free_query_operator[]" class="free_operator ui selection dropdown">
+                                            <select id="free_query_operator_{{ loop.index }}" name="free_query_operator[]" class="free_operator ui selection dropdown">
                                                 <option value="{{ constant("Galette\\Filters\\AdvancedMembersList::OP_EQUALS") }}"{% if fs.qry_op == constant("Galette\\Filters\\AdvancedMembersList::OP_EQUALS") %} selected="selected"{% endif %}>{{ _T('is') }}</option>
                                             </select>
-                                            <input type="radio" name="free_text[]" id="free_text_yes" value="1"{% if fs.search == 1 %} checked="checked"{% endif %}/><label for="free_text_yes">{{ _T('Yes') }}</label>
-                                            <input type="radio" name="free_text[]" id="free_text_no" value="0"{% if fs.search == 0 %} checked="checked"{% endif %}/><label for="free_text_no">{{ _T('No') }}</label>
+                                            <input type="radio" name="free_text[]" id="free_text_yes_{{ loop.index }}" value="1"{% if fs.search == 1 %} checked="checked"{% endif %}/><label for="free_text_yes_{{ loop.index }}">{{ _T('Yes') }}</label>
+                                            <input type="radio" name="free_text[]" id="free_text_no_{{ loop.index }}" value="0"{% if fs.search == 0 %} checked="checked"{% endif %}/><label for="free_text_no_{{ loop.index }}">{{ _T('No') }}</label>
     {% else %}
-                                            <select name="free_query_operator[]" class="free_operator ui selection dropdown">
+                                            <select id="free_query_operator_{{ loop.index }}" name="free_query_operator[]" class="free_operator ui selection dropdown">
                                                 <option value="{{ constant("Galette\\Filters\\AdvancedMembersList::OP_EQUALS") }}"{% if fs.qry_op == constant("Galette\\Filters\\AdvancedMembersList::OP_EQUALS") %} selected="selected"{% endif %}>{{ _T('is') }}</option>
                                                 <option value="{{ constant("Galette\\Filters\\AdvancedMembersList::OP_CONTAINS") }}"{% if fs.qry_op == constant("Galette\\Filters\\AdvancedMembersList::OP_CONTAINS") %} selected="selected"{% endif %}>{{ _T('contains') }}</option>
                                                 <option value="{{ constant("Galette\\Filters\\AdvancedMembersList::OP_NOT_EQUALS") }}"{% if fs.qry_op == constant("Galette\\Filters\\AdvancedMembersList::OP_NOT_EQUALS") %} selected="selected"{% endif %}>{{ _T('is not') }}</option>
@@ -547,13 +551,13 @@
                                                 <option value="{{ constant("Galette\\Filters\\AdvancedMembersList::OP_STARTS_WITH") }}"{% if fs.qry_op == constant("Galette\\Filters\\AdvancedMembersList::OP_STARTS_WITH") %} selected="selected"{% endif %}>{{ _T('starts with') }}</option>
                                                 <option value="{{ constant("Galette\\Filters\\AdvancedMembersList::OP_ENDS_WITH") }}"{% if fs.qry_op == constant("Galette\\Filters\\AdvancedMembersList::OP_ENDS_WITH") %} selected="selected"{% endif %}>{{ _T('ends with') }}</option>
                                             </select>
-                                            <input type="text" name="free_text[]" value="{{ fs.search }}"{% if cur_field is not null and get_class(cur_field) == "Galette\\DynamicFields\\Text" %} class="large"{% endif %}/>
+                                            <label for="free_text_{{ loop.index }}" class="visually-hidden">{{ _T('Value') }}</label>
+                                            <input id="free_text_{{ loop.index }}" type="text" name="free_text[]" value="{{ fs.search }}"{% if cur_field is not null and get_class(cur_field) == "Galette\\DynamicFields\\Text" %} class="large"{% endif %}/>
     {% endif %}
                                         </div>
                                         <a
                                             href="#"
-                                            class="ui small compact red icon button filtered fright tooltip delete delcriteria"
-                                            title="{{ _T('Remove criteria') }}"
+                                            class="ui small compact red icon button filtered fright delete delcriteria icon-only"
                                         >
                                             <i class="trash alt icon" aria-hidden="true"></i>
                                             <span class="visually-hidden">{{ _T('Remove criteria') }}</span>
@@ -769,19 +773,36 @@
                 _rmFilter();
 
                $('#addbutton_g').click(function(){
-                    $('#gs_sortable li:first')
-                            .clone() // copy
-                            .insertAfter('#gs_sortable li:last'); // where
-                    $('#gs_sortable li:last .ui.dropdown').dropdown('refresh');
+                    var _newindex_g = $(this).parent().parent().find('.active.content #gs_sortable li:last select').attr('id').replace('groups_search_', '');
+                    ++_newindex_g;
+                    $('#gs_sortable li:last')
+                        .clone() // copy
+                        .insertAfter('#gs_sortable li:last') // where
+                        .find("[id$='_formLabel']").attr('id', 'groups_search_' + _newindex_g + '_formLabel').attr('for', 'groups_search_' + _newindex_g)
+                        .parent().find('select').attr('id', 'groups_search_' + _newindex_g)
+                        .parent().find('input.search').attr('aria-labelledby', 'groups_search_' + _newindex_g + '_formLabel')
+                    ;
+                    $('#gs_sortable li:last .ui.dropdown').dropdown('clear').dropdown('refresh');
                     _fs_dropdown();
                     _rmFilter();
                     return false;
                 });
 
                 $('#addbutton').click(function(){
-                    $('#fs_sortable li:first')
-                            .clone() // copy
-                            .insertAfter('#fs_sortable li:last'); // where
+                    var _newindex_fs = $(this).parent().parent().find('.active.content #fs_sortable li:last select').attr('id').replace('free_logical_operator_', '');
+                    ++_newindex_fs;
+                    $('#fs_sortable li:last')
+                        .clone() // copy
+                        .insertAfter('#fs_sortable li:last') // where
+                        .find("[for^='free_logical_operator_']").attr('for', 'free_logical_operator_' + _newindex_fs)
+                        .parent().find("[id^='free_logical_operator_']").attr('id', 'free_logical_operator_' + _newindex_fs)
+                        .parent().parent().find("[id^='free_field_selector_']").attr('id', 'free_field_selector_' + _newindex_fs)
+                        .parent().find("[for^='free_field_selector_']").attr('id', 'free_field_selector_' + _newindex_fs + '_formLabel').attr('for', 'free_field_selector_' + _newindex_fs)
+                        .parent().find('input.search').attr('aria-labelledby', 'free_field_selector_' + _newindex_fs + '_formLabel')
+                        .parent().parent().find("[for^='free_query_operator_']").attr('for', 'free_query_operator_' + _newindex_fs)
+                        .parent().find("[id^='free_query_operator_']").attr('id', 'free_query_operator_' + _newindex_fs)
+                        // TODO : change id, for and aria-labelledby attributes of remaining "value" fields depending on their type (text, select, radio, date, ...)
+                    ;
                     $('#fs_sortable li:last .ui.dropdown:not(.origselect)').dropdown('refresh');
                     _fs_dropdown();
                     _rmFilter();

--- a/galette/templates/default/pages/advanced_search.html.twig
+++ b/galette/templates/default/pages/advanced_search.html.twig
@@ -670,10 +670,11 @@
                         var _field = _fields[value];
                         var _type = _field.type;
                         var _html;
+                        var _current_index = $(this).attr('id').replace('free_field_selector_', '');
                         switch(_type) {
                             case '{{ constant('Galette\\DynamicFields\\DynamicField::BOOLEAN') }}':
                                 _html  = _getOperatorSelector(['op_equals']);
-                                _html += '<input type="radio" name="free_text[]" id="free_text_yes" value="1"/><label for="free_text_yes">{{ _T('Yes') }}</label><input type="radio" name="free_text[]" id="free_text_no" value="0"/><label for="free_text_no">{{ _T('No') }}</label>';
+                                _html += '<input type="radio" name="free_text[]" id="free_text_yes_' + _current_index + '" value="1"/><label for="free_text_yes_' + _current_index + '">{{ _T('Yes') }}</label><input type="radio" name="free_text[]" id="free_text_no_' + _current_index + '" value="0"/><label for="free_text_no_' + _current_index + '">{{ _T('No') }}</label>';
                                 break;
                             case '{{ constant('Galette\\DynamicFields\\DynamicField::CHOICE') }}':
                                 _html = _getOperatorSelector(['op_equals', 'op_not_equals']);
@@ -687,20 +688,23 @@
                                         _options += '<option value="' + key + '">' + _field.values[key] + '</option>';
                                     }
                                 }
-                                _html += '<select name="free_text[]" class="ui search selection dropdown">' + _options + '</select>';
+                                _html += '<label for="free_text_' + _current_index + '" class="visually-hidden">{{ _T("Choice") }}</label>'
+                                _html += '<select id="free_text_' + _current_index + '" name="free_text[]" class="ui search selection dropdown lastdropdown">' + _options + '</select>';
                                 break;
                             case '{{ constant('Galette\\DynamicFields\\DynamicField::DATE') }}':
                                 _html  = _getOperatorSelector(['op_equals', 'op_before', 'op_after']);
                                 _html += '<div class="ui calendar fs-calendar">'
+                                _html += '<label for="free_text_' + _current_index + '" class="visually-hidden">{{ _T("Date") }}</label>'
                                 _html += '<div class="ui input left icon">'
                                 _html += '<i class="calendar icon" aria-hidden="true"></i>'
-                                _html += '<input type="text" name="free_text[]" class="modif_date" placeholder="{{ _T('yyyy-mm-dd format') }}"/>';
+                                _html += '<input id="free_text_' + _current_index + '" type="text" name="free_text[]" class="modif_date" placeholder="{{ _T('yyyy-mm-dd format') }}"/>';
                                 _html += '</div>'
                                 _html += '</div>'
                                 break;
                             default:
                                 _html  = _getOperatorSelector(['op_equals', 'op_contains', 'op_not_equals', 'op_not_contains', 'op_starts_with', 'op_ends_with']);
-                                _html += '<input type="text" name="free_text[]"/>';
+                                _html += '<label for="free_text_' + _current_index + '" class="visually-hidden">{{ _T("Value") }}</label>'
+                                _html += '<input id="free_text_' + _current_index + '" type="text" name="free_text[]"/>';
                                 break;
 
                         }
@@ -801,7 +805,27 @@
                         .parent().find('input.search').attr('aria-labelledby', 'free_field_selector_' + _newindex_fs + '_formLabel')
                         .parent().parent().find("[for^='free_query_operator_']").attr('for', 'free_query_operator_' + _newindex_fs)
                         .parent().find("[id^='free_query_operator_']").attr('id', 'free_query_operator_' + _newindex_fs)
-                        // TODO : change id, for and aria-labelledby attributes of remaining "value" fields depending on their type (text, select, radio, date, ...)
+                    ;
+                    $('#fs_sortable li:last [id^="free_text_yes_"]')
+                        .attr('id', 'free_text_yes_' + _newindex_fs)
+                        .parent().find("[for^='free_text_yes_']").attr('for', 'free_text_yes_' + _newindex_fs)
+                    ;
+                    $('#fs_sortable li:last [id^="free_text_no_"]')
+                        .attr('id', 'free_text_no_' + _newindex_fs)
+                        .parent().find("[for^='free_text_no_']").attr('for', 'free_text_no_' + _newindex_fs)
+                    ;
+                    $('#fs_sortable li:last .ui.dropdown.lastdropdown')
+                        .parent().find("[id$='_formLabel']").attr('id', 'free_text_' + _newindex_fs + '_formLabel').attr('for', 'free_text_' + _newindex_fs)
+                        .parent().find('select').attr('id', 'free_text_' + _newindex_fs)
+                        .parent().find('input.search').attr('aria-labelledby', 'free_text_' + _newindex_fs + '_formLabel')
+                    ;
+                    $('#fs_sortable li:last .ui.calendar')
+                        .find("[for^='free_text_']").attr('for', 'free_text_' + _newindex_fs)
+                        .parent().find("[id^='free_text_']").attr('id', 'free_text_' + _newindex_fs)
+                    ;
+                    $('#fs_sortable li:last input[type="text"][id^="free_text_"]')
+                        .attr('id', 'free_text_' + _newindex_fs)
+                        .parent().find("[for^='free_text_']").attr('for', 'free_text_' + _newindex_fs)
                     ;
                     $('#fs_sortable li:last .ui.dropdown:not(.origselect)').dropdown('refresh');
                     _fs_dropdown();

--- a/galette/templates/default/pages/configuration_core_lists.html.twig
+++ b/galette/templates/default/pages/configuration_core_lists.html.twig
@@ -81,9 +81,9 @@
                             {{ permission }}
                         </td>
                         <td class="center actions_row collapsing">
-                            <a href="#" class="delete">
-                                <i class="ui trash red icon tooltip" aria-hidden="true"></i>
-                                <span class="ui special popup">{{ _T("Delete '%s' field")|replace({'%s': field.label}) }}</span>
+                            <a href="#" class="delete icon-only">
+                                <i class="ui trash red icon" aria-hidden="true"></i>
+                                <span class="visually-hidden">{{ _T("Delete '%s' field")|replace({'%s': field.label}) }}</span>
                             </a>
                         </td>
                     </tr>
@@ -92,7 +92,7 @@
             </table>
         </div>
         <div class="ui basic center aligned segment">
-            <button type="submit" class="ui labeled icon primary button action">
+            <button type="submit" class="ui labeled icon primary button action icon-only">
                 <i class="save icon" aria-hidden="true"></i> {{ _T("Save") }}
             </button>
         </div>

--- a/galette/templates/default/pages/configuration_core_lists.html.twig
+++ b/galette/templates/default/pages/configuration_core_lists.html.twig
@@ -39,8 +39,13 @@
                 </thead>
                 <tfoot>
                     <tr>
-                        <td class="collapsing" data-scope="row"></td>
+                        <td class="collapsing" data-scope="row">
+                            <span class="visually-hidden">
+                                {{ _T("Add field") }}
+                            </span>
+                        </td>
                         <td class="left" data-col-label="{{ _T("Available fields") }}" colspan="2">
+                            <label for="remaining_fields_dropdown" class="visually-hidden">{{ _T("Field name") }}</label>
                             <div id="remaining_fields_dropdown" class="ui fluid search clearable selection dropdown">
                                 <i class="dropdown icon"></i>
                                 <div class="default text">{{ _T("Available fields") }}</div>

--- a/galette/templates/default/pages/configuration_payment_types.html.twig
+++ b/galette/templates/default/pages/configuration_payment_types.html.twig
@@ -63,27 +63,27 @@
                             <td class="center actions_row collapsing">
                                 <a
                                     href="{{ url_for('editPaymentType', {'id': ptype.__get('id')}) }}"
-                                    class="action single-edit"
+                                    class="action single-edit icon-only"
                                 >
-                                    <i class="ui edit icon tooltip" aria-hidden="true"></i>
-                                    <span class="ui special popup">{{ _T("Edit '%s' payment type")|replace({'%s': ptype.getName()}) }}</span>
+                                    <i class="ui edit icon" aria-hidden="true"></i>
+                                    <span class="visually-hidden">{{ _T("Edit '%s' payment type")|replace({'%s': ptype.getName()}) }}</span>
                                 </a>
                                 <a
                                     href="{{ url_for('dynamicTranslations', {}, {'text_orig': ptype.getName(false)}) }}"
-                                    class="action single-translate"
+                                    class="action single-translate icon-only"
                                 >
-                                    <i class="ui language grey icon tooltip" aria-hidden="true"></i>
-                                    <span class="ui special popup">{{ _T("Translate '%s'")|replace({'%s': ptype.getName()}) }}</span>
+                                    <i class="ui language grey icon" aria-hidden="true"></i>
+                                    <span class="visually-hidden">{{ _T("Translate '%s'")|replace({'%s': ptype.getName()}) }}</span>
                                 </a>
                 {% if ptype.isSystemType() %}
                                 <i class="ui icon">&nbsp;</i>
                 {% else %}
                                 <a
                                     href="{{ url_for('removePaymentType', {'id': ptype.__get('id')}) }}"
-                                    class="delete"
+                                    class="delete icon-only"
                                 >
-                                    <i class="ui trash red icon tooltip" aria-hidden="true"></i>
-                                    <span class="ui special popup">{{ _T("Delete '%s' payment type")|replace({'%s': ptype.getName()}) }}</span>
+                                    <i class="ui trash red icon" aria-hidden="true"></i>
+                                    <span class="visually-hidden">{{ _T("Delete '%s' payment type")|replace({'%s': ptype.getName()}) }}</span>
                                 </a>
                 {% endif %}
                             </td>

--- a/galette/templates/default/pages/configuration_payment_types.html.twig
+++ b/galette/templates/default/pages/configuration_payment_types.html.twig
@@ -41,7 +41,7 @@
                             <td class="left" data-col-label="{{ _T("Label") }}">
                                 <div class="required field">
                                     <label for="name" class="visually-hidden">{{ _T("Name") }}</label>
-                                    <input size="20" type="text" name="name" required="required"/>
+                                    <input id="name" size="20" type="text" name="name" required="required"/>
                                 </div>
                             </td>
                             <td class="center actions_row collapsing">

--- a/galette/templates/default/pages/configuration_titles.html.twig
+++ b/galette/templates/default/pages/configuration_titles.html.twig
@@ -42,13 +42,13 @@
                         <td class="left" data-col-label="{{ _T("Short form") }}">
                             <div class="required field">
                                 <label for="short_label" class="visually-hidden">{{ _T("Short form") }}</label>
-                                <input size="20" type="text" name="short_label" required="required"/>
+                                <input size="20" type="text" name="short_label" id="short_label" required="required"/>
                             </div>
                         </td>
                         <td class="left" data-col-label="{{ _T("Long form") }}">
                             <div class="required field">
                                 <label for="long_label" class="visually-hidden">{{ _T("Long form") }}</label>
-                                <input size="20" type="text" name="long_label" required="required"/>
+                                <input size="20" type="text" name="long_label" id="long_label"  required="required"/>
                             </div>
                         </td>
                         <td class="center actions_row collapsing">
@@ -71,20 +71,20 @@
                         <td class="center actions_row collapsing">
                             <a
                                 href="{{ url_for('editTitle', {'id': title.id}) }}"
-                                class="action single-edit"
+                                class="action single-edit icon-only"
                             >
                                 <i class="ui edit icon tooltip" aria-hidden="true"></i>
-                                <span class="ui special popup">{{ _T("Edit '%s' title")|replace({'%s': title.short|escape}) }}</span>
+                                <span class="visually-hidden">{{ _T("Edit '%s' title")|replace({'%s': title.short|escape}) }}</span>
                             </a>
             {% if title.id == 1 or title.id == 2 %}
                             <i class="ui icon">&nbsp;</i>
             {% else %}
                             <a
                                 href="{{ url_for('removeTitle', {'id': title.id}) }}"
-                                class="delete "
+                                class="delete icon-only"
                             >
                                 <i class="ui trash red icon tooltip" aria-hidden="true"></i>
-                                <span class="ui special popup">{{ _T("Delete '%s' title")|replace({'%s': title.short|escape}) }}</span>
+                                <span class="visually-hidden">{{ _T("Delete '%s' title")|replace({'%s': title.short|escape}) }}</span>
                             </a>
             {% endif %}
                         </td>

--- a/galette/templates/default/pages/contributions_list.html.twig
+++ b/galette/templates/default/pages/contributions_list.html.twig
@@ -174,9 +174,10 @@
                         {% if login.isAdmin() or login.isStaff() or login.isGroupManager() and preferences.pref_bool_groupsmanagers_see_contributions or member.hasChildren() or (member.hasParent() and (member_logged_in_as != login.loggedInAs(true))) %}
                             <a
                                 href="{{ url_for("contributions", {"type": "contributions", "option": "member", "value": "all"}) }}"
+                                class="icon-only"
                             >
                                 <i class="icon times tooltip" aria-hidden="true"></i>
-                                <span class="ui special popup">
+                                <span class="visually-hidden">
                                     {% if member.hasChildren() or (member.hasParent() and (member_logged_in_as != login.loggedInAs(true))) %}
                                         {{ _T("Show all your contributions") }}
                                     {% else %}
@@ -304,9 +305,10 @@
                     {% if contribution.isTransactionPart() %}
                         <a
                             href="{{ url_for("editTransaction", {"id": contribution.transaction.id}) }}"
+                            class="icon-only"
                         >
                             <i class="ui sitemap {% if contribution.transaction.getMissingAmount() == 0 %}blue{% else %}orange{% endif %} icon tooltip" aria-hidden="true"></i>
-                            <span class="ui special popup">
+                            <span class="visually-hidden">
                                 {{ _T("Edit transaction #%id")|replace({"%id": contribution.transaction.id}) }}
                                 {% if contribution.transaction.getMissingAmount() != 0 %}({{ _T("Amount is not fully dispatched") }}){% endif %}
                             </span>
@@ -315,9 +317,9 @@
                         <i class="ui icon" aria-hidden="true"></i>
                     {% endif %}
                     {% if contribution.hasSchedule() %}
-                        <a href="{{ url_for("scheduledPayments") }}?id_cotis={{ contribution.id }}">
+                        <a href="{{ url_for("scheduledPayments") }}?id_cotis={{ contribution.id }}" class="icon-only">
                             <i class="ui calendar alternate outline {% if contribution.isScheduleFullyAllocated() %}blue{% else %}orange{% endif %} icon tooltip" aria-hidden="true"></i>
-                            <span class="ui special popup">
+                            <span class="visually-hidden">
                                 {{ _T("View scheduled payments") }}
                                 {% if not contribution.isScheduleFullyAllocated() %}({{ _T("Amount is not fully dispatched") }}){% endif %}
                             </span>
@@ -330,10 +332,11 @@
                         {% if preferences.pref_bool_groupsmanagers_create_transactions %}
                             <a
                                 href="{{ url_for("editTransaction", {"id": contribution.transaction.id}) }}"
+                                class="icon-only"
                             >
                         {% endif %}
                                 <i class="ui sitemap {% if contribution.transaction.getMissingAmount() == 0 %}blue{% else %}orange{% endif %} icon tooltip" aria-hidden="true"></i>
-                                <span class="ui special popup">
+                                <span class="visually-hidden">
                                     {% if preferences.pref_bool_groupsmanagers_create_transactions %}
                                         {{ _T("Edit transaction #%id")|replace({"%id": contribution.transaction.id}) }}
                                     {% else %}
@@ -367,9 +370,9 @@
                         <i class="ui icon" aria-hidden="true"></i>
                     {% endif %}
                     {% if contribution.hasSchedule() %}
-                        <a href="{{ url_for("myScheduledPayments") }}?id_cotis={{ contribution.id }}">
+                        <a href="{{ url_for("myScheduledPayments") }}?id_cotis={{ contribution.id }}" class="icon-only">
                             <i class="ui calendar alternate outline {% if contribution.isScheduleFullyAllocated() %}blue{% else %}orange{% endif %} icon tooltip" aria-hidden="true"></i>
-                            <span class="ui special popup">
+                            <span class="visually-hidden">
                                 {{ _T("View scheduled payments") }}
                                 {% if not contribution.isScheduleFullyAllocated() %}({{ _T("Amount is not fully dispatched") }}){% endif %}
                             </span>
@@ -415,24 +418,25 @@
                 <td class="actions_row center collapsing">
                     <a
                             href="{{ url_for("printContribution", {"id": contribution.id}) }}"
+                            class="icon-only"
                     >
                         <i class="ui file pdf green icon tooltip" aria-hidden="true"></i>
-                        <span class="ui special popup">{{ _T("Print an invoice or a receipt (depending on contribution type)") }}</span>
+                        <span class="visually-hidden">{{ _T("Print an invoice or a receipt (depending on contribution type)") }}</span>
                     </a>
                     {% if (login.isAdmin() or login.isStaff()) %}
                         <a
                                 href="{{ url_for("editContribution", {"type": ctype, "id": contribution.id}) }}"
-                                class="action"
+                                class="action icon-only"
                         >
                             <i class="ui edit icon tooltip" aria-hidden="true"></i>
-                            <span class="ui special popup">{{ _T("Edit the contribution") }}</span>
+                            <span class="visually-hidden">{{ _T("Edit the contribution") }}</span>
                         </a>
                         <a
                                 href="{{ url_for("removeContribution", {"type": "contributions", "id": contribution.id}) }}"
-                                class="delete"
+                                class="delete icon-only"
                         >
                             <i class="ui trash red icon tooltip" aria-hidden="true"></i>
-                            <span class="ui special popup">{{ _T("Delete the contribution") }}</span>
+                            <span class="visually-hidden">{{ _T("Delete the contribution") }}</span>
                         </a>
                     {% endif %}
                 </td>

--- a/galette/templates/default/pages/contributions_list.html.twig
+++ b/galette/templates/default/pages/contributions_list.html.twig
@@ -287,14 +287,18 @@
 
         <tr class="{% if mode == 'ajax' %}contribution_row {% endif %}{{ contribution.getRowClass() }}" id="row_{{ contribution.id }}">
             <td class="collapsing" data-scope="row" data-col-label="{{ _T('ID') }}">
-                {% if (login.isAdmin() or login.isStaff()) or mode == 'ajax' %}
-                    <span class="ui checkbox">
+                <span{% if (login.isAdmin() or login.isStaff()) or mode == 'ajax' %} class="ui checkbox"{% endif %}>
+                    {% if (login.isAdmin() or login.isStaff()) or mode == 'ajax' %}
                         <input type="checkbox" name="entries_sel[]" id="entry_sel_{{ contribution.id }}" value="{{ contribution.id }}"/>
-                    </span>
-                {% else %}
-                    <input type="hidden" name="contrib_id" value="{{ contribution.id }}"/>
-                {% endif %}
-                <label for="entry_sel_{{ contribution.id }}">{{ contribution.id }}</label>
+                        <label for="entry_sel_{{ contribution.id }}">
+                    {% else %}
+                        <input type="hidden" name="contrib_id" value="{{ contribution.id }}"/>
+                    {% endif %}
+                        {{ contribution.id }}
+                    {% if (login.isAdmin() or login.isStaff()) or mode == 'ajax' %}
+                        </label>
+                    {% endif %}
+                </span>
 
                 {% if (login.isAdmin() or login.isStaff()) and mode != 'ajax' %}
                     {% if contribution.isTransactionPart() %}

--- a/galette/templates/default/pages/contributions_list.html.twig
+++ b/galette/templates/default/pages/contributions_list.html.twig
@@ -289,12 +289,12 @@
             <td class="collapsing" data-scope="row" data-col-label="{{ _T('ID') }}">
                 {% if (login.isAdmin() or login.isStaff()) or mode == 'ajax' %}
                     <span class="ui checkbox">
-                        <input type="checkbox" name="entries_sel[]" value="{{ contribution.id }}"/>
+                        <input type="checkbox" name="entries_sel[]" id="entry_sel_{{ contribution.id }}" value="{{ contribution.id }}"/>
                     </span>
                 {% else %}
                     <input type="hidden" name="contrib_id" value="{{ contribution.id }}"/>
                 {% endif %}
-                {{ contribution.id }}
+                <label for="entry_sel_{{ contribution.id }}">{{ contribution.id }}</label>
 
                 {% if (login.isAdmin() or login.isStaff()) and mode != 'ajax' %}
                     {% if contribution.isTransactionPart() %}

--- a/galette/templates/default/pages/contributions_list.html.twig
+++ b/galette/templates/default/pages/contributions_list.html.twig
@@ -176,7 +176,7 @@
                                 href="{{ url_for("contributions", {"type": "contributions", "option": "member", "value": "all"}) }}"
                                 class="icon-only"
                             >
-                                <i class="icon times tooltip" aria-hidden="true"></i>
+                                <i class="icon times" aria-hidden="true"></i>
                                 <span class="visually-hidden">
                                     {% if member.hasChildren() or (member.hasParent() and (member_logged_in_as != login.loggedInAs(true))) %}
                                         {{ _T("Show all your contributions") }}
@@ -307,7 +307,7 @@
                             href="{{ url_for("editTransaction", {"id": contribution.transaction.id}) }}"
                             class="icon-only"
                         >
-                            <i class="ui sitemap {% if contribution.transaction.getMissingAmount() == 0 %}blue{% else %}orange{% endif %} icon tooltip" aria-hidden="true"></i>
+                            <i class="ui sitemap {% if contribution.transaction.getMissingAmount() == 0 %}blue{% else %}orange{% endif %} icon" aria-hidden="true"></i>
                             <span class="visually-hidden">
                                 {{ _T("Edit transaction #%id")|replace({"%id": contribution.transaction.id}) }}
                                 {% if contribution.transaction.getMissingAmount() != 0 %}({{ _T("Amount is not fully dispatched") }}){% endif %}
@@ -318,7 +318,7 @@
                     {% endif %}
                     {% if contribution.hasSchedule() %}
                         <a href="{{ url_for("scheduledPayments") }}?id_cotis={{ contribution.id }}" class="icon-only">
-                            <i class="ui calendar alternate outline {% if contribution.isScheduleFullyAllocated() %}blue{% else %}orange{% endif %} icon tooltip" aria-hidden="true"></i>
+                            <i class="ui calendar alternate outline {% if contribution.isScheduleFullyAllocated() %}blue{% else %}orange{% endif %} icon" aria-hidden="true"></i>
                             <span class="visually-hidden">
                                 {{ _T("View scheduled payments") }}
                                 {% if not contribution.isScheduleFullyAllocated() %}({{ _T("Amount is not fully dispatched") }}){% endif %}
@@ -335,7 +335,7 @@
                                 class="icon-only"
                             >
                         {% endif %}
-                                <i class="ui sitemap {% if contribution.transaction.getMissingAmount() == 0 %}blue{% else %}orange{% endif %} icon tooltip" aria-hidden="true"></i>
+                                <i class="ui sitemap {% if contribution.transaction.getMissingAmount() == 0 %}blue{% else %}orange{% endif %} icon" aria-hidden="true"></i>
                                 <span class="visually-hidden">
                                     {% if preferences.pref_bool_groupsmanagers_create_transactions %}
                                         {{ _T("Edit transaction #%id")|replace({"%id": contribution.transaction.id}) }}
@@ -371,7 +371,7 @@
                     {% endif %}
                     {% if contribution.hasSchedule() %}
                         <a href="{{ url_for("myScheduledPayments") }}?id_cotis={{ contribution.id }}" class="icon-only">
-                            <i class="ui calendar alternate outline {% if contribution.isScheduleFullyAllocated() %}blue{% else %}orange{% endif %} icon tooltip" aria-hidden="true"></i>
+                            <i class="ui calendar alternate outline {% if contribution.isScheduleFullyAllocated() %}blue{% else %}orange{% endif %} icon" aria-hidden="true"></i>
                             <span class="visually-hidden">
                                 {{ _T("View scheduled payments") }}
                                 {% if not contribution.isScheduleFullyAllocated() %}({{ _T("Amount is not fully dispatched") }}){% endif %}
@@ -397,9 +397,10 @@
                     {% if filters.filtre_cotis_adh == "" or filters.filtre_cotis_adh == null %}
                         <a
                                 href="{{ url_for("contributions", {"type": "contributions", "option": "member", "value": mid}) }}"
-                                title="{{ _T("Show only '%1$s' contributions")|format(mname) }}"
+                                class="icon-only"
                         >
                             <i class="ui filter grey small icon" aria-hidden="true"></i>
+                            <span class="visually-hidden">{{ _T("Show only '%1$s' contributions")|format(mname) }}</span>
                         </a>
                     {% endif %}
                     <a
@@ -420,7 +421,7 @@
                             href="{{ url_for("printContribution", {"id": contribution.id}) }}"
                             class="icon-only"
                     >
-                        <i class="ui file pdf green icon tooltip" aria-hidden="true"></i>
+                        <i class="ui file pdf green icon" aria-hidden="true"></i>
                         <span class="visually-hidden">{{ _T("Print an invoice or a receipt (depending on contribution type)") }}</span>
                     </a>
                     {% if (login.isAdmin() or login.isStaff()) %}
@@ -428,14 +429,14 @@
                                 href="{{ url_for("editContribution", {"type": ctype, "id": contribution.id}) }}"
                                 class="action icon-only"
                         >
-                            <i class="ui edit icon tooltip" aria-hidden="true"></i>
+                            <i class="ui edit icon" aria-hidden="true"></i>
                             <span class="visually-hidden">{{ _T("Edit the contribution") }}</span>
                         </a>
                         <a
                                 href="{{ url_for("removeContribution", {"type": "contributions", "id": contribution.id}) }}"
                                 class="delete icon-only"
                         >
-                            <i class="ui trash red icon tooltip" aria-hidden="true"></i>
+                            <i class="ui trash red icon" aria-hidden="true"></i>
                             <span class="visually-hidden">{{ _T("Delete the contribution") }}</span>
                         </a>
                     {% endif %}

--- a/galette/templates/default/pages/contributions_types_list.html.twig
+++ b/galette/templates/default/pages/contributions_types_list.html.twig
@@ -118,24 +118,24 @@
                     <td class="center actions_row collapsing">
                         <a
                             href="{{ url_for('editContributionType', {'id': eid}) }}"
-                            class="action single-edit"
+                            class="action single-edit icon-only"
                         >
                             <i class="ui edit icon tooltip" aria-hidden="true"></i>
-                            <span class="ui special popup">{{ _T("Edit '%s' field")|replace({'%s': entry.name}) }}</span>
+                            <span class="visually-hidden">{{ _T("Edit '%s' field")|replace({'%s': entry.name}) }}</span>
                         </a>
                         <a
                             href="{{ url_for('dynamicTranslations', {}, {'text_orig': entry.text_orig}) }}"
-                            class="action single-translate"
+                            class="action single-translate icon-only"
                         >
                             <i class="ui language grey icon tooltip" aria-hidden="true"></i>
-                            <span class="ui special popup">{{ _T("Translate '%s'")|replace({'%s': entry.name}) }}</span>
+                            <span class="visually-hidden">{{ _T("Translate '%s'")|replace({'%s': entry.name}) }}</span>
                         </a>
                         <a
                             href="{{ url_for('removeContributionType', {'id': eid}) }}"
-                            class="delete"
+                            class="delete icon-only"
                         >
                             <i class="ui trash red icon tooltip" aria-hidden="true"></i>
-                            <span class="ui special popup">{{ _T("Delete '%s' field")|replace({'%s': entry.name}) }}</span>
+                            <span class="visually-hidden">{{ _T("Delete '%s' field")|replace({'%s': entry.name}) }}</span>
                         </a>
                     </td>
                 </tr>

--- a/galette/templates/default/pages/contributions_types_list.html.twig
+++ b/galette/templates/default/pages/contributions_types_list.html.twig
@@ -79,7 +79,9 @@
                             id: 'cotis_extension',
                             value: constant("Galette\\Entity\\ContributionsTypes::DEFAULT_TYPE"),
                             values: cotisextensions,
-                            nolabel: true
+                            nolabel: false,
+                            labelclass: 'visually-hidden',
+                            label: _T("Membership extension")
                         } %}
                     </td>
                     <td class="center actions_row collapsing">

--- a/galette/templates/default/pages/document_form.html.twig
+++ b/galette/templates/default/pages/document_form.html.twig
@@ -26,7 +26,7 @@
         <div class="ui segment" id="general">
     {% endif %}
             <div class="field ui items">
-                <label>{{ _T("File:") }}</label>
+                <label for="document_new">{{ _T("File:") }}</label>
     {% if document.getID() is not null %}
                 <a href="{{ url_for('getDocumentFile', {'id': document.getID()}) }}">
                     {{ document.getDocumentFilename() }}
@@ -44,7 +44,7 @@
                 </div>
             </div>
             <div class="required field">
-                <label>{{ _T("Document type") }}</label>
+                <label for="document_type_input">{{ _T("Document type") }}</label>
                 <div id="document_type" class="jsonly search-dropdown documents-dropdown ui input">
                     <input id="document_type_input" type="hidden" name="document_type" value="{{ document.getType() }}">
                     <i class="jsonly displaynone dropdown icon" aria-hidden="true"></i>

--- a/galette/templates/default/pages/documents_list.html.twig
+++ b/galette/templates/default/pages/documents_list.html.twig
@@ -87,17 +87,17 @@
                 <td class="actions_row center collapsing">
                     <a
                             href="{{ url_for("editDocument", {"id": document.getID()}) }}"
-                            class="action"
+                            class="action icon-only"
                     >
-                        <i class="ui edit icon tooltip" aria-hidden="true"></i>
-                        <span class="ui special popup">{{ _T("Edit document") }}</span>
+                        <i class="ui edit icon" aria-hidden="true"></i>
+                        <span class="visually-hidden">{{ _T("Edit document") }}</span>
                     </a>
                     <a
                             href="{{ url_for("removeDocument", {"id": document.getID()}) }}"
-                            class="delete"
+                            class="delete icon-only"
                     >
-                        <i class="ui trash red icon tooltip" aria-hidden="true"></i>
-                        <span class="ui special popup">{{ _T("Delete document") }}</span>
+                        <i class="ui trash red icon" aria-hidden="true"></i>
+                        <span class="visually-hidden">{{ _T("Delete document") }}</span>
                     </a>
                 </td>
             {% endif %}

--- a/galette/templates/default/pages/export.html.twig
+++ b/galette/templates/default/pages/export.html.twig
@@ -82,10 +82,10 @@
                                     <td class="actions_row collapsing">
                                         <a
                                             href="{{ url_for("removeCsv", {"type": "export", "file": export.name}) }}"
-                                            class="delete "
+                                            class="delete icon-only"
                                         >
-                                            <i class="ui trash red icon tooltip" aria-hidden="true"></i>
-                                            <span class="ui special popup">{{ _T('Remove \'%1$s\' from disk')|format(export.name) }}</span>
+                                            <i class="ui trash red icon" aria-hidden="true"></i>
+                                            <span class="visually-hidden">{{ _T('Remove \'%1$s\' from disk')|format(export.name) }}</span>
                                         </a>
                                     </td>
                                 </tr>

--- a/galette/templates/default/pages/export.html.twig
+++ b/galette/templates/default/pages/export.html.twig
@@ -108,7 +108,9 @@
                         <table class="ui celled striped table">
                             <thead>
                                 <tr>
-                                    <th class="small_head collapsing"/>
+                                    <th class="small_head collapsing">
+                                        <span class="visually-hidden">{{ _T('Selection') }}</span>
+                                    </th>
                                     <th>{{ _T('Name') }}</th>
                                     <th>{{ _T('Description') }}</th>
                                 </tr>
@@ -148,7 +150,9 @@
                         <table class="same ui celled striped table">
                             <thead>
                                 <tr>
-                                    <th class="small_head collapsing"/>
+                                    <th class="small_head collapsing">
+                                        <span class="visually-hidden">{{ _T('Selection') }}</span>
+                                    </th>
                                     <th>{{ _T('Table name') }}</th>
                                 </tr>
                             </thead>

--- a/galette/templates/default/pages/groups_list.html.twig
+++ b/galette/templates/default/pages/groups_list.html.twig
@@ -54,21 +54,21 @@
         </td>
         <td class="center actions_row collapsing">
             {% if login.isGroupManager(group.getId()) and can_export %}
-                <a href="{{ url_for("pdf_groups", {"id": group.getId()}) }}">
-                    <i class="file pdf green icon tooltip" aria-hidden="true"></i>
-                    <span class="ui special popup">{{ _T("Export as PDF") }}</span>
+                <a href="{{ url_for("pdf_groups", {"id": group.getId()}) }}" class="icon-only">
+                    <i class="file pdf green icon" aria-hidden="true"></i>
+                    <span class="visually-hidden">{{ _T("Export as PDF") }}</span>
                 </a>
             {% endif %}
             {% if login.isGroupManager(group.getId()) %}
-                <a href="{{ url_for("editGroup", {"id": group.getId()}) }}">
-                    <i class="ui {% if can_edit %}edit{% else %}eye outline{% endif %} icon tooltip" aria-hidden="true"></i>
-                    <span class="ui special popup">{% if can_edit %}{{ _T("Edit") }}{% else %}{{ _T("Display") }}{% endif %}</span>
+                <a href="{{ url_for("editGroup", {"id": group.getId()}) }}" class="icon-only">
+                    <i class="ui {% if can_edit %}edit{% else %}eye outline{% endif %} icon" aria-hidden="true"></i>
+                    <span class="visually-hidden">{% if can_edit %}{{ _T("Edit") }}{% else %}{{ _T("Display") }}{% endif %}</span>
                 </a>
             {% endif %}
             {% if login.isAdmin() or login.isStaff() %}
-                <a href="{{ url_for("removeGroup", {"id": group.getId()}) }}" class="delete">
+                <a href="{{ url_for("removeGroup", {"id": group.getId()}) }}" class="delete icon-only">
                     <i class="ui trash red icon tooltip" aria-hidden="true"></i>
-                    <span class="ui special popup">{{ _T("Delete") }}</span>
+                    <span class="visually-hidden">{{ _T("Delete") }}</span>
                 </a>
             {% endif %}
         </td>

--- a/galette/templates/default/pages/import.html.twig
+++ b/galette/templates/default/pages/import.html.twig
@@ -68,10 +68,10 @@
                                         <td class="actions_row collapsing">
                                             <a
                                                 href="{{ url_for("removeCsv", {"type": "import", "file": import.name}) }}"
-                                                class="delete"
+                                                class="delete icon-only"
                                             >
-                                                <i class="ui trash red icon tooltip" aria-hidden="true"></i>
-                                                <span class="ui special popup">{{ _T('Remove \'%1$s\' from disk')|format(import.name) }}</span>
+                                                <i class="ui trash red icon" aria-hidden="true"></i>
+                                                <span class="visually-hidden">{{ _T('Remove \'%1$s\' from disk')|format(import.name) }}</span>
                                             </a>
                                         </td>
                                     </tr>

--- a/galette/templates/default/pages/import.html.twig
+++ b/galette/templates/default/pages/import.html.twig
@@ -40,7 +40,9 @@
                             <table class="listing ui celled striped table">
                                 <thead>
                                     <tr>
-                                        <th class="small_head collapsing"></th>
+                                        <th class="small_head collapsing">
+                                            <span class="visually-hidden">{{ _T('Choice') }}</span>
+                                        </th>
                                         <th>{{ _T('Name') }}</th>
                                         <th class="collapsing">{{ _T('Date') }}</th>
                                         <th class="collapsing">{{ _T('Size') }}</th>

--- a/galette/templates/default/pages/import_model.html.twig
+++ b/galette/templates/default/pages/import_model.html.twig
@@ -63,7 +63,7 @@
                 href="{{ url_for('importModel') }}?remove=true"
                 title="{{ _T('Remove model and back to defaults') }}"
             >
-                <i class="trash icon" aria-hiden="true"></i>
+                <i class="trash icon" aria-hidden="true"></i>
                 {{ _T('Remove model') }}
             </a>
             {% endif %}
@@ -75,7 +75,9 @@
         <table class="listing ui celled striped table">
             <thead>
                 <tr>
-                    <th class="collapsing"></th>
+                    <th class="collapsing">
+                        <span class="visually-hidden">{{ _T('Selection') }}</span>
+                    </th>
                     <th>{{ _T('Field') }}</th>
                 </tr>
             </thead>

--- a/galette/templates/default/pages/mailings_list.html.twig
+++ b/galette/templates/default/pages/mailings_list.html.twig
@@ -188,23 +188,24 @@
             <td class="center actions_row collapsing">
                 <a
                         href="{{ url_for("mailingPreview", {"id": log.mailing_id}) }}"
-                        class="showdetails"
+                        class="showdetails icon-only"
                 >
-                    <i class="ui eye green icon tooltip" aria-hidden="true"></i>
-                    <span class="ui special popup">{{ _T("Display mailing '%1$s' details in preview window")|format(log.mailing_subject) }}</span>
+                    <i class="ui eye green icon" aria-hidden="true"></i>
+                    <span class="visually-hidden">{{ _T("Display mailing '%1$s' details in preview window")|format(log.mailing_subject) }}</span>
                 </a>
                 <a
                         href="{{ url_for('mailing') }}?from={{ log.mailing_id }}"
+                        class="icon-only"
                 >
-                    <i class="ui clone blue icon tooltip" aria-hidden="true"></i>
-                    <span class="ui special popup">{{ _T("Use mailing '%1$s' as a template for a new one")|format(log.mailing_subject) }}</span>
+                    <i class="ui clone blue icon" aria-hidden="true"></i>
+                    <span class="visually-hidden">{{ _T("Use mailing '%1$s' as a template for a new one")|format(log.mailing_subject) }}</span>
                 </a>
                 <a
                         href="{{ url_for("removeMailing", {"id": log.mailing_id}) }}"
-                        class="delete"
+                        class="delete icon-only"
                 >
-                    <i class="ui trash red icon tooltip" aria-hidden="true"></i>
-                    <span class="ui special popup">{{ _T("Delete mailing '%1$s'")|format(log.mailing_subject) }}</span>
+                    <i class="ui trash red icon" aria-hidden="true"></i>
+                    <span class="visually-hidden">{{ _T("Delete mailing '%1$s'")|format(log.mailing_subject) }}</span>
                 </a>
             </td>
         </tr>

--- a/galette/templates/default/pages/member_show.html.twig
+++ b/galette/templates/default/pages/member_show.html.twig
@@ -161,7 +161,7 @@
     {% set elements = display_element.elements %}
             <div class="fieldset-{{ display_element.id }} ui basic fitted segment">
                 <div class="ui styled fluid accordion row">
-                    <div class="active title" role="heading" aria-level="3">
+                    <div class="active title" role="heading" aria-level="2">
                         <i class="jsonly displaynone icon dropdown" aria-hidden="true"></i>
                         {{ _T(display_element.label) }}
                     </div>

--- a/galette/templates/default/pages/member_show.html.twig
+++ b/galette/templates/default/pages/member_show.html.twig
@@ -161,7 +161,7 @@
     {% set elements = display_element.elements %}
             <div class="fieldset-{{ display_element.id }} ui basic fitted segment">
                 <div class="ui styled fluid accordion row">
-                    <div class="active title">
+                    <div class="active title" role="heading" aria-level="3">
                         <i class="jsonly displaynone icon dropdown" aria-hidden="true"></i>
                         {{ _T(display_element.label) }}
                     </div>

--- a/galette/templates/default/pages/member_show.html.twig
+++ b/galette/templates/default/pages/member_show.html.twig
@@ -231,9 +231,9 @@
                                     <i class="ui venus icon" aria-hidden="true"></i>
                     {% endif %}
                 {% endif %}
-                {% if element.field_id == 'email_adh' %}
+                {% if element.field_id == 'email_adh' and value != '' %}
                                         <a href="mailto:{{ value }}">{{ value }}</a>
-                {% elseif element.field_id == 'tel_adh' or element.field_id == 'gsm_adh' %}
+                {% elseif (element.field_id == 'tel_adh' or element.field_id == 'gsm_adh') and value != '' %}
                                         <a href="tel:{{ value }}">{{ value }}</a>
                 {% elseif element.field_id == 'ddn_adh' %}
                                 {{ value }} {{ member.getAge() }}

--- a/galette/templates/default/pages/members_list.html.twig
+++ b/galette/templates/default/pages/members_list.html.twig
@@ -326,9 +326,9 @@
         {% if column.field_id == 'id_adh' %}
                         <td class="right collapsing" data-scope="row" data-col-label="{{ _T('ID') }}">
                             <span class="ui checkbox">
-                                <input type="checkbox" name="entries_sel[]" value="{{ member.__get('id') }}"/>
+                                <input type="checkbox" name="entries_sel[]" id="member_checkbox_{{ member.__get('id') }}" value="{{ member.__get('id') }}"/>
                             </span>
-                            {{ member.id }}
+                            <label for="member_checkbox_{{ member.__get('id') }}">{{ member.id }}</label>
                         </td>
         {% elseif column.field_id == 'list_adh_name' %}
                         <td class="username_row" data-scope="row" data-col-label="{{ column.label }}">

--- a/galette/templates/default/pages/members_list.html.twig
+++ b/galette/templates/default/pages/members_list.html.twig
@@ -327,8 +327,8 @@
                         <td class="right collapsing" data-scope="row" data-col-label="{{ _T('ID') }}">
                             <span class="ui checkbox">
                                 <input type="checkbox" name="entries_sel[]" id="member_checkbox_{{ member.__get('id') }}" value="{{ member.__get('id') }}"/>
+                                <label for="member_checkbox_{{ member.__get('id') }}">{{ member.id }}</label>
                             </span>
-                            <label for="member_checkbox_{{ member.__get('id') }}">{{ member.id }}</label>
                         </td>
         {% elseif column.field_id == 'list_adh_name' %}
                         <td class="username_row" data-scope="row" data-col-label="{{ column.label }}">

--- a/galette/templates/default/pages/members_list.html.twig
+++ b/galette/templates/default/pages/members_list.html.twig
@@ -351,9 +351,9 @@
                             <i class="ui icon" aria-hidden="true"></i>
             {% endif %}
             {% if member.email != '' %}
-                            <a href="mailto:{{ member.email }}">
+                            <a href="mailto:{{ member.email }}" class="icon-only">
                                 <i class="ui envelope outline teal icon tooltip" aria-hidden="true"></i>
-                                <span class="ui special popup">{{ _T('Mail') }}</span>
+                                <span class="visually-hidden">{{ _T('Mail') }}</span>
                             </a>
 
             {% else %}

--- a/galette/templates/default/pages/plugins.html.twig
+++ b/galette/templates/default/pages/plugins.html.twig
@@ -29,7 +29,7 @@
                 <th class="listing">{{ _T('Author') }}</th>
                 <th class="listing collapsing">{{ _T('Version') }}</th>
                 <th class="listing collapsing">{{ _T('Release date') }}</th>
-                <th class="listing actions_row collapsing"></th>
+                <th class="listing actions_row collapsing">{{ _T('Actions') }}</th>
             </tr>
         </thead>
         <tbody>
@@ -77,7 +77,7 @@
             <tr>
                 <th class="listing">{{ _T('Name') }}</th>
                 <th class="listing" colspan="4">{{ _T('Cause') }}</th>
-                <th class="listing actions_row collapsing"></th>
+                <th class="listing actions_row collapsing">{{ _T('Enable') }}</th>
             </tr>
             </thead>
 {% for name, plugin in plugins_disabled_list %}

--- a/galette/templates/default/pages/plugins.html.twig
+++ b/galette/templates/default/pages/plugins.html.twig
@@ -46,19 +46,19 @@
                 <td class="actions_row collapsing">
                     <a
                         href="{{ url_for("pluginsActivation", {"action": "deactivate", "module_id": name}) }}"
-                        class="toggleActivation use"
+                        class="toggleActivation use icon-only"
                     >
-                        <i class="ui toggle on red icon tooltip" aria-hidden="true"></i>
-                        <span class="ui special popup">{{ _T("Click here to deactivate plugin '%1$s'")|format(plugin.name) }}</span>
+                        <i class="ui toggle on red icon" aria-hidden="true"></i>
+                        <span class="visually-hidden">{{ _T("Click here to deactivate plugin '%1$s'")|format(plugin.name) }}</span>
                     </a>
     {% if plugins.needsDatabase(name) %}
                     <a
                         href="{{ url_for("pluginInitDb", {"id": name}) }}"
                         id="initdb_{{ name }}"
-                        class="initdb action"
+                        class="initdb action icon-only"
                     >
-                        <i class="ui database blue icon tooltip" aria-hidden="true"></i>
-                        <span class="ui special popup">{{ _T("Initialize '%1$s' database")|format(plugin.name) }}</span>
+                        <i class="ui database blue icon" aria-hidden="true"></i>
+                        <span class="visually-hidden">{{ _T("Initialize '%1$s' database")|format(plugin.name) }}</span>
                     </a>
     {% else %}
                     <i class="ui icon">&nbsp;</i>
@@ -97,10 +97,10 @@
                 <td class="actions_row collapsing">
                     <a
                         href="{{ url_for("pluginsActivation", {"action": "activate", "module_id": name}) }}"
-                        class="toggleActivation delete"
+                        class="toggleActivation delete icon-only"
                     >
-                        <i class="ui toggle off grey icon tooltip" aria-hidden="true"></i>
-                        <span class="ui special popup">{{ _T("Activate plugin '%1$s'")|format(name) }}</span>
+                        <i class="ui toggle off grey icon" aria-hidden="true"></i>
+                        <span class="visually-hidden">{{ _T("Activate plugin '%1$s'")|format(name) }}</span>
                     </a>
                     <i class="ui icon">&nbsp;</i>
                 </td>

--- a/galette/templates/default/pages/preferences.html.twig
+++ b/galette/templates/default/pages/preferences.html.twig
@@ -785,7 +785,7 @@
                         </div>
                         <div class="field">
                             <label for="pref_mail_smtp_password">{{ _T("SMTP (or GMail) password:") }}</label>
-                            <input type="password" name="pref_mail_smtp_password" id="pref_mail_smtp_password" value="{{ pref.pref_mail_smtp_password }}" autocomplete="off" maxlength="100" size="30"/>
+                            <input type="password" name="pref_mail_smtp_password" id="pref_mail_smtp_password" value="{{ pref.pref_mail_smtp_password }}" autocomplete="new-password" maxlength="100" size="30"/>
                         </div>
                     </div>
                 </div>{# /column #}
@@ -1107,12 +1107,12 @@
                 <div id="pref_admin_pass_field" class="inline field">
                     <label for="pref_admin_pass">{{ _T("Password:") }}</label>
                     <div class="ui input">
-                        <input type="password" name="pref_admin_pass" id="pref_admin_pass" value="" maxlength="20" autocomplete="off"/>
+                        <input type="password" name="pref_admin_pass" id="pref_admin_pass" value="" maxlength="20" autocomplete="new-password"/>
                     </div>
                 </div>
                 <div class="inline field">
                     <label for="pref_admin_pass_check">{{ _T("Retype password:") }}</label>
-                    <input type="password" name="pref_admin_pass_check" id="pref_admin_pass_check" value="" maxlength="20"/>
+                    <input type="password" name="pref_admin_pass_check" id="pref_admin_pass_check" value="" maxlength="20" autocomplete="new-password"/>
                 </div>
     {% endif %}
         </div>{# /tab segment #}

--- a/galette/templates/default/pages/preferences.html.twig
+++ b/galette/templates/default/pages/preferences.html.twig
@@ -785,7 +785,7 @@
                         </div>
                         <div class="field">
                             <label for="pref_mail_smtp_password">{{ _T("SMTP (or GMail) password:") }}</label>
-                            <input type="password" name="pref_mail_smtp_password" id="pref_mail_smtp_password" value="{{ pref.pref_mail_smtp_password }}" autocomplete="new-password" maxlength="100" size="30"/>
+                            <input type="password" name="pref_mail_smtp_password" id="pref_mail_smtp_password" value="{{ pref.pref_mail_smtp_password }}" autocomplete="off" maxlength="100" size="30"/>
                         </div>
                     </div>
                 </div>{# /column #}

--- a/galette/templates/default/pages/public/list.html.twig
+++ b/galette/templates/default/pages/public/list.html.twig
@@ -60,7 +60,9 @@
         </td>
         <td class="{{ rclass }}" data-col-label="{{ _T('Nickname') }}">{{ member.nickname|escape }}</td>
         {% if login.isLogged() %}
-            <td class="{{ rclass }}" data-col-label="{{ _T('Email') }}"><a href="mailto:{{ member.email }}">{{ member.email }}</a></td>
+            <td class="{{ rclass }}" data-col-label="{{ _T('Email') }}">
+                {% if member.email != '' %}<a href="mailto:{{ member.email }}">{{ member.email }}</a>{% endif %}
+            </td>
         {% endif %}
         <td class="{{ rclass }}" data-col-label="{{ _T('Information') }}">{{ member.others_infos }}</td>
     </tr>

--- a/galette/templates/default/pages/saved_searches_list.html.twig
+++ b/galette/templates/default/pages/saved_searches_list.html.twig
@@ -68,17 +68,18 @@
             <td class="center actions_row collapsing">
                 <a
                         href="{{ url_for("loadSearch", {"id": search.id}) }}"
+                        class="icon-only"
                 >
-                    <i class="ui search icon tooltip" aria-hidden="true"></i>
-                    <span class="ui special popup">{{ _T("Load saved search") }}</span>
+                    <i class="ui search icon" aria-hidden="true"></i>
+                    <span class="visually-hidden">{{ _T("Load saved search") }}</span>
                 </a>
 
                 <a
                         href="{{ url_for("removeSearch", {"id": search.id}) }}"
-                        class="delete"
+                        class="delete icon-only"
                 >
-                    <i class="ui trash red icon tooltip" aria-hidden="true"></i>
-                    <span class="ui special popup">{{ _T("Remove saved search") }}</span>
+                    <i class="ui trash red icon" aria-hidden="true"></i>
+                    <span class="visually-hidden">{{ _T("Remove saved search") }}</span>
                 </a>
             </td>
         </tr>

--- a/galette/templates/default/pages/scheduledpayment_form.html.twig
+++ b/galette/templates/default/pages/scheduledpayment_form.html.twig
@@ -32,7 +32,7 @@
                     <div class="six wide column">
                         <div class="inline field required">
                             <label for="montant_cotis">{{ scheduled.getFieldLabel('amount') }}</label>
-                            <input type="text" name="amount" id="amount" value="{% if scheduled.getId() %}{{ scheduled.getAmount() }}{% else %}{{ scheduled.getMissingAmount() }}{% endif %}" maxlength="10" required="required"/>
+                            <input type="text" name="amount" id="montant_cotis" value="{% if scheduled.getId() %}{{ scheduled.getAmount() }}{% else %}{{ scheduled.getMissingAmount() }}{% endif %}" maxlength="10" required="required"/>
                         </div>
     {# payment type #}
     {% set ptype = scheduled.getPaymentType().id %}
@@ -61,10 +61,10 @@
                                 <div class="ui tiny header">
                                     <a
                                         href="{{ url_for("editContribution", {"type": contribution.isFee() ? constant('Galette\\Entity\\Contribution::TYPE_FEE') : constant('Galette\\Entity\\Contribution::TYPE_DONATION'), "id": contribution.id}) }}"
-                                        class="ui mini icon blue compact button tooltip"
+                                        class="ui mini icon blue compact button icon-only"
                                     >
-                                        <i class="eye icon tooltip" aria-hidden="true"></i>
-                                        <span class="ui special popup">{{ _T("View contribution") }}</span>
+                                        <i class="eye icon" aria-hidden="true"></i>
+                                        <span class="visually-hidden">{{ _T("View contribution") }}</span>
                                     </a>
                                     {{ _T("Related contribution information") }}
                                 </div>

--- a/galette/templates/default/pages/scheduledpayments_list.html.twig
+++ b/galette/templates/default/pages/scheduledpayments_list.html.twig
@@ -189,9 +189,10 @@
                             {% if login.isAdmin() or login.isStaff() or member.hasChildren() or (member.hasParent() and (member_logged_in_as != login.loggedInAs(true))) %}
                                 <a
                                     href="{{ url_for("scheduledPayments", {"option": "member", "value": "all"}) }}"
+                                    class="icon-only"
                                 >
-                                    <i class="icon times tooltip" aria-hidden="true"></i>
-                                    <span class="ui special popup">
+                                    <i class="icon times" aria-hidden="true"></i>
+                                    <span class="visually-hidden">
                                     {% if member.hasChildren() or (member.hasParent() and (member_logged_in_as != login.loggedInAs(true))) %}
                                         {{ _T("Show all your scheduled payments") }}
                                     {% else %}
@@ -266,8 +267,8 @@
                 </span>
                 {{ scheduled.getId() }}
                 {% if (login.isAdmin() or login.isStaff()) and mode != 'ajax' %}
-                    <a href="{{ url_for("editContribution", {"type": ctype, "id": contribution.id}) }}">
-                        <i class="icons tooltip" aria-hidden="true">
+                    <a href="{{ url_for("editContribution", {"type": ctype, "id": contribution.id}) }}" class="icon-only">
+                        <i class="icons" aria-hidden="true">
                             {% if contribution.isFee() %}
                                 <i class="user icon"></i>
                             {% else %}
@@ -275,7 +276,7 @@
                             {% endif %}
                           <i class="corner linkify icon"></i>
                         </i>
-                        <span class="ui special popup">
+                        <span class="visually-hidden">
                             {% if contribution.isFee() %}
                                 {{ _T("Edit membership fee %1$s")|format(contribution.id) }}
                             {% else %}
@@ -290,9 +291,10 @@
                     {% if (filters.member_filter == "" or filters.member_filter == null) and mode != "ajax" %}
                         <a
                             href="{{ url_for("scheduledPayments", {"option": "member", "value": mid}) }}"
-                            title="{{ _T("Show only '%1$s' scheduled payments")|format(mname) }}"
+                            class="icon-only"
                         >
                             <i class="filter grey small icon" aria-hidden="true"></i>
+                            <span class="visually-hidden">{{ _T("Show only '%1$s' scheduled payments")|format(mname) }}</span>
                         </a>
                     {% endif %}
                      <a
@@ -324,17 +326,17 @@
                     {% if (login.isAdmin() or login.isStaff()) %}
                         <a
                             href="{{ url_for("editScheduledPayment", {"id": scheduled.getId()}) }}"
-                            class="action"
+                            class="action icon-only"
                         >
-                            <i class="ui edit icon tooltip" aria-hidden="true"></i>
-                            <span class="ui special popup">{{ _T("Edit scheduled payment") }}</span>
+                            <i class="ui edit icon" aria-hidden="true"></i>
+                            <span class="visually-hidden">{{ _T("Edit scheduled payment") }}</span>
                         </a>
                         <a
                             href="{{ url_for("removeScheduledPayment", {"id": scheduled.getId()}) }}"
-                            class="delete"
+                            class="delete icon-only"
                         >
-                            <i class="ui trash red icon tooltip" aria-hidden="true"></i>
-                            <span class="ui special popup">{{ _T("Delete scheduled payment") }}</span>
+                            <i class="ui trash red icon" aria-hidden="true"></i>
+                            <span class="visually-hidden">{{ _T("Delete scheduled payment") }}</span>
                         </a>
                     {% endif %}
                 </td>

--- a/galette/templates/default/pages/scheduledpayments_list.html.twig
+++ b/galette/templates/default/pages/scheduledpayments_list.html.twig
@@ -263,9 +263,9 @@
         <tr class="{% if mode == 'ajax' %}schedule_row {% endif %}" id="row_{{ scheduled.getId() }}">
             <td class="collapsing" data-scope="row" data-col-label="{{ _T('ID') }}">
                 <span class="ui checkbox">
-                    <input type="checkbox" name="entries_sel[]" value="{{ scheduled.getId() }}"/>
+                    <input type="checkbox" name="entries_sel[]" id="scheduled_checkbox_{{ scheduled.getId() }}" value="{{ scheduled.getId() }}"/>
+                    <label for="scheduled_checkbox_{{ scheduled.getId() }}">{{ scheduled.getId() }}</label>
                 </span>
-                {{ scheduled.getId() }}
                 {% if (login.isAdmin() or login.isStaff()) and mode != 'ajax' %}
                     <a href="{{ url_for("editContribution", {"type": ctype, "id": contribution.id}) }}" class="icon-only">
                         <i class="icons" aria-hidden="true">

--- a/galette/templates/default/pages/status_list.html.twig
+++ b/galette/templates/default/pages/status_list.html.twig
@@ -40,18 +40,18 @@
                 </thead>
                 <tfoot>
                 <tr>
-                    <td class="collapsing" data-scope="row">
+                    <td class="collapsing" data-scope="row" data-col-label="{{ _T("New status") }}">
                         <span class="visually-hidden">
                             {{ _T("New status") }}
                         </span>
                     </td>
-                    <td class="left" data-col-label="{{ _T("Name") }}">
+                    <td class="left">
                         <div class="required field">
                             <label for="libelle_statut">{{ _T("Name") }}</label>
                             <input size="40" type="text" name="libelle_statut" id="libelle_statut" required="required"/>
                         </div>
                     </td>
-                    <td class="left" data-col-label="{{ _T("Priority") }}">
+                    <td class="left">
                         <div class="required field">
                             <label for="priorite_statut">{{ _T("Priority") }}</label>
                             <input size="4" type="text" name="priorite_statut" id="priorite_statut" value="99" />

--- a/galette/templates/default/pages/status_list.html.twig
+++ b/galette/templates/default/pages/status_list.html.twig
@@ -39,7 +39,7 @@
                 </tr>
                 </thead>
                 <tfoot>
-                <tr>
+                <tr class="bottom aligned">
                     <td class="collapsing" data-scope="row" data-col-label="{{ _T("New status") }}">
                         <span class="visually-hidden">
                             {{ _T("New status") }}

--- a/galette/templates/default/pages/status_list.html.twig
+++ b/galette/templates/default/pages/status_list.html.twig
@@ -89,27 +89,24 @@
                         <td class="center actions_row collapsing">
                             <a
                                 href="{{ url_for('editStatus', {'id': eid}) }}"
-                                class="action single-edit"
+                                class="action single-edit icon-only"
                                 aria-label="{{ _T("Edit '%s' field")|replace({'%s': entry.name}) }}"
                             >
-                                <i class="ui edit icon tooltip" aria-hidden="true"></i>
-                                <span class="ui special popup">{{ _T("Edit '%s' field")|replace({'%s': entry.name}) }}</span>
+                                <i class="ui edit icon" aria-hidden="true"></i>
                             </a>
                             <a
                                 href="{{ url_for('dynamicTranslations', {}, {'text_orig': entry.text_orig}) }}"
-                                class="action single-translate"
+                                class="action single-translate icon-only"
                                 aria-label="{{ _T("Translate '%s'")|replace({'%s': entry.name}) }}"
                             >
-                                <i class="ui language grey icon tooltip" aria-hidden="true"></i>
-                                <span class="ui special popup">{{ _T("Translate '%s'")|replace({'%s': entry.name}) }}</span>
+                                <i class="ui language grey icon" aria-hidden="true"></i>
                             </a>
                             <a
                                 href="{{ url_for('removeStatus', {'id': eid}) }}"
-                                class="delete"
+                                class="delete icon-only"
                                 aria-label="{{ _T("Delete '%s' field")|replace({'%s': entry.name}) }}"
                             >
-                                <i class="ui trash red icon tooltip" aria-hidden="true"></i>
-                                <span class="ui special popup">{{ _T("Delete '%s' field")|replace({'%s': entry.name}) }}</span>
+                                <i class="ui trash red icon" aria-hidden="true"></i>
                             </a>
                         </td>
                     </tr>

--- a/galette/templates/default/pages/status_list.html.twig
+++ b/galette/templates/default/pages/status_list.html.twig
@@ -47,14 +47,14 @@
                     </td>
                     <td class="left" data-col-label="{{ _T("Name") }}">
                         <div class="required field">
-                            <label for="name" class="visually-hidden">{{ _T("Name") }}</label>
-                            <input size="40" type="text" name="libelle_statut" required="required"/>
+                            <label for="libelle_statut">{{ _T("Name") }}</label>
+                            <input size="40" type="text" name="libelle_statut" id="libelle_statut" required="required"/>
                         </div>
                     </td>
                     <td class="left" data-col-label="{{ _T("Priority") }}">
                         <div class="required field">
-                            <label for="name" class="visually-hidden">{{ _T("Priority") }}</label>
-                            <input size="4" type="text" name="priorite_statut" value="99" />
+                            <label for="priorite_statut">{{ _T("Priority") }}</label>
+                            <input size="4" type="text" name="priorite_statut" id="priorite_statut" value="99" />
                         </div>
                     </td>
                     <td class="center actions_row collapsing">
@@ -74,7 +74,7 @@
                         </td>
                         <td class="left" data-col-label="{{ _T("Name") }}">
                             {% if entry.extra < 30 %}
-                                <span>
+                            <span>
                                 <i class="ui user tie icon tooltip" aria-hidden="true"></i>
                                 <span class="ui special popup">{{ _T("Staff member") }}</span>
                             </span>

--- a/galette/templates/default/pages/status_list.html.twig
+++ b/galette/templates/default/pages/status_list.html.twig
@@ -90,23 +90,23 @@
                             <a
                                 href="{{ url_for('editStatus', {'id': eid}) }}"
                                 class="action single-edit icon-only"
-                                aria-label="{{ _T("Edit '%s' field")|replace({'%s': entry.name}) }}"
                             >
                                 <i class="ui edit icon" aria-hidden="true"></i>
+                                <span class="visually-hidden">{{ _T("Edit '%s' field")|replace({'%s': entry.name}) }}</span>
                             </a>
                             <a
                                 href="{{ url_for('dynamicTranslations', {}, {'text_orig': entry.text_orig}) }}"
                                 class="action single-translate icon-only"
-                                aria-label="{{ _T("Translate '%s'")|replace({'%s': entry.name}) }}"
                             >
                                 <i class="ui language grey icon" aria-hidden="true"></i>
+                                <span class="visually-hidden">{{ _T("Translate '%s'")|replace({'%s': entry.name}) }}</span>
                             </a>
                             <a
                                 href="{{ url_for('removeStatus', {'id': eid}) }}"
                                 class="delete icon-only"
-                                aria-label="{{ _T("Delete '%s' field")|replace({'%s': entry.name}) }}"
                             >
                                 <i class="ui trash red icon" aria-hidden="true"></i>
+                                <span class="visually-hidden">{{ _T("Delete '%s' field")|replace({'%s': entry.name}) }}</span>
                             </a>
                         </td>
                     </tr>

--- a/galette/templates/default/pages/status_list.html.twig
+++ b/galette/templates/default/pages/status_list.html.twig
@@ -47,13 +47,13 @@
                     </td>
                     <td class="left">
                         <div class="required field">
-                            <label for="libelle_statut">{{ _T("Name") }}</label>
+                            <label for="libelle_statut" class="visually-hidden">{{ _T("Name") }}</label>
                             <input size="40" type="text" name="libelle_statut" id="libelle_statut" required="required"/>
                         </div>
                     </td>
                     <td class="left">
                         <div class="required field">
-                            <label for="priorite_statut">{{ _T("Priority") }}</label>
+                            <label for="priorite_statut" class="visually-hidden">{{ _T("Priority") }}</label>
                             <input size="4" type="text" name="priorite_statut" id="priorite_statut" value="99" />
                         </div>
                     </td>

--- a/galette/templates/default/pages/status_list.html.twig
+++ b/galette/templates/default/pages/status_list.html.twig
@@ -52,7 +52,10 @@
                         </div>
                     </td>
                     <td class="left" data-col-label="{{ _T("Priority") }}">
-                        <input size="4" type="text" name="priorite_statut" value="99" />
+                        <div class="required field">
+                            <label for="name" class="visually-hidden">{{ _T("Priority") }}</label>
+                            <input size="4" type="text" name="priorite_statut" value="99" />
+                        </div>
                     </td>
                     <td class="center actions_row collapsing">
                         <input type="hidden" name="new" value="1" />

--- a/galette/templates/default/pages/status_list.html.twig
+++ b/galette/templates/default/pages/status_list.html.twig
@@ -88,22 +88,25 @@
                         </td>
                         <td class="center actions_row collapsing">
                             <a
-                                    href="{{ url_for('editStatus', {'id': eid}) }}"
-                                    class="action single-edit"
+                                href="{{ url_for('editStatus', {'id': eid}) }}"
+                                class="action single-edit"
+                                aria-label="{{ _T("Edit '%s' field")|replace({'%s': entry.name}) }}"
                             >
                                 <i class="ui edit icon tooltip" aria-hidden="true"></i>
                                 <span class="ui special popup">{{ _T("Edit '%s' field")|replace({'%s': entry.name}) }}</span>
                             </a>
-                        <a
-                            href="{{ url_for('dynamicTranslations', {}, {'text_orig': entry.text_orig}) }}"
-                            class="action single-translate"
-                        >
-                            <i class="ui language grey icon tooltip" aria-hidden="true"></i>
-                            <span class="ui special popup">{{ _T("Translate '%s'")|replace({'%s': entry.name}) }}</span>
-                        </a>
                             <a
-                                    href="{{ url_for('removeStatus', {'id': eid}) }}"
-                                    class="delete"
+                                href="{{ url_for('dynamicTranslations', {}, {'text_orig': entry.text_orig}) }}"
+                                class="action single-translate"
+                                aria-label="{{ _T("Translate '%s'")|replace({'%s': entry.name}) }}"
+                            >
+                                <i class="ui language grey icon tooltip" aria-hidden="true"></i>
+                                <span class="ui special popup">{{ _T("Translate '%s'")|replace({'%s': entry.name}) }}</span>
+                            </a>
+                            <a
+                                href="{{ url_for('removeStatus', {'id': eid}) }}"
+                                class="delete"
+                                aria-label="{{ _T("Delete '%s' field")|replace({'%s': entry.name}) }}"
                             >
                                 <i class="ui trash red icon tooltip" aria-hidden="true"></i>
                                 <span class="ui special popup">{{ _T("Delete '%s' field")|replace({'%s': entry.name}) }}</span>

--- a/galette/templates/default/pages/transactions_list.html.twig
+++ b/galette/templates/default/pages/transactions_list.html.twig
@@ -200,18 +200,18 @@
                 {{ transaction.id }}
                 {% if (login.isAdmin() or login.isStaff() or (login.isGroupManager() and preferences.pref_bool_groupsmanagers_see_contributions)) and mode != 'ajax' %}
                     {% if transaction.getDispatchedAmount() != 0 %}
-                        <a href="{{ url_for("contributions", {"type": "contributions"}) }}?trans_id={{ transaction.id }}">
+                        <a href="{{ url_for("contributions", {"type": "contributions"}) }}?trans_id={{ transaction.id }}" class="icon-only">
                             <i class="ui linkify icon tooltip" aria-hidden="true"></i>
-                            <span class="ui special popup">{{ _T("View contributions") }}</span>
+                            <span class="visually-hidden">{{ _T("View contributions") }}</span>
                         </a>
                     {% else %}
                         <i class="ui icon" aria-hidden="true"></i>
                     {% endif %}
                 {% else %}
                     {% if transaction.getDispatchedAmount() != 0 %}
-                        <a href="{{ url_for("myContributions", {"type": "contributions"}) }}?trans_id={{ transaction.id }}">
+                        <a href="{{ url_for("myContributions", {"type": "contributions"}) }}?trans_id={{ transaction.id }}" class="icon-only">
                             <i class="ui linkify icon tooltip" aria-hidden="true"></i>
-                            <span class="ui special popup">{{ _T("View contributions") }}</span>
+                            <span class="visually-hidden">{{ _T("View contributions") }}</span>
                         </a>
                     {% else %}
                         <i class="ui icon" aria-hidden="true"></i>
@@ -244,18 +244,18 @@
                 <td class="center actions_row collapsing">
                     <a
                         href="{{ url_for("editTransaction", {"id": transaction.id}) }}"
-                        class="action"
+                        class="action icon-only"
                     >
                         <i class="ui edit icon tooltip" aria-hidden="true"></i>
-                        <span class="ui special popup">{{ _T("Edit transaction #%id")|replace({"%id": transaction.id}) }}</span>
+                        <span class="visually-hidden">{{ _T("Edit transaction #%id")|replace({"%id": transaction.id}) }}</span>
                     </a>
                     {% if login.isAdmin() or login.isStaff() %}
                     <a
                         href="{{ url_for("removeContribution", {"type": "transactions", "id": transaction.id}) }}"
-                        class="delete"
+                        class="delete icon-only"
                     >
                         <i class="ui trash red icon tooltip" aria-hidden="true"></i>
-                        <span class="ui special popup">{{ _T("Remove transaction #%id")|replace({"%id": transaction.id}) }}</span>
+                        <span class="visually-hidden">{{ _T("Remove transaction #%id")|replace({"%id": transaction.id}) }}</span>
                     </a>
                     {% endif %}
                 </td>

--- a/galette/templates/default/pages/transactions_list.html.twig
+++ b/galette/templates/default/pages/transactions_list.html.twig
@@ -201,7 +201,7 @@
                 {% if (login.isAdmin() or login.isStaff() or (login.isGroupManager() and preferences.pref_bool_groupsmanagers_see_contributions)) and mode != 'ajax' %}
                     {% if transaction.getDispatchedAmount() != 0 %}
                         <a href="{{ url_for("contributions", {"type": "contributions"}) }}?trans_id={{ transaction.id }}" class="icon-only">
-                            <i class="ui linkify icon tooltip" aria-hidden="true"></i>
+                            <i class="ui linkify icon" aria-hidden="true"></i>
                             <span class="visually-hidden">{{ _T("View contributions") }}</span>
                         </a>
                     {% else %}
@@ -210,7 +210,7 @@
                 {% else %}
                     {% if transaction.getDispatchedAmount() != 0 %}
                         <a href="{{ url_for("myContributions", {"type": "contributions"}) }}?trans_id={{ transaction.id }}" class="icon-only">
-                            <i class="ui linkify icon tooltip" aria-hidden="true"></i>
+                            <i class="ui linkify icon" aria-hidden="true"></i>
                             <span class="visually-hidden">{{ _T("View contributions") }}</span>
                         </a>
                     {% else %}
@@ -224,9 +224,10 @@
                     {% if filters.filtre_cotis_adh == "" or filters.filtre_cotis_adh == null %}
                         <a
                             href="{{ url_for("contributions", {"type": "transactions", "option": "member", "value": mid}) }}"
-                            title="{{ _T("Show only '%1$s' transactions")|format(mname) }}"
+                            class="icon-only"
                         >
                             <i class="filter grey small icon" aria-hidden="true"></i>
+                            <span class="visually-hidden">{{ _T("Show only '%1$s' transactions")|format(mname) }}</span>
                         </a>
                     {% endif %}
                     <a
@@ -246,7 +247,7 @@
                         href="{{ url_for("editTransaction", {"id": transaction.id}) }}"
                         class="action icon-only"
                     >
-                        <i class="ui edit icon tooltip" aria-hidden="true"></i>
+                        <i class="ui edit icon" aria-hidden="true"></i>
                         <span class="visually-hidden">{{ _T("Edit transaction #%id")|replace({"%id": transaction.id}) }}</span>
                     </a>
                     {% if login.isAdmin() or login.isStaff() %}
@@ -254,7 +255,7 @@
                         href="{{ url_for("removeContribution", {"type": "transactions", "id": transaction.id}) }}"
                         class="delete icon-only"
                     >
-                        <i class="ui trash red icon tooltip" aria-hidden="true"></i>
+                        <i class="ui trash red icon" aria-hidden="true"></i>
                         <span class="visually-hidden">{{ _T("Remove transaction #%id")|replace({"%id": transaction.id}) }}</span>
                     </a>
                     {% endif %}

--- a/tests/Galette/Controllers/Crud/ContributionsController.php
+++ b/tests/Galette/Controllers/Crud/ContributionsController.php
@@ -256,17 +256,17 @@ class ContributionsController extends GaletteRoutingTestCase
         $body = (string)$test_response->getBody();
         //member one contribution is listed
         $this->assertStringContainsString(
-            sprintf('<input type="checkbox" name="entries_sel[]" value="%1$s"/>', $contrib_one->id),
+            sprintf('<input type="checkbox" name="entries_sel[]" id="entry_sel_%1$s" value="%1$s"/>', $contrib_one->id),
             $body
         );
         //member child contribution is listed
         $this->assertStringContainsString(
-            sprintf('<input type="checkbox" name="entries_sel[]" value="%1$s"/>', $child_contrib->id),
+            sprintf('<input type="checkbox" name="entries_sel[]" id="entry_sel_%1$s" value="%1$s"/>', $child_contrib->id),
             $body
         );
         //second member contribution is listed
         $this->assertStringContainsString(
-            sprintf('<input type="checkbox" name="entries_sel[]" value="%1$s"/>', $contrib_two->id),
+            sprintf('<input type="checkbox" name="entries_sel[]" id="entry_sel_%1$s" value="%1$s"/>', $contrib_two->id),
             $body
         );
         $this->login->logout();
@@ -289,17 +289,17 @@ class ContributionsController extends GaletteRoutingTestCase
         $body = (string)$test_response->getBody();
         //member one contribution is listed
         $this->assertStringContainsString(
-            sprintf('<input type="checkbox" name="entries_sel[]" value="%1$s"/>', $contrib_one->id),
+            sprintf('<input type="checkbox" name="entries_sel[]" id="entry_sel_%1$s" value="%1$s"/>', $contrib_one->id),
             $body
         );
         //member child contribution is listed
         $this->assertStringContainsString(
-            sprintf('<input type="checkbox" name="entries_sel[]" value="%1$s"/>', $child_contrib->id),
+            sprintf('<input type="checkbox" name="entries_sel[]" id="entry_sel_%1$s" value="%1$s"/>', $child_contrib->id),
             $body
         );
         //second member contribution is listed
         $this->assertStringContainsString(
-            sprintf('<input type="checkbox" name="entries_sel[]" value="%1$s"/>', $contrib_two->id),
+            sprintf('<input type="checkbox" name="entries_sel[]" id="entry_sel_%1$s" value="%1$s"/>', $contrib_two->id),
             $body
         );
 

--- a/tests/Galette/Controllers/Crud/ScheduledPaymentController.php
+++ b/tests/Galette/Controllers/Crud/ScheduledPaymentController.php
@@ -177,12 +177,12 @@ class ScheduledPaymentController extends GaletteRoutingTestCase
         $body = (string)$test_response->getBody();
         //member one scheduled payment is listed
         $this->assertStringContainsString(
-            sprintf('<input type="checkbox" name="entries_sel[]" value="%1$s"/>', $scheduled_one->getId()),
+            sprintf('<input type="checkbox" name="entries_sel[]" id="scheduled_checkbox_%1$s" value="%1$s"/>', $scheduled_one->getId()),
             $body
         );
         //member two scheduled payment is listed
         $this->assertStringContainsString(
-            sprintf('<input type="checkbox" name="entries_sel[]" value="%1$s"/>', $scheduled_two->getId()),
+            sprintf('<input type="checkbox" name="entries_sel[]" id="scheduled_checkbox_%1$s" value="%1$s"/>', $scheduled_two->getId()),
             $body
         );
 

--- a/tests/Galette/Controllers/Crud/ScheduledPaymentController.php
+++ b/tests/Galette/Controllers/Crud/ScheduledPaymentController.php
@@ -138,13 +138,13 @@ class ScheduledPaymentController extends GaletteRoutingTestCase
 
         //member one scheduled payment is listed
         $this->assertStringContainsString(
-            sprintf('<input type="checkbox" name="entries_sel[]" value="%1$s"/>', $scheduled_one->getId()),
+            sprintf('<input type="checkbox" name="entries_sel[]" id="scheduled_checkbox_%1$s" value="%1$s"/>', $scheduled_one->getId()),
             $body
         );
 
         //member two scheduled payment is not listed
         $this->assertStringNotContainsString(
-            sprintf('<input type="checkbox" name="entries_sel[]" value="%1$s"/>', $scheduled_two->getId()),
+            sprintf('<input type="checkbox" name="entries_sel[]" id="scheduled_checkbox_%1$s" value="%1$s"/>', $scheduled_two->getId()),
             $body
         );
         $this->login->logOut();
@@ -157,12 +157,12 @@ class ScheduledPaymentController extends GaletteRoutingTestCase
         $body = (string)$test_response->getBody();
         //member one scheduled payment is listed
         $this->assertStringContainsString(
-            sprintf('<input type="checkbox" name="entries_sel[]" value="%1$s"/>', $scheduled_one->getId()),
+            sprintf('<input type="checkbox" name="entries_sel[]" id="scheduled_checkbox_%1$s" value="%1$s"/>', $scheduled_one->getId()),
             $body
         );
         //member two scheduled payment is listed
         $this->assertStringContainsString(
-            sprintf('<input type="checkbox" name="entries_sel[]" value="%1$s"/>', $scheduled_two->getId()),
+            sprintf('<input type="checkbox" name="entries_sel[]" id="scheduled_checkbox_%1$s" value="%1$s"/>', $scheduled_two->getId()),
             $body
         );
 

--- a/tests/e2e/fixtures/a11y.fixture.ts
+++ b/tests/e2e/fixtures/a11y.fixture.ts
@@ -36,7 +36,7 @@ import type { Page } from '@playwright/test';
  */
 export function axeBuilder(page: Page): AxeBuilder {
   //FIXME: real A11y issues must be fixed in order to activate all tags.
-  return new AxeBuilder({ page }).withTags(['wcag21a', 'wcag21aa', 'RGAAv4']);
+  return new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'RGAAv4']);
 }
 
 /**

--- a/tests/e2e/fixtures/a11y.fixture.ts
+++ b/tests/e2e/fixtures/a11y.fixture.ts
@@ -36,7 +36,7 @@ import type { Page } from '@playwright/test';
  */
 export function axeBuilder(page: Page): AxeBuilder {
   //FIXME: real A11y issues must be fixed in order to activate all tags.
-  return new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'RGAAv4', 'best-practice']);
+  return new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'RGAAv4', 'best-practice', 'EN-301-549']);
 }
 
 /**

--- a/tests/e2e/fixtures/a11y.fixture.ts
+++ b/tests/e2e/fixtures/a11y.fixture.ts
@@ -36,7 +36,7 @@ import type { Page } from '@playwright/test';
  */
 export function axeBuilder(page: Page): AxeBuilder {
   //FIXME: real A11y issues must be fixed in order to activate all tags.
-  return new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'RGAAv4']);
+  return new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'RGAAv4', 'best-practice']);
 }
 
 /**

--- a/tests/e2e/fixtures/a11y.fixture.ts
+++ b/tests/e2e/fixtures/a11y.fixture.ts
@@ -36,7 +36,7 @@ import type { Page } from '@playwright/test';
  */
 export function axeBuilder(page: Page): AxeBuilder {
   //FIXME: real A11y issues must be fixed in order to activate all tags.
-  return new AxeBuilder({ page }).withTags(['wcag21a'/*, 'wcag21aa', 'RGAAv4'*/]);
+  return new AxeBuilder({ page }).withTags(['wcag21a', 'wcag21aa', 'RGAAv4']);
 }
 
 /**

--- a/tests/e2e/fixtures/a11y.fixture.ts
+++ b/tests/e2e/fixtures/a11y.fixture.ts
@@ -36,6 +36,7 @@ import type { Page } from '@playwright/test';
  */
 export function axeBuilder(page: Page): AxeBuilder {
   //FIXME: real A11y issues must be fixed in order to activate all tags.
+  // See available tags: https://www.deque.com/axe/core-documentation/api-documentation/#axecore-tags
   return new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'RGAAv4', 'best-practice', 'EN-301-549']);
 }
 

--- a/tests/e2e/specs/a11y.spec.ts
+++ b/tests/e2e/specs/a11y.spec.ts
@@ -67,7 +67,7 @@ test.describe('Accessibility', () => {
     await listPage.goto();
     await listPage.memberTable.waitFor({ state: 'visible' });
 
-    const results = await axeBuilder(page).analyze();
+    const results = await axeBuilder(page).exclude('*[autocomplete="fomantic-search"]').analyze();
     expect(results.violations, formatViolations(results.violations)).toEqual([]);
   });
 
@@ -90,7 +90,7 @@ test.describe('Accessibility', () => {
     await page.goto('/member/add');
     await page.locator('#nom_adh').waitFor({ state: 'visible' });
 
-    const results = await axeBuilder(page).analyze();
+    const results = await axeBuilder(page).exclude('*[autocomplete="fomantic-search"]').analyze();
     expect(results.violations, formatViolations(results.violations)).toEqual([]);
   });
 
@@ -99,7 +99,7 @@ test.describe('Accessibility', () => {
     const searchInput = page.locator('#filter_str');
     await searchInput.waitFor({ state: 'visible' });
 
-    const results = await axeBuilder(page).include('form, [role="search"]').analyze();
+    const results = await axeBuilder(page).exclude('*[autocomplete="fomantic-search"]').include('form, [role="search"]').analyze();
     expect(results.violations, formatViolations(results.violations)).toEqual([]);
   });
 
@@ -137,7 +137,7 @@ test.describe('Accessibility', () => {
     await page.locator('form a[href*="/contribution/fee/add"]').click();
     await page.locator('#montant_cotis').waitFor({ state: 'visible' });
 
-    const results = await axeBuilder(page).analyze();
+    const results = await axeBuilder(page).exclude('*[autocomplete="fomantic-search"]').analyze();
     expect(results.violations, formatViolations(results.violations)).toEqual([]);
   });
 
@@ -191,7 +191,7 @@ test.describe('Accessibility', () => {
       await groupRows.first().locator('a[href*="/group/edit/"]').click();
       await page.locator('h1, h2').waitFor({ state: 'visible' });
 
-      const results = await axeBuilder(page).analyze();
+      const results = await axeBuilder(page).exclude('*[autocomplete="fomantic-search"]').analyze();
       expect(results.violations, formatViolations(results.violations)).toEqual([]);
     }
   });
@@ -209,7 +209,7 @@ test.describe('Accessibility', () => {
     await page.goto('/contributions-types');
     await page.locator('h1, h2').waitFor({ state: 'visible' });
 
-    const results = await axeBuilder(page).analyze();
+    const results = await axeBuilder(page).exclude('*[autocomplete="fomantic-search"]').analyze();
     expect(results.violations, formatViolations(results.violations)).toEqual([]);
   });
 

--- a/tests/e2e/specs/a11y.spec.ts
+++ b/tests/e2e/specs/a11y.spec.ts
@@ -190,10 +190,8 @@ test.describe('Accessibility', () => {
       // Navigate to first group's edit page
       await groupRows.first().locator('a[href*="/group/edit/"]').click();
       await page.locator('h1, h2').waitFor({ state: 'visible' });
-      const disbaled_btns = page.locator('button.disabled');
-      await expect(disbaled_btns).toHaveCount(0);
 
-      const results = await axeBuilder(page).exclude('*[autocomplete="fomantic-search"]').analyze();
+      const results = await axeBuilder(page).exclude('*[autocomplete="fomantic-search"],#btnmanagers_small,#btnusers_small').analyze();
       expect(results.violations, formatViolations(results.violations)).toEqual([]);
     }
   });

--- a/tests/e2e/specs/a11y.spec.ts
+++ b/tests/e2e/specs/a11y.spec.ts
@@ -45,6 +45,14 @@ test.describe('Accessibility', () => {
     expect(results.violations, formatViolations(results.violations)).toEqual([]);
   });
 
+  base('A11y - 404 page', async ({ page }) => {
+    await page.goto('/invalid-url');
+    await page.locator('h1').waitFor({ state: 'visible' });
+
+    const results = await axeBuilder(page).analyze();
+    expect(results.violations, formatViolations(results.violations)).toEqual([]);
+  });
+
   // Dashboard
   test('A11y - Dashboard page', async ({ loggedInPage: page }) => {
     await page.goto('/dashboard');
@@ -94,6 +102,14 @@ test.describe('Accessibility', () => {
     expect(results.violations, formatViolations(results.violations)).toEqual([]);
   });
 
+  test('A11y - Member advanced search', async ({ loggedInPage: page }) => {
+    await page.goto('/advanced-search');
+    await page.locator('#filter_str').waitFor({ state: 'visible' });
+
+    const results = await axeBuilder(page).exclude('*[autocomplete="fomantic-search"]').analyze();
+    expect(results.violations, formatViolations(results.violations)).toEqual([]);
+  });
+
   test('A11y - Members search form', async ({ loggedInPage: page }) => {
     await page.goto('/members');
     const searchInput = page.locator('#filter_str');
@@ -136,6 +152,15 @@ test.describe('Accessibility', () => {
       .click();
     await page.locator('form a[href*="/contribution/fee/add"]').click();
     await page.locator('#montant_cotis').waitFor({ state: 'visible' });
+
+    const results = await axeBuilder(page).exclude('*[autocomplete="fomantic-search"]').analyze();
+    expect(results.violations, formatViolations(results.violations)).toEqual([]);
+  });
+
+  // Scheduled payments
+  test('A11y - Scheduled payments list page', async ({ loggedInPage: page }) => {
+    await page.goto('/scheduled-payments');
+    await page.locator('table.listing').waitFor({ state: 'visible' });
 
     const results = await axeBuilder(page).exclude('*[autocomplete="fomantic-search"]').analyze();
     expect(results.violations, formatViolations(results.violations)).toEqual([]);
@@ -205,6 +230,38 @@ test.describe('Accessibility', () => {
     expect(results.violations, formatViolations(results.violations)).toEqual([]);
   });
 
+  test('A11y - Plugins page', async ({ loggedInPage: page }) => {
+    await page.goto('/plugins');
+    await page.locator('table.listing').waitFor({ state: 'visible' });
+
+    const results = await axeBuilder(page).analyze();
+    expect(results.violations, formatViolations(results.violations)).toEqual([]);
+  });
+
+  test('A11y - Core list configuration page', async ({ loggedInPage: page }) => {
+    await page.goto('/lists/adherents/configure');
+    await page.locator('table.listing').waitFor({ state: 'visible' });
+
+    const results = await axeBuilder(page).analyze();
+    expect(results.violations, formatViolations(results.violations)).toEqual([]);
+  });
+
+  test('A11y - Core fields configuration page', async ({ loggedInPage: page }) => {
+    await page.goto('/fields/core/configure');
+    await page.locator('table.listing').waitFor({ state: 'visible' });
+
+    const results = await axeBuilder(page).analyze();
+    expect(results.violations, formatViolations(results.violations)).toEqual([]);
+  });
+
+  test('A11y - Dynamic fields configuration page', async ({ loggedInPage: page }) => {
+    await page.goto('/fields/dynamic/configure');
+    await page.locator('table.listing').waitFor({ state: 'visible' });
+
+    const results = await axeBuilder(page).analyze();
+    expect(results.violations, formatViolations(results.violations)).toEqual([]);
+  });
+
   test('A11y - Contribution types page', async ({ loggedInPage: page }) => {
     await page.goto('/contributions-types');
     await page.locator('h1, h2').waitFor({ state: 'visible' });
@@ -213,6 +270,16 @@ test.describe('Accessibility', () => {
       .exclude('*[autocomplete="fomantic-search"]')
       .exclude('.note-editable') // Summernote related issue
       .exclude('.note-resizebar') //Summernote issue
+      .analyze();
+    expect(results.violations, formatViolations(results.violations)).toEqual([]);
+  });
+
+  test('A11y - Payment types page', async ({ loggedInPage: page }) => {
+    await page.goto('/payment-types');
+    await page.locator('h1, h2').waitFor({ state: 'visible' });
+
+    const results = await axeBuilder(page)
+      .exclude('*[autocomplete="fomantic-search"]')
       .analyze();
     expect(results.violations, formatViolations(results.violations)).toEqual([]);
   });
@@ -250,6 +317,22 @@ test.describe('Accessibility', () => {
     expect(results.violations, formatViolations(results.violations)).toEqual([]);
   });
 
+  test('A11y - Import model configuration page', async ({ loggedInPage: page }) => {
+    await page.goto('/import/model');
+    await page.waitForSelector('a[href*="/import/model/get"]', { timeout: 10000 });
+
+    const results = await axeBuilder(page).analyze();
+    expect(results.violations, formatViolations(results.violations)).toEqual([]);
+  });
+
+  test('A11y - Import model change page', async ({ loggedInPage: page }) => {
+    await page.goto('/import/model?tab=change');
+    await page.waitForSelector('#store-model', { timeout: 10000 });
+
+    const results = await axeBuilder(page).analyze();
+    expect(results.violations, formatViolations(results.violations)).toEqual([]);
+  });
+
   // Public Pages - by default, limited to up-to-date members.
   test('A11y - Public members list', async ({ loggedInPage: page }) => {
     await page.goto('/public/members/list');
@@ -262,6 +345,30 @@ test.describe('Accessibility', () => {
   test('A11y - Public members gallery', async ({ loggedInPage: page }) => {
     await page.goto('/public/members/gallery');
     await page.waitForSelector('h1, h2, .ui.message', { timeout: 10000 });
+
+    const results = await axeBuilder(page).analyze();
+    expect(results.violations, formatViolations(results.violations)).toEqual([]);
+  });
+
+  test('A11y - Public staff list', async ({ loggedInPage: page }) => {
+    await page.goto('/public/staff/list');
+    await page.waitForSelector('h1, h2, .ui.message', { timeout: 10000 });
+
+    const results = await axeBuilder(page).analyze();
+    expect(results.violations, formatViolations(results.violations)).toEqual([]);
+  });
+
+  test('A11y - Public staff gallery', async ({ loggedInPage: page }) => {
+    await page.goto('/public/staff/gallery');
+    await page.waitForSelector('h1, h2, .ui.message', { timeout: 10000 });
+
+    const results = await axeBuilder(page).analyze();
+    expect(results.violations, formatViolations(results.violations)).toEqual([]);
+  });
+
+  test('A11y - Public documents list', async ({ loggedInPage: page }) => {
+    await page.goto('/public/documents');
+    await page.waitForSelector('.ui.message', { timeout: 10000 });
 
     const results = await axeBuilder(page).analyze();
     expect(results.violations, formatViolations(results.violations)).toEqual([]);

--- a/tests/e2e/specs/a11y.spec.ts
+++ b/tests/e2e/specs/a11y.spec.ts
@@ -108,7 +108,7 @@ test.describe('Accessibility', () => {
     await page.goto('/contributions');
     await page.locator('table.listing').waitFor({ state: 'visible' });
 
-    const results = await axeBuilder(page).disableRules(['autocomplete-valid']).analyze();
+    const results = await axeBuilder(page).exclude('*[autocomplete="fomantic-search"]').analyze();
     expect(results.violations, formatViolations(results.violations)).toEqual([]);
   });
 
@@ -154,9 +154,9 @@ test.describe('Accessibility', () => {
     await page.goto('/transactions');
     await page.locator('table.listing').waitFor({ state: 'visible' });
 
-    const firstContribution = page.locator('a[href*="/transaction"]').first();
-    if (await firstContribution.isVisible()) {
-      await firstContribution.click();
+    const firstTransaction = page.locator('a[href*="/transaction"]').first();
+    if (await firstTransaction.isVisible()) {
+      await firstTransaction.click();
       await page.locator('h1, h2').waitFor({ state: 'visible' });
 
       const results = await axeBuilder(page).analyze();
@@ -165,17 +165,10 @@ test.describe('Accessibility', () => {
   });
 
   test('A11y - Transaction add form', async ({ loggedInPage: page }) => {
-    // Navigate via member's transaction page to pre-select member
-    const listPage = new MemberListPage(page);
-    await listPage.goto();
-    await listPage.filterByName('SKYWALKER Luke');
-    await listPage.getMemberRowByName('SKYWALKER Luke')
-      .locator('a:has(i.receipt.green.icon)')
-      .click();
-    await page.locator('form a[href*="/transaction/add"]').click();
-    await page.locator('#montant_cotis').waitFor({ state: 'visible' });
+    await page.goto('/transaction/add');
+    await page.locator('#trans_amount').waitFor({ state: 'visible' });
 
-    const results = await axeBuilder(page).analyze();
+    const results = await axeBuilder(page).exclude('*[autocomplete="fomantic-search"]').analyze();
     expect(results.violations, formatViolations(results.violations)).toEqual([]);
   });
 

--- a/tests/e2e/specs/a11y.spec.ts
+++ b/tests/e2e/specs/a11y.spec.ts
@@ -197,6 +197,14 @@ test.describe('Accessibility', () => {
     expect(results.violations, formatViolations(results.violations)).toEqual([]);
   });
 
+  test('A11y - Reminders', async ({ loggedInPage: page }) => {
+    await page.goto('/reminders');
+    await page.locator('#send_reminders').waitFor({ state: 'visible' });
+
+    const results = await axeBuilder(page).analyze();
+    expect(results.violations, formatViolations(results.violations)).toEqual([]);
+  });
+
   // Groups
   test('A11y - Groups list page', async ({ loggedInPage: page }) => {
     await page.goto('/groups');
@@ -219,6 +227,45 @@ test.describe('Accessibility', () => {
       const results = await axeBuilder(page).exclude('*[autocomplete="fomantic-search"],#btnmanagers_small,#btnusers_small').analyze();
       expect(results.violations, formatViolations(results.violations)).toEqual([]);
     }
+  });
+
+  // Documents
+  test('A11y - Documents list page', async ({ loggedInPage: page }) => {
+    await page.goto('/documents');
+    await page.locator('h1, h2').waitFor({ state: 'visible' });
+
+    const results = await axeBuilder(page).analyze();
+    expect(results.violations, formatViolations(results.violations)).toEqual([]);
+  });
+
+  test('A11y - Documents add page', async ({ loggedInPage: page }) => {
+    await page.goto('/document/add');
+    await page.locator('h1, h2').waitFor({ state: 'visible' });
+
+    const results = await axeBuilder(page)
+      .exclude('*[autocomplete="fomantic-search"]')
+      .exclude('.note-editable') // Summernote related issue
+      .exclude('.note-resizebar') //Summernote issue
+      .analyze();
+    expect(results.violations, formatViolations(results.violations)).toEqual([]);
+  });
+
+  // Charts
+  test('A11y - Charts', async ({ loggedInPage: page }) => {
+    await page.goto('/charts');
+    await page.locator('h1').waitFor({ state: 'visible' });
+
+    const results = await axeBuilder(page).analyze();
+    expect(results.violations, formatViolations(results.violations)).toEqual([]);
+  });
+
+  // History
+  test('A11y - History', async ({ loggedInPage: page }) => {
+    await page.goto('/history');
+    await page.locator('table.listing').waitFor({ state: 'visible' });
+
+    const results = await axeBuilder(page).exclude('*[autocomplete="fomantic-search"]').analyze();
+    expect(results.violations, formatViolations(results.violations)).toEqual([]);
   });
 
   // Configuration

--- a/tests/e2e/specs/a11y.spec.ts
+++ b/tests/e2e/specs/a11y.spec.ts
@@ -108,7 +108,7 @@ test.describe('Accessibility', () => {
     await page.goto('/contributions');
     await page.locator('table.listing').waitFor({ state: 'visible' });
 
-    const results = await axeBuilder(page).analyze();
+    const results = await axeBuilder(page).disableRules(['autocomplete-valid']).analyze();
     expect(results.violations, formatViolations(results.violations)).toEqual([]);
   });
 

--- a/tests/e2e/specs/a11y.spec.ts
+++ b/tests/e2e/specs/a11y.spec.ts
@@ -34,6 +34,8 @@ import { test } from '../fixtures/auth.fixture';
 import { axeBuilder, formatViolations } from '../fixtures/a11y.fixture';
 import { MemberListPage } from '../pages/MemberListPage';
 
+let animationTimeout = 500;
+
 test.describe('Accessibility', () => {
 
   // Public Pages
@@ -84,7 +86,7 @@ test.describe('Accessibility', () => {
     const searchInput = page.locator('#filter_str').first();
     await searchInput.fill('luke');
     await page.locator('button[type="submit"]').first().click();
-    await page.waitForTimeout(500);
+    await page.waitForTimeout(animationTimeout);
 
     const memberLink = page.locator('a:has-text("Skywalker")').first();
     await memberLink.click();
@@ -223,8 +225,9 @@ test.describe('Accessibility', () => {
       // Navigate to first group's edit page
       await groupRows.first().locator('a[href*="/group/edit/"]').click();
       await page.locator('h1, h2').waitFor({ state: 'visible' });
+      await page.waitForTimeout(animationTimeout);
 
-      const results = await axeBuilder(page).exclude('*[autocomplete="fomantic-search"],#btnmanagers_small,#btnusers_small').analyze();
+      const results = await axeBuilder(page).exclude('*[autocomplete="fomantic-search"]').analyze();
       expect(results.violations, formatViolations(results.violations)).toEqual([]);
     }
   });
@@ -309,6 +312,18 @@ test.describe('Accessibility', () => {
     expect(results.violations, formatViolations(results.violations)).toEqual([]);
   });
 
+  test('A11y - Dynamic fields add', async ({ loggedInPage: page }) => {
+    await page.goto('/fields/dynamic/configure');
+    await page.locator('table.listing').waitFor({ state: 'visible' });
+
+    await page.getByRole('link', { name: 'Add' }).click();
+    await page.getByRole('textbox', { name: 'Field name' }).waitFor({ state: 'visible' });
+    await page.waitForTimeout(animationTimeout);
+
+    const results = await axeBuilder(page).analyze();
+    expect(results.violations, formatViolations(results.violations)).toEqual([]);
+  });
+
   test('A11y - Contribution types page', async ({ loggedInPage: page }) => {
     await page.goto('/contributions-types');
     await page.locator('h1, h2').waitFor({ state: 'visible' });
@@ -341,6 +356,14 @@ test.describe('Accessibility', () => {
 
   test('A11y - Status page', async ({ loggedInPage: page }) => {
     await page.goto('/status');
+    await page.waitForSelector('form, table', { timeout: 10000 });
+
+    const results = await axeBuilder(page).analyze();
+    expect(results.violations, formatViolations(results.violations)).toEqual([]);
+  });
+
+  test('A11y - Dynamic translations page', async ({ loggedInPage: page }) => {
+    await page.goto('/dynamic-translations?text_orig=President');
     await page.waitForSelector('form, table', { timeout: 10000 });
 
     const results = await axeBuilder(page).analyze();

--- a/tests/e2e/specs/a11y.spec.ts
+++ b/tests/e2e/specs/a11y.spec.ts
@@ -209,7 +209,11 @@ test.describe('Accessibility', () => {
     await page.goto('/contributions-types');
     await page.locator('h1, h2').waitFor({ state: 'visible' });
 
-    const results = await axeBuilder(page).exclude('*[autocomplete="fomantic-search"]').analyze();
+    const results = await axeBuilder(page)
+      .exclude('*[autocomplete="fomantic-search"]')
+      .exclude('.note-editable') // Summernote related issue
+      .exclude('.note-resizebar') //Summernote issue
+      .analyze();
     expect(results.violations, formatViolations(results.violations)).toEqual([]);
   });
 

--- a/tests/e2e/specs/a11y.spec.ts
+++ b/tests/e2e/specs/a11y.spec.ts
@@ -141,6 +141,44 @@ test.describe('Accessibility', () => {
     expect(results.violations, formatViolations(results.violations)).toEqual([]);
   });
 
+  // Transactions
+  test('A11y - Transaction list page', async ({ loggedInPage: page }) => {
+    await page.goto('/transactions');
+    await page.locator('table.listing').waitFor({ state: 'visible' });
+
+    const results = await axeBuilder(page).analyze();
+    expect(results.violations, formatViolations(results.violations)).toEqual([]);
+  });
+
+  test('A11y - Transaction details page', async ({ loggedInPage: page }) => {
+    await page.goto('/transactions');
+    await page.locator('table.listing').waitFor({ state: 'visible' });
+
+    const firstContribution = page.locator('a[href*="/transaction"]').first();
+    if (await firstContribution.isVisible()) {
+      await firstContribution.click();
+      await page.locator('h1, h2').waitFor({ state: 'visible' });
+
+      const results = await axeBuilder(page).analyze();
+      expect(results.violations, formatViolations(results.violations)).toEqual([]);
+    }
+  });
+
+  test('A11y - Transaction add form', async ({ loggedInPage: page }) => {
+    // Navigate via member's transaction page to pre-select member
+    const listPage = new MemberListPage(page);
+    await listPage.goto();
+    await listPage.filterByName('SKYWALKER Luke');
+    await listPage.getMemberRowByName('SKYWALKER Luke')
+      .locator('a:has(i.receipt.green.icon)')
+      .click();
+    await page.locator('form a[href*="/transaction/add"]').click();
+    await page.locator('#montant_cotis').waitFor({ state: 'visible' });
+
+    const results = await axeBuilder(page).analyze();
+    expect(results.violations, formatViolations(results.violations)).toEqual([]);
+  });
+
   // Groups
   test('A11y - Groups list page', async ({ loggedInPage: page }) => {
     await page.goto('/groups');

--- a/tests/e2e/specs/a11y.spec.ts
+++ b/tests/e2e/specs/a11y.spec.ts
@@ -190,8 +190,6 @@ test.describe('Accessibility', () => {
       // Navigate to first group's edit page
       await groupRows.first().locator('a[href*="/group/edit/"]').click();
       await page.locator('h1, h2').waitFor({ state: 'visible' });
-      const disbaled_btns = page.locator('button.disabled');
-      await expect(disbaled_btns).toHaveCount(0);
 
       const results = await axeBuilder(page).exclude('*[autocomplete="fomantic-search"]').analyze();
       expect(results.violations, formatViolations(results.violations)).toEqual([]);

--- a/tests/e2e/specs/a11y.spec.ts
+++ b/tests/e2e/specs/a11y.spec.ts
@@ -190,6 +190,8 @@ test.describe('Accessibility', () => {
       // Navigate to first group's edit page
       await groupRows.first().locator('a[href*="/group/edit/"]').click();
       await page.locator('h1, h2').waitFor({ state: 'visible' });
+      const disbaled_btns = page.locator('button.disabled');
+      await expect(disbaled_btns).toHaveCount(0);
 
       const results = await axeBuilder(page).exclude('*[autocomplete="fomantic-search"]').analyze();
       expect(results.violations, formatViolations(results.violations)).toEqual([]);

--- a/tests/e2e/specs/a11y.spec.ts
+++ b/tests/e2e/specs/a11y.spec.ts
@@ -242,13 +242,13 @@ test.describe('Accessibility', () => {
     await page.goto('/lists/adherents/configure');
     await page.locator('table.listing').waitFor({ state: 'visible' });
 
-    const results = await axeBuilder(page).analyze();
+    const results = await axeBuilder(page).exclude('*[autocomplete="fomantic-search"]').analyze();
     expect(results.violations, formatViolations(results.violations)).toEqual([]);
   });
 
   test('A11y - Core fields configuration page', async ({ loggedInPage: page }) => {
     await page.goto('/fields/core/configure');
-    await page.locator('table.listing').waitFor({ state: 'visible' });
+    await page.locator('#sortable_categories').waitFor({ state: 'visible' });
 
     const results = await axeBuilder(page).analyze();
     expect(results.violations, formatViolations(results.violations)).toEqual([]);

--- a/ui/js/common.js
+++ b/ui/js/common.js
@@ -36,6 +36,7 @@ var _bindFomanticComponents = function() {
         $checkbox        = $('.ui.checkbox, .ui.radio.checkbox'),
         $tabulation      = $('.ui.tabbed .item'),
         $popup           = $('a[title], .tooltip'),
+        $iconOnly        = $('.icon-only'),
         $inlinePopup     = $('.inline-tooltip'),
         $infoPopup       = $('i.circular.basic.question.icon.tooltip'),
         $menuPopupRight  = $('.ui.vertical.accordion.menu a[title]'),
@@ -85,6 +86,16 @@ var _bindFomanticComponents = function() {
             variation: 'inverted',
             inline: false,
             addTouchEvents: false,
+        })
+    ;
+    $iconOnly.each(function() {
+        const $this = $(this);
+        $this.popup({
+            variation: 'inverted',
+            inline: false,
+            addTouchEvents: false,
+            content: $this.attr('aria-label'),
+            });
         })
     ;
     $inlinePopup

--- a/ui/js/common.js
+++ b/ui/js/common.js
@@ -94,7 +94,7 @@ var _bindFomanticComponents = function() {
             variation: 'inverted',
             inline: false,
             addTouchEvents: false,
-            content: $this.attr('aria-label'),
+            content: $this.find('.visually-hidden').html(),
             });
         })
     ;

--- a/ui/semantic/galette/collections/form.overrides
+++ b/ui/semantic/galette/collections/form.overrides
@@ -84,6 +84,13 @@
   margin-bottom: 0;
 }
 
+/*-------------------------------
+      Socials combo fields
+--------------------------------*/
+.ui.form .addsocial .combo-social.fields {
+  align-items: end;
+}
+
 /*--------------------------
       Mass change + label
 ---------------------------*/

--- a/ui/semantic/galette/collections/table.overrides
+++ b/ui/semantic/galette/collections/table.overrides
@@ -26,15 +26,20 @@
 /*----------------------
      Listing tables
 -----------------------*/
-table.listing td {
-    line-height:1.5em;
-    padding:.1em .2em;
-}
-table.listing tbody tr:hover > td {
-    background-color: @activeLineBackgroundColor !important;
+table.listing {
+    tbody tr:hover > td {
+        background-color: @activeLineBackgroundColor !important;
 
-    a {
-        color: darken(@linkColor, 5);
+        a {
+            color: darken(@linkColor, 5);
+        }
+    }
+    td {
+        line-height:1.5em;
+        padding:.1em .2em;
+    }
+    tfoot .bottom.aligned button {
+        margin-bottom: 1px;
     }
 }
 td.emptylist {

--- a/ui/semantic/galette/collections/table.overrides
+++ b/ui/semantic/galette/collections/table.overrides
@@ -37,6 +37,10 @@ table.listing {
     td {
         line-height:1.5em;
         padding:.1em .2em;
+
+        a:not(.icon-only) {
+            text-decoration: underline
+        }
     }
     tfoot .bottom.aligned button {
         margin-bottom: 1px;

--- a/ui/semantic/galette/globals/site.overrides
+++ b/ui/semantic/galette/globals/site.overrides
@@ -573,6 +573,7 @@ ul.leaders span + span {
 /*-----------------------------
     Summernote display
 ------------------------------*/
+tfoot .note-editor .note-editable,
 .field .note-editor.note-frame .note-editing-area .note-editable[contenteditable="false"] {
     background-color: #fff;
 }


### PR DESCRIPTION
Enable wcag21aa and rgaav4 in Playwright a11y tests.

A graphical report is available on build summaries:
https://github.com/galette/galette/actions/runs/24474947060?pr=826

Unfortunately, the full report with errors is too large to be displayed; the best option is probably to download the playwright report, unzip it and open it on a local instance with:
```
$ cd /path/to/galette
npx playwright show-report "/path/to/playwright-report"
```

For a complete Playwright guide, see https://github.com/galette/galette/blob/develop/README.tests.md#running-e2e-tests-playwright