### PR TITLE
Fix constrast on labels

### DIFF
--- a/ui/semantic/galette/elements/label.overrides
+++ b/ui/semantic/galette/elements/label.overrides
@@ -4,5 +4,5 @@
 
 .ui.primary.labels .label,
 .ui.ui.ui.primary.label {
-    color: @primaryTextColor;
+    color: @darkGrey;
 }


### PR DESCRIPTION
I have to admit that I don't know why, in this case (that was the same with buttons), `@primaryTextColor` (which has been redefined as `@darkGrey` in `site.variables`) is not applied, whereas in other overrides files it is applied properly :sweat_smile: 