### PR TITLE
Revive Db::tableExists with a better solution

### DIFF
--- a/galette/lib/Galette/Core/Db.php
+++ b/galette/lib/Galette/Core/Db.php
@@ -76,6 +76,7 @@ class Db
 
     public const int MYSQL_DEFAULT_PORT = 3306;
     public const int PGSQL_DEFAULT_PORT = 5432;
+    private bool $log_execute = true;
 
     /**
      * Main constructor
@@ -513,28 +514,24 @@ class Db
     }
 
     /**
-     * Does a given table exists?
+     * Does a given table exist?
      *
      * @param string $name Table name
-     * @deprecated 1.2.2: performances are terrible.
      */
     public function tableExists(string $name): bool
     {
-        Analog::log(
-            __METHOD__ . ' should not be used because of very poor performances.',
-            Analog::WARNING
-        );
-        $metadata = Factory::createSourceFromAdapter($this->db);
+        $this->log_execute = false;
         try {
-            $metadata->getTable(PREFIX_DB . $name);
+            $this->execute($this->select($name)->limit(1));
             return true;
-        } catch (Throwable) {
-            Analog::log(
-                'Table "' . $name . '" does not exist',
-                Analog::INFO
-            );
-            return false;
+        } catch (\Throwable $e) {
+            if (!$this->isMissingTableException($e)) {
+                throw $e;
+            }
+        } finally {
+            $this->log_execute = true;
         }
+        return false;
     }
 
     /**
@@ -826,14 +823,16 @@ class Db
                 Adapter::QUERY_MODE_EXECUTE
             );
         } catch (Throwable $e) {
-            $msg = 'Query error: ';
-            if (isset($query_string)) {
-                $msg .= $query_string;
+            if ($this->log_execute) {
+                $msg = 'Query error: ';
+                if (isset($query_string)) {
+                    $msg .= $query_string;
+                }
+                Analog::log(
+                    $msg . ' ' . $e->__toString(),
+                    Analog::ERROR
+                );
             }
-            Analog::log(
-                $msg . ' ' . $e->__toString(),
-                Analog::ERROR
-            );
             if ($this->isDuplicateException($sql, $e)) {
                 throw new \OverflowException('Duplicate entry', 0, $e);
             }

--- a/tests/Galette/Core/Db.php
+++ b/tests/Galette/Core/Db.php
@@ -562,15 +562,13 @@ class Db extends BaseGaletteTestCase
     public function testTableExists(): void
     {
         $this->assertTrue($this->zdb->tableExists('preferences'));
-        $this->expectLogEntry(
-            \Analog\Analog::WARNING,
-            'Galette\Core\Db::tableExists should not be used because of very poor performances.'
-        );
         $this->assertFalse($this->zdb->tableExists('does_not_exists'));
-        $this->expectLogEntry(
-            \Analog\Analog::WARNING,
-            'Galette\Core\Db::tableExists should not be used because of very poor performances.'
-        );
+        $warning = new \ArrayObject([
+            'Level' => 'Error',
+            'Code'  => 1146,
+            'Message' => "regex:/.*does_not_exists.*/i"
+        ]);
+        $this->expected_mysql_warnings[] = $warning;
     }
 
     /**


### PR DESCRIPTION
On plugins side, `Db::tableExists` was replaced because of poor perfs with something like:

```
try {
    $this->zdb->execute($this->zdb->select('table')->limit(1));
    return true;
} catch (\Throwable $e) {
    if (!$this->zdb->isMissingTableException($e)) {
        throw $e;
    }
}
return false;
```

This works; but this is quite complex for plugins. Also, this generates an error in the logs when table does not exists (thown from Db::execute.

My proposition is to rewrite DB::tableExists with new way; and hide error messages when needed.