### PR TITLE
Fix langs with regions

### DIFF
--- a/galette/lib/Galette/Core/I18n.php
+++ b/galette/lib/Galette/Core/I18n.php
@@ -219,11 +219,13 @@ class I18n
     /**
      * Get long identifier
      *
+     * @param bool $noutf if true, remove utf part
+     *
      * @return string current language long identifier
      */
-    public function getLongID(): string
+    public function getLongID(bool $noutf = false): string
     {
-        return $this->longid;
+        return $noutf ? str_replace('.utf8', '', $this->longid) : $this->longid;
     }
 
     /**
@@ -274,14 +276,44 @@ class I18n
                 $real_lang = str_replace('.utf8', '', $lang);
                 $parsed_lang = \Locale::parseLocale($lang);
 
+                $shortname = $parsed_lang['language'] ?? '';
+                $region = '';
+                if (isset($parsed_lang['region'])) {
+                    $region = strtolower($parsed_lang['region']);
+                }
+
+                $longname = \Locale::getDisplayLanguage(
+                    $lang,
+                    $real_lang
+                );
+
+                $longname_region = \Locale::getDisplayRegion(
+                    $lang,
+                    $real_lang
+                );
+
+                $excluded_regions = [
+                    'us',
+                    $parsed_lang['language']
+                ];
+                if (in_array($parsed_lang['language'], ['nb', 'nn'])) {
+                    //norvégien nynorsk (Norvège) (nn-NO)
+                    //norvégien bokmål (Norvège) (nb-NO)
+                    //But not:
+                    //norvégien bokmål (Svalbard et Jan Mayen) (nb-SJ)
+                    //norvégien nynorsk (Norvège) (nn-NO)
+                    $excluded_regions[] = 'no';
+                }
+
+                if (!in_array($region, $excluded_regions) && !empty($longname_region)) {
+                    $longname .= ', ' . $longname_region;
+                }
+
                 $langs[$real_lang] = [
                     'long'      => $lang,
-                    'shortname' => $parsed_lang['language'] ?? '',
+                    'shortname' => $shortname,
                     'longname'  => mb_convert_case(
-                        \Locale::getDisplayLanguage(
-                            $lang,
-                            $real_lang
-                        ),
+                        $longname,
                         MB_CASE_TITLE,
                         'UTF-8'
                     )

--- a/galette/lib/Galette/Core/L10n.php
+++ b/galette/lib/Galette/Core/L10n.php
@@ -266,6 +266,8 @@ class L10n
             foreach ($this->i18n->getList() as $l) {
                 $results[] = [
                     'key'  => $l->getLongID(),
+                    'lang' => $l->getAbbrev(),
+                    'rtl' => $l->isRTL(),
                     'name' => ucwords($l->getName()),
                     'text' => $existing_translations[$l->getLongID()] ?? ''
                 ];

--- a/galette/templates/default/elements/language.html.twig
+++ b/galette/templates/default/elements/language.html.twig
@@ -35,19 +35,22 @@
     <div class="image header title"{% if ui == 'item'%} data-fold="fold-language" tabindex="0"{% endif %}>
 {% endif %}
         <i class="icon language" aria-hidden="true"></i>
-        <span>{{ galette_lang }}</span>
+        <span>{{ i18n.getName() }}</span>
         <i class="dropdown icon" aria-hidden="true"></i>
 {% if header == true %}
     </div>
 {% endif %}
     <div class="{{ content_classes }}">
-{% for langue in languages %}
-    {% if langue.getAbbrev() != galette_lang %}
-        <a href="?ui_pref_lang={{ langue.getID() }}"
-           title="{{ _T("Switch locale to '%locale'")|replace({"%locale": langue.getName()}) }}"
-           class="item"
+{% for glang in languages %}
+    {% if glang.getAbbrev() != galette_lang %}
+        {% set html_lang -%}
+            <span{% if glang.isRtl() %} dir="rtl"{% endif %} lang="{{ glang.getAbbrev() }}">{{ glang.getName() }}</span>
+        {%- endset %}
+        <a href="?ui_pref_lang={{ glang.getID() }}"
+           class="item tooltip"
+           data-html="{{ _T("Switch locale to '%locale'")|replace({"%locale": html_lang})|e }}"
         >
-            {{ langue.getName() }} <span>({{ langue.getAbbrev() }})</span>
+            {{ html_lang }} ({{ glang.getLongId(true) }})
         </a>
     {% endif %}
 {% endfor %}

--- a/galette/templates/default/pages/configuration_dynamic_translations.html.twig
+++ b/galette/templates/default/pages/configuration_dynamic_translations.html.twig
@@ -57,7 +57,7 @@
     {% endif %}
             <table class="ui striped definition table">
     {% for k, text in trans %}
-                <tr>
+                <tr lang="{{ text.lang }}"{% if text.rtl %} class="rtl"{% endif %}>
                     <th class="collapsing"><label for="text_trans_{{ text.key }}">{{ text.name }}</label></th>
                     <td>
                         <input type="text" name="text_trans_{{ text.key }}" id="text_trans_{{ text.key }}" value="{% if text.text %}{{ text.text|escape }}{% endif %}"/>

--- a/ui/semantic/galette/globals/site.overrides
+++ b/ui/semantic/galette/globals/site.overrides
@@ -48,10 +48,6 @@
   font-style: italic;
 }
 
-.language span {
-  text-transform: uppercase;
-}
-
 .error-trace pre {
   overflow-x: auto;
 }


### PR DESCRIPTION
closes #2008

Before (see duplicated "Português"):
<img width="193" height="701" alt="Capture d’écran du 2026-04-23 00-25-26" src="https://github.com/user-attachments/assets/abbfd65a-12de-4892-80f0-90361ad5a1e1" />

After:
<img width="230" height="678" alt="Capture d’écran du 2026-04-23 00-42-33" src="https://github.com/user-attachments/assets/848ee42c-90de-4aee-b791-db5a2c2335e3" />

No longer duplicates, the region (Brasil) is displayed. I made exceptions:
- `US` would have been displayed as "English, United States",
- When the region and locale code are the same (`fr_FR`, `de_DE`, `it_IT`, ...)

No idea if I should add an exception for `nb_NO`.