### PR TITLE
Remove useless route

### DIFF
--- a/galette/includes/routes/management.routes.php
+++ b/galette/includes/routes/management.routes.php
@@ -266,11 +266,6 @@ $app->get(
     [Crud\ContributionsTypesController::class, 'edit']
 )->setName('editContributionType')->add($authenticate);
 
-$app->get(
-    '/contributions-types/add',
-    [Crud\ContributionsTypesController::class, 'add']
-)->setName('addContributionType')->add($authenticate);
-
 $app->post(
     '/contributions-types/edit/{id:\d+}',
     [Crud\ContributionsTypesController::class, 'doEdit']


### PR DESCRIPTION
There is no "add contribution type" view, since it's done from list (like some others).
Therefore, declared route is useless.

But that may conflict with https://github.com/galette/galette/pull/801 - I've not yet found any similar case :-/