### PR TITLE
Migrate named closure routes to controllers

### DIFF
--- a/galette/includes/routes/main.routes.php
+++ b/galette/includes/routes/main.routes.php
@@ -12,9 +12,6 @@ use Galette\Controllers\GaletteController;
 use Galette\Controllers\ImagesController;
 use Galette\Middleware\Authenticate;
 
-use function Safe\file_get_contents;
-use function Safe\file_put_contents;
-
 /**
  * @var \Slim\App<\DI\Container> $app
  */
@@ -56,22 +53,10 @@ $app->get(
 
 $app->post(
     '/write-dark-css',
-    function ($request, $response) {
-        $post = $request->getParsedBody();
-        file_put_contents(GALETTE_CACHE_DIR . '/dark.css', $post);
-        return $response->withStatus(200);
-    }
+    [GaletteController::class, 'writeDarkCss']
 )->setName('writeDarkCSS');
 
 $app->get(
     '/get-dark-css',
-    function ($request, $response) {
-        $cssfile = GALETTE_CACHE_DIR . '/dark.css';
-        if (file_exists($cssfile)) {
-            $response = $response->withHeader('Content-type', 'text/css');
-            $body = $response->getBody();
-            $body->write(file_get_contents($cssfile));
-        }
-        return $response;
-    }
+    [GaletteController::class, 'getDarkCss']
 )->setName('getDarkCSS');

--- a/galette/includes/routes/plugins.routes.php
+++ b/galette/includes/routes/plugins.routes.php
@@ -8,13 +8,10 @@
 
 declare(strict_types=1);
 
+use Galette\Controllers\PluginsController;
 use Galette\Core\Login;
 use Galette\Core\Plugins;
 use Galette\Middleware\Authenticate;
-use Slim\Psr7\Request;
-use Slim\Psr7\Response;
-
-use function Safe\file_get_contents;
 
 /**
  * @var \Slim\App<\DI\Container> $app
@@ -29,42 +26,7 @@ $app->group(
         //Global route to access plugin resources (CSS, JS, images, ...)
         $app->get(
             '/{plugin}/res/{path:.*}',
-            function (Request $request, Response $response, $plugin, $path) use ($container) {
-                $ext = pathinfo($path)['extension'];
-                $auth_ext = [
-                    'js'    => 'text/javascript',
-                    'css'   => 'text/css',
-                    'png'   => 'image/png',
-                    'jpg'   => 'image/jpg',
-                    'jpeg'  => 'image/jpg',
-                    'gif'   => 'image/gif',
-                    'svg'   => 'image/svg+xml',
-                    'map'   => 'application/json',
-                    'woff'  => 'application/font-woff',
-                    'woff2' => 'application/font-woff2'
-                ];
-                if (!str_contains($path, '../') && isset($auth_ext[$ext])) {
-                    $file = $container->get(Plugins::class)->getFile(
-                        $plugin,
-                        $path
-                    );
-
-                    $response = $response->withHeader('Content-type', $auth_ext[$ext]);
-
-                    $body = $response->getBody();
-                    $body->write(file_get_contents($file));
-                    return $response;
-                } else {
-                    throw new \RuntimeException(
-                        sprintf(
-                            'Invalid extension %1$s (%2$s)!',
-                            $ext,
-                            $path
-                        ),
-                        404
-                    );
-                }
-            }
+            [PluginsController::class, 'resource']
         )->setName('plugin_res');
 
         //Declare configured routes for each plugin

--- a/galette/lib/Galette/Controllers/GaletteController.php
+++ b/galette/lib/Galette/Controllers/GaletteController.php
@@ -31,6 +31,8 @@ use Galette\Repository\Members;
 use Galette\Repository\Reminders;
 
 use function Safe\dir;
+use function Safe\file_get_contents;
+use function Safe\file_put_contents;
 
 /**
  * Galette main controller
@@ -651,6 +653,29 @@ class GaletteController extends AbstractController
      */
     public function empty(Response $response): Response
     {
+        return $response;
+    }
+
+    /**
+     * Store dark mode CSS in cache directory.
+     */
+    public function writeDarkCss(Request $request, Response $response): Response
+    {
+        $post = $request->getParsedBody();
+        file_put_contents(GALETTE_CACHE_DIR . '/dark.css', $post);
+        return $response->withStatus(200);
+    }
+
+    /**
+     * Serve cached dark mode CSS.
+     */
+    public function getDarkCss(Response $response): Response
+    {
+        $cssfile = GALETTE_CACHE_DIR . '/dark.css';
+        if (file_exists($cssfile)) {
+            $response = $response->withHeader('Content-type', 'text/css');
+            $response->getBody()->write(file_get_contents($cssfile));
+        }
         return $response;
     }
 }

--- a/galette/lib/Galette/Controllers/PluginsController.php
+++ b/galette/lib/Galette/Controllers/PluginsController.php
@@ -18,6 +18,7 @@ use Galette\Core\Install;
 use Galette\Core\PluginInstall;
 use Analog\Analog;
 
+use function Safe\file_get_contents;
 use function Safe\ob_end_clean;
 use function Safe\ob_start;
 
@@ -239,6 +240,41 @@ class PluginsController extends AbstractController
             'modals/plugin_initdb.html.twig',
             $params
         );
+        return $response;
+    }
+
+    /**
+     * Serve a plugin static resource (CSS, JS, image, font, ...).
+     *
+     * @param string $plugin Plugin identifier
+     * @param string $path   Path of the resource within the plugin
+     */
+    public function resource(Response $response, string $plugin, string $path): Response
+    {
+        $ext = pathinfo($path)['extension'] ?? '';
+        $auth_ext = [
+            'js'    => 'text/javascript',
+            'css'   => 'text/css',
+            'png'   => 'image/png',
+            'jpg'   => 'image/jpg',
+            'jpeg'  => 'image/jpg',
+            'gif'   => 'image/gif',
+            'svg'   => 'image/svg+xml',
+            'map'   => 'application/json',
+            'woff'  => 'application/font-woff',
+            'woff2' => 'application/font-woff2'
+        ];
+        if (str_contains($path, '../') || !isset($auth_ext[$ext])) {
+            throw new \RuntimeException(
+                sprintf('Invalid extension %1$s (%2$s)!', $ext, $path),
+                404
+            );
+        }
+
+        $file = $this->plugins->getFile($plugin, $path);
+
+        $response = $response->withHeader('Content-type', $auth_ext[$ext]);
+        $response->getBody()->write(file_get_contents($file));
         return $response;
     }
 }

--- a/tests/e2e/specs/public-pages.spec.ts
+++ b/tests/e2e/specs/public-pages.spec.ts
@@ -18,6 +18,7 @@ import {
 
 
 test.describe('Public Pages', () => {
+  test.describe.configure({ mode: 'serial' });
 
   // Enable public pages before each test and restore defaults after
   test.beforeEach(async ({ loggedInPage: page }) => {
@@ -285,7 +286,6 @@ test.describe('Public Pages', () => {
   // Visibility Tests by Role
   test.describe('Public Pages Visibility by Role', () => {
 
-    /* FIXME: works locally, but not on CI (not always...) :/
     test('Public - PUBLIC visibility allows anonymous access', async ({ browser, loggedInAs }) => {
       // Set all pages to PUBLIC (no auth required) using an admin session
       const adminPage = await loggedInAs('superadmin');
@@ -307,7 +307,7 @@ test.describe('Public Pages', () => {
       } finally {
         await context.close();
       }
-    });*/
+    });
 
     test('Public - RESTRICTED visibility requires authentication', async ({ browser, loggedInAs }) => {
       // Set to RESTRICTED (members only)
@@ -336,7 +336,6 @@ test.describe('Public Pages', () => {
       await memberPage.close();
     });
 
-    /* FIXME: works locally, but not on CI :/
     test('Public - PRIVATE visibility requires admin/staff access', async ({ browser, loggedInAs }) => {
       // Set to PRIVATE (admin/staff only)
       const adminPage = await loggedInAs('superadmin');
@@ -367,7 +366,7 @@ test.describe('Public Pages', () => {
       await staffPage.goto('/public/members/list');
       expect(staffPage.url()).toContain('/public/members/list');
       await staffPage.close();
-    });*/
+    });
 
     test('Public - HIDDEN visibility denies all access', async ({ loggedInAs }) => {
       // Set to HIDDEN (no one can access)
@@ -382,7 +381,6 @@ test.describe('Public Pages', () => {
       await superadminPage.close();
     });
 
-    /* FIXME: works locally, but not on CI (not always...) :/
     test('Public - Gallery visibility can differ from list visibility', async ({ browser, loggedInAs }) => {
       const adminPage = await loggedInAs('superadmin');
 
@@ -416,7 +414,6 @@ test.describe('Public Pages', () => {
       await memberPage.goto('/public/members/gallery');
       await NavigationHelper.expectRedirectTo(memberPage, /\/dashboard/);
       await memberPage.close();
-    });*/
+    });
   });
 });
-


### PR DESCRIPTION
- writeDarkCSS / getDarkCSS: move to GaletteController::writeDarkCss / getDarkCss.
- plugin_res: move to PluginsController::resource.