### PR TITLE
Work on language selection

### DIFF
--- a/galette/includes/dependencies.php
+++ b/galette/includes/dependencies.php
@@ -78,9 +78,6 @@ $container->set(\Slim\Views\Twig::class, function (ContainerInterface $c) {
     $view->getEnvironment()->addGlobal('plugin_headers', $plugins->getTplHeaders());
     $view->getEnvironment()->addGlobal('plugin_scripts', $plugins->getTplScripts());
 
-    // galette_lang should be removed and languages used instead
-    $view->getEnvironment()->addGlobal('galette_lang', $c->get(\Galette\Core\I18n::class)->getAbbrev());
-    $view->getEnvironment()->addGlobal('galette_lang_name', $c->get(\Galette\Core\I18n::class)->getName());
     $view->getEnvironment()->addGlobal('languages', $c->get(\Galette\Core\I18n::class)->getList());
     $view->getEnvironment()->addGlobal('i18n', $c->get(\Galette\Core\I18n::class));
     $view->getEnvironment()->addGlobal('plugins', $plugins);

--- a/galette/lib/Galette/Core/I18n.php
+++ b/galette/lib/Galette/Core/I18n.php
@@ -204,6 +204,16 @@ class I18n
     }
 
     /**
+     * Get current id in web format (with - instead of _)
+     *
+     * @return string current language identifier in web format
+     */
+    public function getWebID(): string
+    {
+        return str_replace('_', '-', $this->id);
+    }
+
+    /**
      * Get long identifier
      *
      * @param bool $noutf if true, remove utf part

--- a/galette/lib/Galette/Core/L10n.php
+++ b/galette/lib/Galette/Core/L10n.php
@@ -253,7 +253,7 @@ class L10n
             foreach ($this->i18n->getList() as $l) {
                 $results[] = [
                     'key'  => $l->getLongID(),
-                    'lang' => $l->getAbbrev(),
+                    'lang' => $l->getWebID(),
                     'rtl' => $l->isRTL(),
                     'name' => ucwords($l->getName()),
                     'text' => $existing_translations[$l->getLongID()] ?? ''

--- a/galette/lib/Galette/Middleware/UpdateAndMaintenance.php
+++ b/galette/lib/Galette/Middleware/UpdateAndMaintenance.php
@@ -97,7 +97,7 @@ class UpdateAndMaintenance
         $theme_path = $path . GALETTE_THEME;
 
         return "<!DOCTYPE html>
-<html class=\"public_page\" lang=\"" . $this->i18n->getAbbrev() . "\">
+<html class=\"public_page\" lang=\"" . $this->i18n->getWebID() . "\"" . ($this->i18n->isRTL() ? " dir=\"rtl\"" : "") . ">
     <head>
         <title>" . $contents['title'] . "</title>
         <meta charset=\"UTF-8\"/>

--- a/galette/templates/default/elements/language.html.twig
+++ b/galette/templates/default/elements/language.html.twig
@@ -28,9 +28,9 @@
 {% endif %}
     <div class="{{ content_classes }}">
 {% for glang in languages %}
-    {% if glang.getAbbrev() != galette_lang %}
+    {% if glang.getID() != i18n.getID() %}
         {% set html_lang -%}
-            <span{% if glang.isRtl() %} dir="rtl"{% endif %} lang="{{ glang.getAbbrev() }}">{{ glang.getName() }}</span>
+            <span{% if glang.isRtl() %} dir="rtl"{% endif %} lang="{{ glang.getWebID() }}">{{ glang.getName() }}</span>
         {%- endset %}
         <a href="?ui_pref_lang={{ glang.getID() }}"
            class="item tooltip"

--- a/galette/templates/default/elements/language.html.twig
+++ b/galette/templates/default/elements/language.html.twig
@@ -6,21 +6,22 @@
 
 {% if ui is defined %}
     {% if ui == 'item'%}
-        {% set component_classes = "tooltip focus-visible language item" %}
+        {% set component_classes = "focus-visible language item" %}
         {% set content_classes = "content" %}
         {% set header = true %}
     {% elseif ui == 'dropdown' %}
-        {% set component_classes = "tooltip focus-visible language ui dropdown navigation right-aligned item" %}
+        {% set component_classes = "focus-visible language ui dropdown navigation right-aligned item" %}
         {% set content_classes = "menu" %}
         {% set header = false %}
     {% endif %}
 {% endif %}
 
-<div class="{{ component_classes }}{% if i18n.isRtl() %} rtl{% endif %}" title="{{ _T("Choose your language") }}">
+<div class="{{ component_classes }}{% if i18n.isRtl() %} rtl{% endif %}">
 {% if header == true %}
     <div class="image header title"{% if ui == 'item'%} data-fold="fold-language" tabindex="0"{% endif %}>
 {% endif %}
         <i class="icon language" aria-hidden="true"></i>
+        <span class="visually-hidden">{{ _T("Choose your language") }}</span>
         <span>{{ i18n.getName() }} ({{ i18n.getLongId(true) }})</span>
         <i class="dropdown icon" aria-hidden="true"></i>
 {% if header == true %}

--- a/galette/templates/default/elements/language.html.twig
+++ b/galette/templates/default/elements/language.html.twig
@@ -21,17 +21,25 @@
     <div class="image header title"{% if ui == 'item'%} data-fold="fold-language" tabindex="0"{% endif %}>
 {% endif %}
         <i class="icon language" aria-hidden="true"></i>
-        <span>{{ i18n.getName() }}</span>
+        <span>{{ i18n.getName() }} ({{ i18n.getLongId(true) }})</span>
         <i class="dropdown icon" aria-hidden="true"></i>
 {% if header == true %}
     </div>
 {% endif %}
     <div class="{{ content_classes }}">
 {% for glang in languages %}
-    {% if glang.getID() != i18n.getID() %}
-        {% set html_lang -%}
-            <span{% if glang.isRtl() %} dir="rtl"{% endif %} lang="{{ glang.getWebID() }}">{{ glang.getName() }}</span>
-        {%- endset %}
+    {% set html_lang -%}
+        <span{% if glang.isRtl() %} dir="rtl"{% endif %} lang="{{ glang.getWebID() }}">{{ glang.getName() }}</span>
+    {%- endset %}
+    {% if glang.getID() == i18n.getID() %}
+        <a href="?ui_pref_lang={{ glang.getID() }}"
+           class="item active tooltip"
+           data-html="{{ _T("Current locale '%1$s'")|replace({"%1$s": html_lang})|e }}"
+           aria-current="true"
+        >
+            {{ html_lang }} ({{ glang.getLongId(true) }})
+        </a>
+    {% else %}
         <a href="?ui_pref_lang={{ glang.getID() }}"
            class="item tooltip"
            data-html="{{ _T("Switch locale to '%locale'")|replace({"%locale": html_lang})|e }}"

--- a/galette/templates/default/elements/scripts.html.twig
+++ b/galette/templates/default/elements/scripts.html.twig
@@ -195,7 +195,7 @@
         <script type="text/javascript" src="{{ base_path() }}/assets/js/xml.js"></script>
         <script type="text/javascript" src="{{ base_path() }}/assets/js/formatting.js"></script>
         <script type="text/javascript" src="{{ base_path() }}/assets/js/summernote.min.js"></script>
-        <script type="text/javascript" src="{{ base_path() }}/assets/js/lang/summernote-{{ i18n.getID()|replace({'_': '-'}) }}.min.js"></script>
+        <script type="text/javascript" src="{{ base_path() }}/assets/js/lang/summernote-{{ i18n.getWebID() }}.min.js"></script>
         <script type="text/javascript">
             function activateHtmlEditor(elt, basic, styletags, insert) {
                 var _styletags = ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
@@ -223,7 +223,7 @@
                     ];
                 }
                 elt.summernote({
-                    lang: '{{ i18n.getID()|replace({'_': '-'}) }}',
+                    lang: '{{ i18n.getWebID() }}',
                     disableDragAndDrop: true,
                     height: 240,
                     toolbar: _toolbar,

--- a/galette/templates/default/page.html.twig
+++ b/galette/templates/default/page.html.twig
@@ -8,9 +8,7 @@
 
 <html lang="{{ i18n.getWebID() }}"{% if i18n.isRtl() %} dir="rtl"{% endif %}>
     <head>
-        {% include 'elements/header.html.twig' with {
-            galette_lang: galette_lang
-        } %}
+        {% include 'elements/header.html.twig' %}
     </head>
     <body id="galette_body" class="pushable dimmable{% if login.isLogged() %} loggedin{% endif %}{% if preferences.pref_enable_custom_colors %} custom-colors{% endif %}{{ (preferences.pref_hide_bg_image) ? ' without-bg' : ' with-bg' }} nojs">
         <a href="#main-content" class="skiptocontent visually-hidden focusable">{{ _T("Skip to content") }}</a>

--- a/galette/templates/default/page.html.twig
+++ b/galette/templates/default/page.html.twig
@@ -6,7 +6,7 @@
 
 <!DOCTYPE html>
 
-<html lang="{{ galette_lang }}"{% if i18n.isRtl() %} dir="rtl"{% endif %}>
+<html lang="{{ i18n.getWebID() }}"{% if i18n.isRtl() %} dir="rtl"{% endif %}>
     <head>
         {% include 'elements/header.html.twig' with {
             galette_lang: galette_lang

--- a/galette/templates/default/pages/403.html.twig
+++ b/galette/templates/default/pages/403.html.twig
@@ -5,7 +5,7 @@
  #}
 
 <!DOCTYPE html>
-<html lang="{{ galette_lang }}" class="public_page">
+<html lang="{{ i18n.getWebID() }}" class="public_page"{% if i18n.isRtl() %} dir="rtl"{% endif %}>
     <head>
         {% include 'elements/header.html.twig' %}
     </head>

--- a/galette/templates/default/pages/404.html.twig
+++ b/galette/templates/default/pages/404.html.twig
@@ -5,7 +5,7 @@
  #}
 
 <!DOCTYPE html>
-<html lang="{{ galette_lang }}" class="public_page">
+<html lang="{{ i18n.getWebID() }}" class="public_page"{% if i18n.isRtl() %} dir="rtl"{% endif %}>
     <head>
         {% include 'elements/header.html.twig' %}
     </head>

--- a/galette/templates/default/pages/configuration_pdf_models.html.twig
+++ b/galette/templates/default/pages/configuration_pdf_models.html.twig
@@ -42,7 +42,7 @@
 
             function _initCodeEditor() {
                 $('textarea.codeeditor').summernote({
-                    lang: '{{ i18n.getID()|replace({'_': '-'}) }}',
+                    lang: '{{ i18n.getWebID() }}',
                     height: 240,
                     toolbar: [
                         ['view', ['codeview']]

--- a/galette/templates/default/pages/member_show.html.twig
+++ b/galette/templates/default/pages/member_show.html.twig
@@ -30,7 +30,8 @@
                                 {{ _T("Modification") }}
                             </a>
                 {% endif %}
-                            <div class="ui combo top right pointing simple dropdown icon button" aria-label="{{ _T("Actions") }}">
+                            <div class="ui combo top right pointing simple dropdown icon button">
+                                <span class="visually-hidden">{{ _T("Actions") }}</span>
                                 <i class="dropdown icon" aria-hidden="true"></i>
                                 <div class="menu">
                 {% if preferences.pref_mail_method != constant('Galette\\Core\\GaletteMail::METHOD_DISABLED') and (login.isAdmin() or login.isStaff()) %}

--- a/galette/templates/default/public_page.html.twig
+++ b/galette/templates/default/public_page.html.twig
@@ -6,7 +6,7 @@
 
 <!DOCTYPE html>
 
-<html lang="{{ galette_lang }}"{% if i18n.isRtl() %} dir="rtl"{% endif %} class="public_page{% if additional_html_class is defined %} {{ additional_html_class }}{% endif %}">
+<html lang="{{ i18n.getWebID() }}"{% if i18n.isRtl() %} dir="rtl"{% endif %} class="public_page{% if additional_html_class is defined %} {{ additional_html_class }}{% endif %}">
     <head>
         {% include 'elements/header.html.twig' with {
             galette_lang: galette_lang

--- a/galette/templates/default/public_page.html.twig
+++ b/galette/templates/default/public_page.html.twig
@@ -8,9 +8,7 @@
 
 <html lang="{{ i18n.getWebID() }}"{% if i18n.isRtl() %} dir="rtl"{% endif %} class="public_page{% if additional_html_class is defined %} {{ additional_html_class }}{% endif %}">
     <head>
-        {% include 'elements/header.html.twig' with {
-            galette_lang: galette_lang
-        } %}
+        {% include 'elements/header.html.twig' %}
     </head>
     <body class="{% if body_class is defined and body_class == "front_page" %}front-page {% endif %}pushable{% if login.isLogged() and ext_auth is not defined %} loggedin{% endif %}{% if preferences.pref_enable_custom_colors %} custom-colors{% endif %}{{ (preferences.pref_hide_bg_image) ? ' without-bg' : ' with-bg' }} nojs">
         <a href="#main-content" class="skiptocontent visually-hidden focusable">{{ _T("Skip to content") }}</a>

--- a/galette/webroot/installer.php
+++ b/galette/webroot/installer.php
@@ -194,7 +194,7 @@ if (isset($_POST['stepback_btn'])) {
 header('Content-Type: text/html; charset=UTF-8');
 ?>
 <!DOCTYPE html>
-<html lang="<?php echo $i18n->getAbbrev(); ?>"<?php echo $i18n->isRtl() ? ' dir="rtl"' : ''; ?>>
+<html lang="<?php echo $i18n->getWebID(); ?>"<?php echo $i18n->isRtl() ? ' dir="rtl"' : ''; ?>>
     <head>
         <title><?php echo _T("Galette Installation") . ' - ' . $install->getStepDetail('title'); ?></title>
         <meta charset="UTF-8"/>
@@ -224,7 +224,7 @@ header('Content-Type: text/html; charset=UTF-8');
 <?php
 foreach ($i18n->getList() as $langue) {
     ?>
-                        <a href="?ui_pref_lang=<?php echo $langue->getID(); ?>" lang="<?php echo $langue->getAbbrev(); ?>" class="item"><?php echo $langue->getName(); ?> <span>(<?php echo $langue->getAbbrev(); ?>)</span></a>
+                        <a href="?ui_pref_lang=<?php echo $langue->getID(); ?>" lang="<?php echo $langue->getWebID(); ?>" class="item"><?php echo $langue->getName(); ?> <span>(<?php echo $langue->getID(); ?>)</span></a>
     <?php
 }
 ?>

--- a/ui/semantic/galette/collections/menu.overrides
+++ b/ui/semantic/galette/collections/menu.overrides
@@ -87,6 +87,23 @@
   }
 }
 
+/*--------------------------
+     Language selector
+---------------------------*/
+
+.ui.language.dropdown > .menu > .item[aria-current],
+.language.item > .content > .item[aria-current] {
+    background: @activeItemBackground !important;
+    color: @activeItemTextColor !important;
+    font-weight: @activeItemFontWeight !important;
+    box-shadow: @activeItemBoxShadow !important;
+}
+.ui.language.dropdown > .menu > .item[aria-current]:hover,
+.language.item > .content > .item[aria-current]:hover {
+    background: @activeHoverItemBackground !important;
+    color: @activeHoverItemColor !important;
+}
+
 /* --------------
       Hover
 --------------- */


### PR DESCRIPTION
Use lang full ID web formatted globally
Display current lang marked active in langs list
Drop `galette_lang` Twig variable (BC on some plugins, I'll submit PRs).

Can be reviewed per commit.