### PR TITLE
Report a missing asset instead of a blank error

### DIFF
--- a/galette/lib/Galette/Core/Logo.php
+++ b/galette/lib/Galette/Core/Logo.php
@@ -13,8 +13,6 @@ namespace Galette\Core;
 use Safe\DateTime;
 use Laminas\Db\Sql\Select;
 
-use function Safe\realpath;
-
 /**
  * This class stores and serve the logo.
  * If no custom logo is found, we take galette's default one.
@@ -61,16 +59,16 @@ class Logo extends Picture
             $special = '_xmas';
         }
 
-        $this->file_path = realpath(
+        $this->format = 'webp';
+        $this->mime = 'image/webp';
+        $this->custom = false;
+        $this->setDefaultPath(
             sprintf(
                 '%s/images/galette%s.webp',
                 _CURRENT_THEME_PATH,
                 $special
             )
         );
-        $this->format = 'webp';
-        $this->mime = 'image/webp';
-        $this->custom = false;
     }
 
     /**

--- a/galette/lib/Galette/Core/Picture.php
+++ b/galette/lib/Galette/Core/Picture.php
@@ -20,6 +20,7 @@ use Slim\Psr7\Response;
 use Throwable;
 use Analog\Analog;
 use Galette\Entity\Adherent;
+use Galette\Exception\MissingAssetException;
 use Galette\Repository\Members;
 use Galette\IO\FileTrait;
 use UnhandledMatchError;
@@ -76,6 +77,10 @@ class Picture
     protected string $format;
     protected string $mime;
     protected bool $has_picture = false;
+    /** Path of the default picture, when it could not be found on disk */
+    protected ?string $missing_asset = null;
+    /** Whether file_path comes from the default picture */
+    private bool $on_default_path = false;
     protected string $store_path = GALETTE_PHOTOS_PATH;
     protected int $max_width = 200;
     protected int $max_height = 200;
@@ -124,8 +129,13 @@ class Picture
         }
 
         //we should not have an empty file_path, but...
-        if (!empty($this->file_path)) {
-            $this->setSizes();
+        if (!empty($this->file_path) && !$this->setSizes() && !$this->on_default_path) {
+            //picture could not be read; fall back to the default one
+            $this->has_picture = false;
+            $this->getDefaultPicture();
+            if (!empty($this->file_path)) {
+                $this->setSizes();
+            }
         }
     }
 
@@ -155,8 +165,13 @@ class Picture
         }
 
         //we should not have an empty file_path, but...
-        if (!empty($this->file_path)) {
-            $this->setSizes();
+        if (!empty($this->file_path) && !$this->setSizes() && !$this->on_default_path) {
+            //picture could not be read; fall back to the default one
+            $this->has_picture = false;
+            $this->getDefaultPicture();
+            if (!empty($this->file_path)) {
+                $this->setSizes();
+            }
         }
     }
 
@@ -265,18 +280,77 @@ class Picture
      */
     protected function getDefaultPicture(): void
     {
-        $this->file_path = realpath(_CURRENT_THEME_PATH . 'images/default.png');
         $this->format = 'png';
         $this->mime = 'image/png';
         $this->has_picture = false;
+        $this->setDefaultPath(_CURRENT_THEME_PATH . 'images/default.png');
+    }
+
+    /**
+     * Set path to the default picture, if it can be found.
+     *
+     * A missing default picture means assets have not been built. Rather than
+     * failing here - pictures are built from the dependency container, long
+     * before any error page can be rendered - the failure is recorded and
+     * reported when the picture is actually used.
+     *
+     * @param string $path Path to the default picture
+     */
+    protected function setDefaultPath(string $path): void
+    {
+        $this->on_default_path = true;
+
+        //realpath() cannot be trusted here: its cache outlives the request
+        //(realpath_cache_ttl, 120s by default), so it keeps resolving paths
+        //removed meanwhile by another process - a build, or a branch switch.
+        if (!file_exists($path)) {
+            $this->missing_asset = $path;
+            return;
+        }
+
+        $this->file_path = realpath($path);
+        $this->missing_asset = null;
+    }
+
+    /**
+     * Intended path of the picture file, whether it exists or not.
+     *
+     * Unlike getPath(), this does not throw on a missing file; it is meant for
+     * subclasses that build upon another picture.
+     */
+    protected function getDefaultPath(): ?string
+    {
+        return $this->missing_asset ?? ($this->file_path ?? null);
+    }
+
+    /**
+     * Throw if the picture file is not available.
+     *
+     * @throws MissingAssetException
+     */
+    protected function checkAvailable(): void
+    {
+        if ($this->missing_asset !== null) {
+            throw new MissingAssetException($this->missing_asset);
+        }
     }
 
     /**
      * Set picture sizes
      */
-    private function setSizes(): void
+    private function setSizes(): bool
     {
-        [$width, $height] = getimagesize($this->file_path);
+        try {
+            [$width, $height] = getimagesize($this->file_path);
+        } catch (Throwable) {
+            //file went away since its path was resolved; never fail here,
+            //pictures are built long before an error page can be rendered.
+            //Falling back to the default picture clears this again.
+            $this->missing_asset = $this->file_path;
+            unset($this->file_path);
+            return false;
+        }
+
         $this->height = $height;
         $this->width = $width;
         $this->optimal_height = $height;
@@ -293,6 +367,8 @@ class Picture
             $this->optimal_width = $this->max_width;
             $this->optimal_height = (int)($this->height * $ratio);
         }
+
+        return true;
     }
 
     /**
@@ -300,6 +376,7 @@ class Picture
      */
     public function getContents(): void
     {
+        $this->checkAvailable();
         readfile($this->file_path);
     }
 
@@ -312,6 +389,7 @@ class Picture
      */
     public function display(Response $response): Response
     {
+        $this->checkAvailable();
         $response = $response->withHeader('Content-Type', $this->mime)
             ->withHeader('Content-Transfer-Encoding', 'binary')
             ->withHeader('Expires', '0')
@@ -906,6 +984,7 @@ class Picture
      */
     public function getOptimalHeight(): int
     {
+        $this->checkAvailable();
         return (int)round($this->optimal_height, 1);
     }
 
@@ -916,6 +995,7 @@ class Picture
      */
     public function getHeight(): int
     {
+        $this->checkAvailable();
         return $this->height;
     }
 
@@ -926,6 +1006,7 @@ class Picture
      */
     public function getOptimalWidth(): int
     {
+        $this->checkAvailable();
         return (int)round($this->optimal_width, 1);
     }
 
@@ -936,6 +1017,7 @@ class Picture
      */
     public function getWidth(): int
     {
+        $this->checkAvailable();
         return $this->width;
     }
 
@@ -964,6 +1046,7 @@ class Picture
      */
     public function getPath(): string
     {
+        $this->checkAvailable();
         return $this->file_path;
     }
 

--- a/galette/lib/Galette/Core/PrintLogo.php
+++ b/galette/lib/Galette/Core/PrintLogo.php
@@ -35,12 +35,21 @@ class PrintLogo extends Logo
     protected function getDefaultPicture(): void
     {
         //if we are here, we want to serve default logo
-        $pic = new Logo();
-        $this->file_path = $pic->getPath();
+        $pic = $this->getLogo();
         $this->format = $pic->getFormat();
         $this->mime = $pic->getMime();
         //anyway, we have no custom print logo
         $this->custom = false;
+        //do not use getPath(), it would throw on a missing logo; report it on use
+        $this->setDefaultPath((string)$pic->getDefaultPath());
+    }
+
+    /**
+     * Logo the print logo is built upon
+     */
+    protected function getLogo(): Logo
+    {
+        return new Logo();
     }
 
     /**
@@ -50,6 +59,7 @@ class PrintLogo extends Logo
      */
     public function getPath(): string
     {
+        $this->checkAvailable();
         if ($this->getFormat() !== 'webp') {
             return $this->file_path;
         }

--- a/galette/lib/Galette/Exception/MissingAssetException.php
+++ b/galette/lib/Galette/Exception/MissingAssetException.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * This file is part of Galette (https://galette.eu).
+ * SPDX-FileCopyrightText: Copyright © 2003-2026 The Galette Team
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Galette\Exception;
+
+use RuntimeException;
+use Throwable;
+
+/**
+ * Missing built asset exception
+ *
+ * Assets are not versioned; they are built with `npm run build`, and shipped
+ * already built in release archives. A missing one is a broken installation,
+ * not something a user can act upon from the interface.
+ *
+ * @author Johan Cwiklinski <johan@x-tnd.be>
+ */
+class MissingAssetException extends RuntimeException
+{
+    /**
+     * Construct the exception
+     *
+     * @param string         $path     Path of the missing file
+     * @param int            $code     Exception code
+     * @param Throwable|null $previous Previous exception
+     */
+    public function __construct(
+        private readonly string $path,
+        int $code = 0,
+        ?Throwable $previous = null
+    ) {
+        parent::__construct(
+            sprintf(
+                'Missing Galette asset "%s"; assets may not have been built.',
+                $path
+            ),
+            $code,
+            $previous
+        );
+    }
+
+    /**
+     * Path of the missing file
+     */
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+}

--- a/galette/lib/Galette/Renderers/Html.php
+++ b/galette/lib/Galette/Renderers/Html.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace Galette\Renderers;
 
+use Galette\Exception\MissingAssetException;
 use Galette\Exception\PHPStartupException;
 use Slim\Exception\HttpException;
 use Slim\Exception\HttpForbiddenException;
@@ -60,6 +61,13 @@ class Html implements ErrorRendererInterface
             $code = $exception->getCode();
         }
 
+        $missing = $this->findMissingAsset($exception);
+        if ($missing !== null) {
+            //Twig error pages display the logo, which is exactly what is
+            //missing; render a self-contained page instead.
+            return $this->renderMissingAsset($missing);
+        }
+
         $php_error = error_get_last();
         if ($php_error !== null) {
             $this->flash->addMessageNow('error', $php_error['message']);
@@ -82,5 +90,64 @@ class Html implements ErrorRendererInterface
         );
 
         return (string)$response->getBody();
+    }
+
+    /**
+     * Look for a missing asset error in the exception chain
+     *
+     * @param Throwable $exception The exception
+     */
+    private function findMissingAsset(Throwable $exception): ?MissingAssetException
+    {
+        $current = $exception;
+        while ($current !== null) {
+            if ($current instanceof MissingAssetException) {
+                return $current;
+            }
+            $current = $current->getPrevious();
+        }
+        return null;
+    }
+
+    /**
+     * Render a self-contained page for a missing asset.
+     *
+     * Neither Twig nor any stylesheet, script or image is involved: they all
+     * come from the very build that is missing.
+     *
+     * @param MissingAssetException $exception The missing asset
+     */
+    private function renderMissingAsset(MissingAssetException $exception): string
+    {
+        $title = 'Galette assets are missing';
+        $path = htmlspecialchars($exception->getPath(), ENT_QUOTES);
+
+        return '<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>' . $title . '</title>
+        <meta charset="UTF-8"/>
+        <meta name="viewport" content="width=device-width"/>
+        <style type="text/css">
+            body { margin: 0; padding: 2em 1em; background: #f4f4f5; color: #1b1c1d;
+                font-family: system-ui, -apple-system, "Segoe UI", sans-serif; line-height: 1.5; }
+            main { max-width: 45em; margin: 0 auto; background: #fff; padding: 1.5em 2em;
+                border: 1px solid #d4d4d5; border-radius: .3em; }
+            h1 { margin-top: 0; }
+            p.error { padding: .8em 1em; border-radius: .3em;
+                background: #fbe9e9; border: 1px solid #e0b4b4; color: #9f3a38; }
+            code { background: #f4f4f5; padding: .1em .3em; border-radius: .2em; word-break: break-all; }
+        </style>
+    </head>
+    <body>
+        <main>
+            <h1>' . $title . '</h1>
+            <p class="error">Galette cannot find <code>' . $path . '</code>.</p>
+            <p>Assets are not part of the source repository, and have to be built.</p>
+            <p>If you installed Galette from a release archive, please download it again from
+                <a href="https://galette.eu">galette.eu</a>.</p>
+        </main>
+    </body>
+</html>';
     }
 }

--- a/tests/Galette/Core/Logo.php
+++ b/tests/Galette/Core/Logo.php
@@ -42,4 +42,65 @@ class Logo extends BaseGaletteTestCase
         $this->assertSame('webp', $instance->getFormat());
         $this->assertFalse($instance->isCustom());
     }
+
+    /**
+     * Test a missing default logo is only reported when the logo is used.
+     *
+     * Logos are built from the dependency container, before any error page can
+     * be rendered; failing right away would only produce a blank HTTP 500.
+     */
+    public function testMissingDefaultLogo(): void
+    {
+        global $zdb;
+        $zdb = $this->zdb;
+
+        //building it must not throw...
+        $instance = new class extends \Galette\Core\Logo {
+            /**
+             * Get default picture
+             */
+            protected function getDefaultPicture(): void
+            {
+                $this->format = 'webp';
+                $this->mime = 'image/webp';
+                $this->setDefaultPath('/nonexistent/images/galette.webp');
+            }
+        };
+
+        //...using it must
+        $this->expectException(\Galette\Exception\MissingAssetException::class);
+        $this->expectExceptionMessage('assets may not have been built');
+        $instance->getOptimalWidth();
+    }
+
+    /**
+     * Test a stale resolved path does not fail the constructor.
+     *
+     * realpath() keeps a cache of its own that outlives the request, and still
+     * resolves files removed meanwhile by another process; the picture then
+     * holds a path that cannot be read.
+     */
+    public function testStaleResolvedPath(): void
+    {
+        global $zdb;
+        $zdb = $this->zdb;
+
+        //building it must not throw, even though the path looks resolved...
+        $instance = new class extends \Galette\Core\Logo {
+            /**
+             * Get default picture
+             */
+            protected function getDefaultPicture(): void
+            {
+                $this->format = 'webp';
+                $this->mime = 'image/webp';
+                //bypass setDefaultPath(), as a stale realpath() would
+                $this->file_path = '/nonexistent/images/galette.webp';
+            }
+        };
+
+        //...using it must
+        $this->expectException(\Galette\Exception\MissingAssetException::class);
+        $instance->getOptimalWidth();
+    }
 }

--- a/tests/Galette/Core/PrintLogo.php
+++ b/tests/Galette/Core/PrintLogo.php
@@ -39,4 +39,42 @@ class PrintLogo extends BaseGaletteTestCase
         $this->assertSame('png', $logo->getFormat());
         $this->assertFalse($logo->isCustom());
     }
+
+    /**
+     * Test a missing logo is only reported when the print logo is used.
+     *
+     * Print logos build upon Logo, whose path cannot be asked for while
+     * constructing them without reintroducing a failure from the container.
+     */
+    public function testMissingDefaultLogo(): void
+    {
+        global $zdb;
+        $zdb = $this->zdb;
+
+        //building it must not throw...
+        $logo = new class extends \Galette\Core\PrintLogo {
+            /**
+             * Get logo
+             */
+            protected function getLogo(): \Galette\Core\Logo
+            {
+                return new class extends \Galette\Core\Logo {
+                    /**
+                     * Get default picture
+                     */
+                    protected function getDefaultPicture(): void
+                    {
+                        $this->format = 'webp';
+                        $this->mime = 'image/webp';
+                        $this->setDefaultPath('/nonexistent/images/galette.webp');
+                    }
+                };
+            }
+        };
+
+        //...using it must
+        $this->expectException(\Galette\Exception\MissingAssetException::class);
+        $this->expectExceptionMessage('assets may not have been built');
+        $logo->getPath();
+    }
 }

--- a/tests/Galette/Renderers/Html.php
+++ b/tests/Galette/Renderers/Html.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * This file is part of Galette (https://galette.eu).
+ * SPDX-FileCopyrightText: Copyright © 2003-2026 The Galette Team
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Galette\Tests\Renderers;
+
+use Galette\Exception\MissingAssetException;
+use Galette\Tests\BaseGaletteTestCase;
+use Slim\Flash\Messages;
+use Slim\Views\Twig;
+
+/**
+ * HTML error renderer tests class
+ *
+ * @author Johan Cwiklinski <johan@x-tnd.be>
+ */
+class Html extends BaseGaletteTestCase
+{
+    /**
+     * Test a missing asset is rendered without Twig.
+     *
+     * Twig error pages extend public_page.html.twig, which displays the logo;
+     * rendering one for a missing logo would throw again, from a place Slim
+     * does not guard.
+     */
+    public function testMissingAssetBypassesTwig(): void
+    {
+        $view = $this->createMock(Twig::class);
+        //Twig must not be involved at all
+        $view->expects($this->never())->method('render');
+
+        $storage = [];
+        $renderer = new \Galette\Renderers\Html($view, new Messages($storage));
+        $html = $renderer(new MissingAssetException('/some/where/galette.webp'), false);
+
+        $this->assertStringContainsString('Galette assets are missing', $html);
+        $this->assertStringContainsString('/some/where/galette.webp', $html);
+        $this->assertStringContainsString('Assets are not part of the source repository', $html);
+        //the page must not pull anything from the missing build
+        $this->assertStringNotContainsString('semantic.min.css', $html);
+        $this->assertStringNotContainsString('<img', $html);
+    }
+
+    /**
+     * Test a missing asset is found through the exception chain
+     */
+    public function testMissingAssetAsPrevious(): void
+    {
+        $view = $this->createMock(Twig::class);
+        $view->expects($this->never())->method('render');
+
+        $storage = [];
+        $renderer = new \Galette\Renderers\Html($view, new Messages($storage));
+        $exception = new \RuntimeException(
+            'Something went wrong',
+            0,
+            new MissingAssetException('/some/where/default.png')
+        );
+        $html = $renderer($exception, false);
+
+        $this->assertStringContainsString('/some/where/default.png', $html);
+    }
+}


### PR DESCRIPTION
I'm frequently switching branches while working, that easily leaves Galette without its default logo - leaving a blank 500 page in the browser and an exception in logs.

Now returns a self-contained page instead.