### PR TITLE
Replace some globals

### DIFF
--- a/galette/lib/Galette/Core/History.php
+++ b/galette/lib/Galette/Core/History.php
@@ -66,12 +66,13 @@ class History
      * (blindly trusting X-Forwarded-For would make the IP address logging
      * very easy to deveive.
      *
-     * @param ?Preferences $preferences Preferences instance; falls back on the
-     *                                  global one, for callers that have none
+     * @param ?Preferences $preferences Preferences instance. Without one, the
+     *                                  header is not looked at: a caller that
+     *                                  cannot say how many proxies sit in
+     *                                  front gets the remote address
      */
     public static function findUserIPAddress(?Preferences $preferences = null): string
     {
-        $preferences ??= $GLOBALS['preferences'] ?? null;
         //1-based index, counted from the end of the header; 0 disables the lookup
         $index = (int)($preferences?->getConfigValue('pref_x_forwarded_for_index') ?? 0);
 

--- a/galette/lib/Galette/Entity/PdfModel.php
+++ b/galette/lib/Galette/Entity/PdfModel.php
@@ -14,6 +14,7 @@ use ArrayObject;
 use Slim\Routing\RouteParser;
 use Throwable;
 use Galette\Core\Db;
+use Galette\Core\I18n;
 use Galette\Core\Preferences;
 use Galette\Features\Replacements;
 use Galette\Repository\PdfModels;
@@ -82,7 +83,8 @@ abstract class PdfModel
         $this->preferences = $preferences;
         $this
             ->setDb($zdb)
-            ->setLogin($login);
+            ->setLogin($login)
+            ->setI18n($container->get(I18n::class));
 
         if (is_int($args)) {
             $this->load($args);

--- a/galette/lib/Galette/Entity/Texts.php
+++ b/galette/lib/Galette/Entity/Texts.php
@@ -71,7 +71,8 @@ class Texts
         }
         $this
             ->setDb($zdb)
-            ->setLogin($login);
+            ->setLogin($login)
+            ->setI18n($container?->get(I18n::class) ?? new I18n());
 
         $this
             ->setLegacy()

--- a/galette/lib/Galette/Features/Replacements.php
+++ b/galette/lib/Galette/Features/Replacements.php
@@ -60,7 +60,12 @@ trait Replacements
     #[Inject]
     protected Preferences $preferences;
 
-    //Cannot be injected here: Uncaught Exception: Serialization of 'Psr\Http\Server\RequestHandlerInterface@anonymous' is not allowed in [no active file]:0
+    //Cannot be injected: Preferences hosts this trait, GaletteMail holds a
+    //Preferences, and MailingsController keeps a Mailing in session. Injecting
+    //the route parser would drag the whole Slim application into that session
+    //write and fail with "Serialization of
+    //'Psr\Http\Server\RequestHandlerInterface@anonymous' is not allowed".
+    //Hosts set it themselves through setRouteparser().
     protected RouteParser $routeparser;
 
     #[Inject]
@@ -543,8 +548,6 @@ trait Replacements
      */
     public function setNoContribution(): self
     {
-        global $login;
-
         $c_replacements = [
             'contrib_label'     => null,
             'contrib_amount'    => null,
@@ -571,7 +574,7 @@ trait Replacements
         $this->setReplacements($c_replacements);
 
         /** the list of all dynamic fields */
-        $fields = new DynamicFieldsSet($this->zdb, $login);
+        $fields = new DynamicFieldsSet($this->zdb, $this->login);
         $dynamic_fields = $fields->getList('contrib');
         $this->setDynamicFields(
             form_name: 'contrib',
@@ -589,9 +592,7 @@ trait Replacements
      */
     public function setContribution(Contribution $contrib): self
     {
-        global $login, $i18n;
-
-        $formatter = new NumberFormatter($i18n->getID(), NumberFormatter::SPELLOUT);
+        $formatter = new NumberFormatter($this->i18n->getID(), NumberFormatter::SPELLOUT);
 
         $c_replacements = [
             'contrib_label'     => $contrib->type->libelle,
@@ -619,7 +620,7 @@ trait Replacements
         $this->setReplacements($c_replacements);
 
         /** the list of all dynamic fields */
-        $fields = new DynamicFieldsSet($this->zdb, $login);
+        $fields = new DynamicFieldsSet($this->zdb, $this->login);
         $dynamic_fields = $fields->getList('contrib');
         $this->setDynamicFields(
             form_name: 'contrib',
@@ -637,8 +638,6 @@ trait Replacements
      */
     public function setMember(Adherent $member): self
     {
-        global $login;
-
         $address = $member->getAddress();
         $address_multi = self::addressToHtml($address);
 
@@ -702,7 +701,7 @@ trait Replacements
         );
 
         /** the list of all dynamic fields */
-        $fields = new DynamicFieldsSet($this->zdb, $login);
+        $fields = new DynamicFieldsSet($this->zdb, $this->login);
         $dynamic_fields = $fields->getList('adh');
         $this->setDynamicFields(
             form_name: 'adh',


### PR DESCRIPTION
Give the replacement hosts the I18n they will need Replace useless global with exisitng property
Ask the caller for the preferences behind the IP lookup

findUserIPAddress() fell back on $GLOBALS['preferences'] to learn how many proxies sit in front of the instance.

Without a Preferences, the X-Forwarded-For header is now simply not read and the remote address is returned - the safe answer for a caller that cannot say how deep the proxy chain is. History::add() passes the one it holds, so nothing changes for the log.