### PR TITLE
Let plugins declare their own preferences

### DIFF
--- a/galette/lib/Galette/Controllers/AdvancedConfigController.php
+++ b/galette/lib/Galette/Controllers/AdvancedConfigController.php
@@ -227,17 +227,21 @@ class AdvancedConfigController extends AbstractController
                 'sensitive' => $sensitive,
                 'readonly'  => PreferencesSchema::isReadOnly($name),
                 'locked_by' => $locked ? $constant : null,
+                'plugin'    => PreferencesSchema::getOwner($name),
                 'min'       => $schema['min'] ?? null,
                 'max'       => $schema['max'] ?? null,
             ];
         }
 
-        //rows left in database by an older version or by a plugin
+        //rows left in database by an older version, or by a plugin that is no
+        //longer active: an active one declares its preferences and is listed above
         foreach (array_diff($this->preferences->getFieldsNames(), array_keys(PreferencesSchema::getAll())) as $name) {
             $entries[] = [
-                'name'  => $name,
-                'known' => false,
-                'value' => $this->preferences->$name,
+                'name'   => $name,
+                'known'  => false,
+                //nothing describes it any more, so nothing owns it either
+                'plugin' => null,
+                'value'  => $this->preferences->$name,
             ];
         }
 

--- a/galette/lib/Galette/Core/GalettePlugin.php
+++ b/galette/lib/Galette/Core/GalettePlugin.php
@@ -23,6 +23,7 @@ use Galette\Entity\Adherent;
  * - DashboardProviderInterface: if the plugin provides extra dashboard entries
  * - MemberActionProviderInterface: if the plugin provides extra member actions
  * - NewsProviderInterface: if the plugin provides news to be displayed in the dashboard
+ * - PreferencesProviderInterface: if the plugin stores settings in Galette preferences
  *
  * Note: a plugin can implement one or more of these interfaces, but it is not mandatory to implement all of them.
  * Methods are kept in the base class for backward compatibility, they will throw a deprecation warning if used

--- a/galette/lib/Galette/Core/Plugins.php
+++ b/galette/lib/Galette/Core/Plugins.php
@@ -325,13 +325,43 @@ class Plugins
         uasort($this->modules, $this->sortModules(...));
 
         // Load translation, _prepend and ns_file
+        $declared = false;
         foreach (array_keys($this->getActiveModules()) as $id) {
             if ($lang !== null) {
                 $this->loadModuleL10N($id, $lang);
             }
             $this->loadEventProviders($id);
             $this->overridePrefs($id);
+            $declared = $this->registerPreferences($id) || $declared;
         }
+
+        if ($declared) {
+            //preferences were built before any plugin was known
+            $this->preferences->refreshSchema();
+        }
+    }
+
+    /**
+     * Register the preferences a module declares
+     *
+     * @param string $id Module ID
+     *
+     * @return bool Whether the module declared any
+     */
+    private function registerPreferences(string $id): bool
+    {
+        $class = $this->getClassName($id, true);
+        if (!class_exists($class) || !is_subclass_of($class, GalettePlugin::class)) {
+            return false;
+        }
+
+        $plugin = $this->container->get($class);
+        if (!$plugin instanceof Plugins\PreferencesProviderInterface) {
+            return false;
+        }
+
+        PreferencesSchema::register($this->modules[$id]['route'], $plugin->getPreferences());
+        return true;
     }
 
     /**
@@ -500,6 +530,7 @@ class Plugins
     public function resetModulesList(): void
     {
         $this->modules = [];
+        PreferencesSchema::reset();
     }
 
     /**
@@ -520,6 +551,8 @@ class Plugins
         } catch (Exception $e) {
             throw new Exception(_T("Cannot deactivate plugin."), $e->getCode(), $e);
         }
+
+        PreferencesSchema::unregister($this->modules[$id]['route']);
     }
 
     /**

--- a/galette/lib/Galette/Core/Plugins/PreferencesProviderInterface.php
+++ b/galette/lib/Galette/Core/Plugins/PreferencesProviderInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of Galette (https://galette.eu).
+ * SPDX-FileCopyrightText: Copyright © 2003-2026 The Galette Team
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Galette\Core\Plugins;
+
+/**
+ * Preferences provider interface
+ *
+ * A plugin implementing this stores its settings in Galette preferences rather
+ * than in a table of its own: they get a type, validation, the usual
+ * `$preferences->name` access, and a row on the advanced configuration page.
+ *
+ * @author Johan Cwiklinski <johan@x-tnd.be>
+ */
+interface PreferencesProviderInterface
+{
+    /**
+     * Get the preferences the plugin declares
+     *
+     * Keys must be prefixed with `pref_<plugin route>_`, values are
+     * `PreferencesSchema` entries: a known `type`, a scalar `default`, and
+     * optionally `min`, `max`, `error`, `sensitive`, `acl`. Anything else is
+     * dropped and reported.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public function getPreferences(): array;
+}

--- a/galette/lib/Galette/Core/Preferences.php
+++ b/galette/lib/Galette/Core/Preferences.php
@@ -246,6 +246,44 @@ class Preferences
     }
 
     /**
+     * Take into account preferences declared after this instance was built
+     *
+     * Preferences are constructed before plugins are even listed, so a plugin
+     * declaring its own arrives too late for the constructor. This picks the
+     * new entries up and creates their missing rows.
+     */
+    public function refreshSchema(): void
+    {
+        $this->required = PreferencesSchema::getRequired();
+        $this->checkUpdate();
+    }
+
+    /**
+     * Forget the defaults derived from the schema
+     *
+     * Called by PreferencesSchema whenever a plugin registration changes what
+     * the schema holds.
+     */
+    public static function invalidateDefaults(): void
+    {
+        self::$defaults = null;
+    }
+
+    /**
+     * Get the value of a preference declared by a plugin
+     *
+     * Those are deliberately not annotated on this class: naming them here
+     * would have core depend on its plugins. Static analysis therefore cannot
+     * follow `$preferences->pref_myplugin_thing`, and this is the way in.
+     *
+     * @param string $name Preference name
+     */
+    public function getPluginValue(string $name): mixed
+    {
+        return $this->__get($name);
+    }
+
+    /**
      * Check if all fields referenced in the default array do exist,
      * create them if not
      */
@@ -459,6 +497,12 @@ class Preferences
         $complete = [];
 
         foreach ($this->getFieldsNames() as $fieldname) {
+            if (PreferencesSchema::getOwner($fieldname) !== null) {
+                //declared by a plugin: it is never part of the core form, and
+                //taking it as missing would blank it on every save
+                continue;
+            }
+
             if (isset($values[$fieldname])) {
                 $value = is_string($values[$fieldname]) ? trim($values[$fieldname]) : $values[$fieldname];
             } else {

--- a/galette/lib/Galette/Core/PreferencesSchema.php
+++ b/galette/lib/Galette/Core/PreferencesSchema.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace Galette\Core;
 
+use Analog\Analog;
 use Galette\Entity\Adherent;
 use Galette\Entity\PaymentType;
 use Galette\Entity\Status;
@@ -26,6 +27,13 @@ use Galette\Repository\Members;
  * Adding a preference means adding one entry here: `Preferences` derives its
  * defaults, its required fields and its type casts from this schema, and the
  * advanced configuration page lists it automatically.
+ *
+ * Plugins declare their own preferences through `PreferencesProviderInterface`;
+ * `Plugins` hands them to `register()`, which merges them into the schema so
+ * every accessor below treats them like any other preference. They are named
+ * `pref_<plugin route>_*` and carry the owning plugin in their `plugin` key.
+ * Their entries only exist while the plugin is active: deactivate it and the
+ * rows stay in database, unknown and read-only, until it comes back.
  *
  * Translated strings are deliberately kept out of the structural schema: it is
  * read on every `Preferences::__get()` call, and `_T()` must not run before the
@@ -45,7 +53,8 @@ use Galette\Repository\Members;
  *     sensitive?: bool,
  *     readonly?: bool,
  *     acl?: string,
- *     constant?: string
+ *     constant?: string,
+ *     plugin?: string
  * }
  */
 final class PreferencesSchema
@@ -80,8 +89,30 @@ final class PreferencesSchema
     public const string ERR_EMAIL = 'email';
     public const string ERR_POSITIVE_NUMBER = 'positive_number';
 
-    /** @var array<string, Entry>|null */
+    /** @var array<int, string> Every type an entry may declare */
+    private const array TYPES = [
+        self::TYPE_STRING,
+        self::TYPE_INT,
+        self::TYPE_BOOL,
+        self::TYPE_EMAIL,
+        self::TYPE_EMAILS,
+        self::TYPE_URL,
+        self::TYPE_COLOR,
+        self::TYPE_HTML,
+        self::TYPE_PASSWORD,
+        self::TYPE_LOGIN,
+        self::TYPE_DATE_MD,
+        self::TYPE_YEAR,
+    ];
+
+    /** @var array<string, Entry>|null Core and plugin entries, merged */
     private static ?array $schema = null;
+
+    /** @var array<string, Entry>|null Core entries alone */
+    private static ?array $core = null;
+
+    /** @var array<string, array<string, Entry>> Plugin route => its entries */
+    private static array $plugin_schema = [];
 
     /**
      * Get the whole schema
@@ -94,9 +125,141 @@ final class PreferencesSchema
     public static function getAll(): array
     {
         if (self::$schema === null) {
-            self::$schema = self::build();
+            self::$schema = self::getCore();
+            foreach (self::$plugin_schema as $entries) {
+                //union, never array_merge: a plugin cannot shadow a core preference
+                self::$schema += $entries;
+            }
         }
         return self::$schema;
+    }
+
+    /**
+     * Get the core schema alone, without any plugin contribution
+     *
+     * Core code that describes itself needs this rather than `getAll()`: the
+     * `@property` annotations on `Preferences` cannot name a plugin's keys
+     * without inverting the dependency.
+     *
+     * @return array<string, Entry>
+     */
+    public static function getCore(): array
+    {
+        if (self::$core === null) {
+            self::$core = self::build();
+        }
+        return self::$core;
+    }
+
+    /**
+     * Register the preferences a plugin declares
+     *
+     * Malformed entries are dropped and reported rather than thrown on:
+     * registration runs while modules are being loaded, where an exception
+     * would take the whole instance down over one faulty third-party plugin.
+     *
+     * @param string              $plugin  Plugin route name
+     * @param array<string,mixed> $entries Preference name => Entry
+     */
+    public static function register(string $plugin, array $entries): void
+    {
+        $accepted = [];
+        $prefix = 'pref_' . $plugin . '_';
+
+        foreach ($entries as $name => $entry) {
+            $error = self::rejectEntry(plugin: $plugin, prefix: $prefix, name: $name, entry: $entry);
+            if ($error !== null) {
+                Analog::log(
+                    sprintf('Plugin "%s" declares an invalid preference: %s', $plugin, $error),
+                    Analog::ERROR
+                );
+                continue;
+            }
+            /** @var Entry $entry */
+            $entry['plugin'] = $plugin;
+            $accepted[$name] = $entry;
+        }
+
+        self::$plugin_schema[$plugin] = $accepted;
+        self::invalidate();
+    }
+
+    /**
+     * Why an entry cannot be accepted, null when it can
+     *
+     * The prefix rule is what keeps a plugin off core preferences: no core
+     * name can ever carry a plugin prefix.
+     *
+     * @param string $plugin Plugin route name
+     * @param string $prefix Prefix every name of that plugin must carry
+     * @param string $name   Preference name
+     * @param mixed  $entry  Candidate entry
+     */
+    private static function rejectEntry(string $plugin, string $prefix, string $name, mixed $entry): ?string
+    {
+        if (!is_array($entry)) {
+            return sprintf('"%s" is not an array', $name);
+        }
+
+        if (!str_starts_with($name, $prefix)) {
+            return sprintf('"%s" is not prefixed with "%s"', $name, $prefix);
+        }
+
+        if (!isset($entry['type']) || !in_array($entry['type'], self::TYPES, true)) {
+            return sprintf('"%s" has no known type', $name);
+        }
+
+        if (!array_key_exists('default', $entry) || !is_scalar($entry['default'])) {
+            return sprintf('"%s" has no scalar default value', $name);
+        }
+
+        return null;
+    }
+
+    /**
+     * Drop the preferences a plugin declared
+     *
+     * @param string $plugin Plugin route name
+     */
+    public static function unregister(string $plugin): void
+    {
+        if (isset(self::$plugin_schema[$plugin])) {
+            unset(self::$plugin_schema[$plugin]);
+            self::invalidate();
+        }
+    }
+
+    /**
+     * Drop every plugin registration
+     *
+     * The registry is static, so it outlives a request only under a test
+     * runner; that is where this is needed.
+     */
+    public static function reset(): void
+    {
+        if (count(self::$plugin_schema) > 0) {
+            self::$plugin_schema = [];
+            self::invalidate();
+        }
+    }
+
+    /**
+     * Which plugin declared that preference, if any
+     *
+     * @param string $name Preference name
+     */
+    public static function getOwner(string $name): ?string
+    {
+        return self::getAll()[$name]['plugin'] ?? null;
+    }
+
+    /**
+     * Forget the merged schema, and the defaults Preferences derives from it
+     */
+    private static function invalidate(): void
+    {
+        self::$schema = null;
+        Preferences::invalidateDefaults();
     }
 
     /**

--- a/galette/templates/default/pages/advanced_config.html.twig
+++ b/galette/templates/default/pages/advanced_config.html.twig
@@ -57,6 +57,9 @@
     {% else %}
                         <span class="ui blue label">{{ _T("modified") }}</span>
     {% endif %}
+    {% if entry.plugin %}
+                        <span class="ui teal label" title="{{ _T("Declared by the %s plugin, and only while it stays active.")|replace({'%s': entry.plugin}) }}">{{ entry.plugin }}</span>
+    {% endif %}
                     </td>
                     <td data-col-label="{{ _T("Value") }}">
     {% if not entry.known or entry.locked_by or entry.readonly %}
@@ -194,7 +197,11 @@
                         </tr>
                         <tr>
                             <th scope="row"><span class="ui grey label">{{ _T("unknown") }}</span></th>
-                            <td class="back">{{ _T("A row found in database that Galette does not describe. It may come from an older version or from a plugin.") }}</td>
+                            <td class="back">{{ _T("A row found in database that Galette does not describe. It may come from an older version, or from a plugin that is no longer active.") }}</td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><span class="ui teal label">{{ _T("plugin name") }}</span></th>
+                            <td class="back">{{ _T("Declared by that plugin rather than by Galette. Deactivate the plugin and the setting becomes unknown again, keeping its value until the plugin comes back.") }}</td>
                         </tr>
                     </tbody>
                 </table>

--- a/tests/Galette/Controllers/AdvancedConfigControllerTest.php
+++ b/tests/Galette/Controllers/AdvancedConfigControllerTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace Galette\Tests\Controllers;
 
+use Galette\Controllers\AdvancedConfigController;
 use Galette\Tests\GaletteRoutingTestCase;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
@@ -280,6 +281,62 @@ class AdvancedConfigControllerTest extends GaletteRoutingTestCase
                 $body,
                 'status ' . $status . ' missing from the legend'
             );
+        }
+    }
+
+    /**
+     * A preference a plugin declares is listed, editable, and credited to it
+     */
+    public function testPluginPreferenceIsEditable(): void
+    {
+        $this->reachPage();
+
+        $body = (string)$this->app->handle($this->createRequest('advancedConfig'))->getBody();
+        $row = $this->rowFor($body, 'pref_plugin1_label');
+
+        $this->assertStringContainsString('>plugin1<', $row, 'owning plugin not shown');
+        $this->assertStringContainsString('name="value"', $row, 'not offered for edition');
+    }
+
+    /**
+     * A row nothing describes is still rendered
+     *
+     * Such rows exist in the field, left by an older version or by a plugin
+     * that has been removed, and they carry none of what the table shows for
+     * a described one.
+     */
+    public function testUnknownRowIsRendered(): void
+    {
+        $this->reachPage();
+
+        $insert = $this->zdb->insert(\Galette\Core\Preferences::TABLE);
+        $insert->values(['nom_pref' => 'pref_left_over', 'val_pref' => 'from an older version']);
+        $this->zdb->execute($insert);
+        //the instance the page renders from was loaded before that row existed
+        $this->preferences->load();
+
+        try {
+            $body = (string)$this->app->handle($this->createRequest('advancedConfig'))->getBody();
+            $row = $this->rowFor($body, 'pref_left_over');
+
+            $this->assertStringContainsString('>' . _T("unknown") . '<', $row);
+            $this->assertStringContainsString('from an older version', $row);
+            $this->assertStringNotContainsString('name="value"', $row, 'offered for edition');
+
+            //the table reads those outside of any "known" guard, so every entry
+            //has to carry them. strict_variables follows GALETTE_DEBUG, so a
+            //missing one only breaks the page on a debugging instance
+            $method = new \ReflectionMethod(AdvancedConfigController::class, 'getEntries');
+            $entries = $method->invoke($this->container->get(AdvancedConfigController::class));
+            foreach ($entries as $entry) {
+                foreach (['name', 'known', 'plugin', 'value'] as $key) {
+                    $this->assertArrayHasKey($key, $entry, $entry['name'] . ' has no ' . $key);
+                }
+            }
+        } finally {
+            $delete = $this->zdb->delete(\Galette\Core\Preferences::TABLE);
+            $delete->where(['nom_pref' => 'pref_left_over']);
+            $this->zdb->execute($delete);
         }
     }
 

--- a/tests/Galette/Core/PluginPreferencesTest.php
+++ b/tests/Galette/Core/PluginPreferencesTest.php
@@ -1,0 +1,175 @@
+<?php
+
+/**
+ * This file is part of Galette (https://galette.eu).
+ * SPDX-FileCopyrightText: Copyright © 2003-2026 The Galette Team
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Galette\Tests\Core;
+
+use Galette\Core\Preferences;
+use Galette\Core\PreferencesSchema;
+use Galette\Tests\GaletteTestCase;
+
+/**
+ * A plugin declaring preferences stores them among Galette's own, under a
+ * prefixed name. The fixture plugin-test1 declares three, so loading plugins
+ * is enough to exercise the whole path.
+ *
+ * @author Johan Cwiklinski <johan@x-tnd.be>
+ */
+class PluginPreferencesTest extends GaletteTestCase
+{
+    /**
+     * Declared entries join the schema, and say who owns them
+     */
+    public function testEntriesJoinTheSchema(): void
+    {
+        $this->assertTrue(PreferencesSchema::has('pref_plugin1_label'));
+        $this->assertSame('plugin1', PreferencesSchema::getOwner('pref_plugin1_label'));
+
+        //core describes itself without them
+        $this->assertArrayNotHasKey('pref_plugin1_label', PreferencesSchema::getCore());
+        $this->assertNull(PreferencesSchema::getOwner('pref_nom'));
+    }
+
+    /**
+     * They are read with the type they declare, not as raw strings
+     */
+    public function testValuesAreTyped(): void
+    {
+        $this->preferences->load();
+
+        $this->assertSame('plugin one', $this->preferences->getPluginValue('pref_plugin1_label'));
+        $this->assertSame(3, $this->preferences->getPluginValue('pref_plugin1_count'));
+        $this->assertFalse($this->preferences->getPluginValue('pref_plugin1_enabled'));
+    }
+
+    /**
+     * Their rows are created, even though preferences were built before any
+     * plugin was known
+     */
+    public function testRowsAreCreated(): void
+    {
+        $this->preferences->load();
+
+        $this->assertContains('pref_plugin1_count', $this->preferences->getFieldsNames());
+    }
+
+    /**
+     * They are writable through the regular API, and validated
+     */
+    public function testValuesAreWritable(): void
+    {
+        $this->preferences->load();
+
+        $this->assertTrue(
+            $this->preferences->setValue('pref_plugin1_count', 7, $this->login),
+            print_r($this->preferences->getErrors(), true)
+        );
+        $this->assertSame(7, $this->preferences->getPluginValue('pref_plugin1_count'));
+
+        //value really reached database
+        $prefs = new Preferences($this->zdb);
+        $this->assertSame(7, $prefs->getPluginValue('pref_plugin1_count'));
+
+        //the schema constraints apply
+        $this->assertFalse($this->preferences->setValue('pref_plugin1_count', 42, $this->login));
+
+        $this->assertTrue($this->preferences->resetValue('pref_plugin1_count', $this->login));
+        $this->assertSame(3, $this->preferences->getPluginValue('pref_plugin1_count'));
+    }
+
+    /**
+     * Saving the core settings form leaves them alone
+     *
+     * The form never renders a plugin preference, so the missing field would
+     * otherwise be taken for an emptied one and blank every plugin setting on
+     * each save.
+     */
+    public function testCoreFormDoesNotBlankThem(): void
+    {
+        $this->preferences->load();
+        $this->preferences->setValue('pref_plugin1_label', 'kept', $this->login);
+
+        //what the core settings form posts: core preferences, and nothing else
+        $values = array_map(
+            fn(array $entry): bool|int|string => $entry['default'],
+            PreferencesSchema::getCore()
+        );
+        $values['pref_nom'] = 'Galette';
+
+        $this->preferences->check($values, $this->login);
+
+        $this->assertSame('kept', $this->preferences->getPluginValue('pref_plugin1_label'));
+
+        $this->preferences->resetValue('pref_plugin1_label', $this->login);
+    }
+
+    /**
+     * Once the plugin is gone the value stays, unknown and read-only
+     */
+    public function testUnregisteredValueSurvives(): void
+    {
+        $this->preferences->load();
+        $this->preferences->setValue('pref_plugin1_label', 'still here', $this->login);
+
+        PreferencesSchema::unregister('plugin1');
+
+        $this->assertFalse(PreferencesSchema::has('pref_plugin1_label'));
+        $this->assertNull(PreferencesSchema::getOwner('pref_plugin1_label'));
+
+        //readable, as the string it is stored as
+        $prefs = new Preferences($this->zdb);
+        $this->assertSame('still here', $prefs->getPluginValue('pref_plugin1_label'));
+
+        //but no longer writable
+        $this->assertFalse($prefs->setValue('pref_plugin1_label', 'nope', $this->login));
+        $this->assertSame(
+            ["Unknown preference 'pref_plugin1_label'!"],
+            $prefs->getErrors()
+        );
+    }
+
+    /**
+     * A malformed declaration is dropped, not honoured, and not fatal
+     */
+    public function testMalformedEntriesAreDropped(): void
+    {
+        global $galette_log_var;
+
+        PreferencesSchema::register('plugin1', [
+            'pref_plugin1_ok' => ['type' => PreferencesSchema::TYPE_STRING, 'default' => 'y'],
+            'unprefixed' => ['type' => PreferencesSchema::TYPE_STRING, 'default' => 'x'],
+            'pref_plugin1_untyped' => ['default' => 'x'],
+            'pref_plugin1_nodefault' => ['type' => PreferencesSchema::TYPE_STRING],
+            'pref_nom' => ['type' => PreferencesSchema::TYPE_STRING, 'default' => 'hijacked'],
+        ]);
+
+        $this->assertTrue(PreferencesSchema::has('pref_plugin1_ok'));
+        $this->assertFalse(PreferencesSchema::has('unprefixed'));
+        $this->assertFalse(PreferencesSchema::has('pref_plugin1_untyped'));
+        $this->assertFalse(PreferencesSchema::has('pref_plugin1_nodefault'));
+
+        //a core preference cannot be taken over: no core name carries a plugin prefix
+        $this->assertNull(PreferencesSchema::getOwner('pref_nom'));
+        $this->assertSame('Galette', PreferencesSchema::getCore()['pref_nom']['default']);
+
+        //every rejection was reported
+        foreach (['unprefixed', 'pref_plugin1_untyped', 'pref_plugin1_nodefault', 'pref_nom'] as $rejected) {
+            $this->assertStringContainsString(
+                sprintf('Plugin "plugin1" declares an invalid preference: "%s"', $rejected),
+                (string)$galette_log_var
+            );
+        }
+
+        //drained here, or they would surface as stray entries in the next test
+        $galette_log_var = null;
+        \Analog\Analog::handler(
+            \Analog\Handler\LevelName::init(\Analog\Handler\Variable::init($galette_log_var))
+        );
+    }
+}

--- a/tests/Galette/Core/Preferences.php
+++ b/tests/Galette/Core/Preferences.php
@@ -367,6 +367,11 @@ class Preferences extends GaletteTestCase
 
     /**
      * Test fields names
+     *
+     * Every declared preference must have a row. The converse does not hold:
+     * a plugin that has been deactivated, or an older version of Galette,
+     * leaves rows behind, and the advanced configuration page reports them as
+     * unknown rather than pretending they cannot exist.
      */
     public function testFieldsNames(): void
     {
@@ -374,10 +379,18 @@ class Preferences extends GaletteTestCase
         $fields_names = $this->preferences->getFieldsNames();
         $expected = array_keys($this->preferences->getDefaults());
 
-        sort($fields_names);
-        sort($expected);
+        $this->assertSame(
+            [],
+            array_values(array_diff($expected, $fields_names)),
+            'declared preferences missing from database'
+        );
 
-        $this->assertSame($expected, $fields_names);
+        foreach (array_diff($fields_names, $expected) as $name) {
+            $this->assertFalse(
+                \Galette\Core\PreferencesSchema::has($name),
+                $name . ' is declared but has no row'
+            );
+        }
     }
 
     /**

--- a/tests/Galette/Core/PreferencesDocblockTest.php
+++ b/tests/Galette/Core/PreferencesDocblockTest.php
@@ -37,11 +37,14 @@ class PreferencesDocblockTest extends GaletteTestCase
 
     /**
      * Every preference is annotated, and nothing else is
+     *
+     * Core preferences only: a plugin declares its own into the schema, and
+     * naming them on this class would have core depend on its plugins.
      */
     public function testDocblockMatchesPreferences(): void
     {
         $documented = $this->getDocumentedProperties();
-        $declared = array_keys($this->preferences->getDefaults());
+        $declared = array_keys(\Galette\Core\PreferencesSchema::getCore());
 
         foreach ($declared as $name) {
             $this->assertArrayHasKey(
@@ -91,7 +94,7 @@ class PreferencesDocblockTest extends GaletteTestCase
         $documented = $this->getDocumentedProperties();
         $casts = $this->getCastTypes();
 
-        foreach (array_keys($this->preferences->getDefaults()) as $name) {
+        foreach (array_keys(\Galette\Core\PreferencesSchema::getCore()) as $name) {
             $expected = $casts[$name] ?? 'string';
 
             $this->assertSame(

--- a/tests/lib/BaseGaletteTestCase.php
+++ b/tests/lib/BaseGaletteTestCase.php
@@ -200,6 +200,10 @@ abstract class BaseGaletteTestCase extends TestCase
             session_write_close();
         }
 
+        //plugin registrations are static: without this they outlive the test
+        //that made them and turn failures into order-dependent ones
+        \Galette\Core\PreferencesSchema::reset();
+
         global $plugins, $app, $container, $zdb, $preferences, $login, $hist, $l10n, $emitter, $routeparser, $i18n, $translator;
         $plugins = $app = $container = $zdb = $preferences = $login = $hist = $l10n = $emitter = $routeparser = $i18n = $translator = null;
         unset(

--- a/tests/plugins/plugin-test1/lib/GaletteTest1Plugin/PluginGalettePlugin1.php
+++ b/tests/plugins/plugin-test1/lib/GaletteTest1Plugin/PluginGalettePlugin1.php
@@ -11,12 +11,43 @@ declare(strict_types=1);
 namespace GaletteTest1Plugin;
 
 use Galette\Core\GalettePlugin;
+use Galette\Core\PreferencesSchema;
+use Galette\Core\Plugins\PreferencesProviderInterface;
 
 /**
+ * This fixture also declares preferences, so that the registration path is
+ * exercised by every test that loads plugins.
+ *
  * @author Johan Cwiklinski <johan@x-tnd.be>
  */
-class PluginGalettePlugin1 extends GalettePlugin
+class PluginGalettePlugin1 extends GalettePlugin implements PreferencesProviderInterface
 {
+    /**
+     * Get the preferences the plugin declares
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public function getPreferences(): array
+    {
+        return [
+            'pref_plugin1_label' => [
+                'type' => PreferencesSchema::TYPE_STRING,
+                'default' => 'plugin one',
+            ],
+            'pref_plugin1_count' => [
+                'type' => PreferencesSchema::TYPE_INT,
+                'default' => 3,
+                'min' => 0,
+                'max' => 10,
+                'error' => PreferencesSchema::ERR_POSITIVE_NUMBER,
+            ],
+            'pref_plugin1_enabled' => [
+                'type' => PreferencesSchema::TYPE_BOOL,
+                'default' => false,
+            ],
+        ];
+    }
+
     /**
      * Is the plugin fully installed (including database, extra configuration, etc.)?
      */


### PR DESCRIPTION
Several exisintg plugins reimplement the same nom_pref/val_pref table and its loader class to hold a handful of settings. The core already reads rows it does not know, keeps them across a settings save and renders them on the advanced configuration page.

Write path was missing. PreferencesProviderInterface closes it: a plugin declares entries, they join the schema, and every accessor treats them as preferences from then on.

Preferences are built before the plugin list even exists, so registration invalidates the memoized schema and defaults, then asks the live instance to refresh and create the missing rows. Entries are named pref_<plugin route>_ and a malformed one is dropped and reported rather than thrown on: registration runs while modules load, where an exception would take the instance down over one faulty third-party plugin.

The prefix rule is also what keeps a plugin off core preferences, and what leaves a recognisable trace once a plugin is gone. Deactivating one drops its entries from the schema but never its rows: the values stay, unknown and read-only, until it comes back.

completeValues() had to learn about them. It blanks every database row missing from the posted form, which is how an unticked checkbox turns a setting off; with plugin keys now writable, saving the core settings form would have wiped every plugin setting. Only __set() refusing unknown names was preventing it.

Plugin preferences are not annotated on Preferences, since core must not name its plugins. getPluginValue() gives plugin authors an entry point static analysis can follow, and the docblock tests now describe the core schema alone.