### PR TITLE
Fix documents visibility filter

### DIFF
--- a/galette/lib/Galette/Controllers/Crud/DocumentsController.php
+++ b/galette/lib/Galette/Controllers/Crud/DocumentsController.php
@@ -260,6 +260,8 @@ class DocumentsController extends CrudController
 
             if (isset($post['visibility_filter']) && $post['visibility_filter'] !== 'none') {
                 $filters->visibility_filter = $post['visibility_filter'];
+            } else {
+                $filters->visibility_filter = null;
             }
         }
 

--- a/galette/lib/Galette/Repository/Documents.php
+++ b/galette/lib/Galette/Repository/Documents.php
@@ -322,7 +322,7 @@ class Documents
                 );
             }
 
-            if ($this->filters->visibility_filter !== null && $this->filters->visibility_filter != '0') {
+            if ($this->filters->visibility_filter !== null && $this->filters->visibility_filter != 'none') {
                 $select->where->equalTo(
                     'visible',
                     $this->filters->visibility_filter

--- a/galette/templates/default/pages/documents_list.html.twig
+++ b/galette/templates/default/pages/documents_list.html.twig
@@ -104,7 +104,7 @@
                     <select id="visibility_filter" name="visibility_filter" class="ui search dropdown">
                         <option value="none">{{ _T('Select') }}</option>
                         {% for key, value in perm_names %}
-                            <option value="{{ key }}"{% if key == filters.visibility_filter %} selected="selected"{% endif %}>{{ value }}</option>
+                            <option value="{{ key }}"{% if filters.visibility_filter is not null and key == filters.visibility_filter %} selected="selected"{% endif %}>{{ value }}</option>
                         {% endfor %}
                     </select>
                 </div>


### PR DESCRIPTION
Beside the fact that the statement in `Documents.php` was incorrect, the fact that permission `NOBODY` has `0` as its value caused the corresponding option in the dropdown to be selected on initial page load.