### PR TITLE
Test emailing settings, fix send mail test button

### DIFF
--- a/galette/includes/core_acls.php
+++ b/galette/includes/core_acls.php
@@ -25,6 +25,7 @@ $core_acls = [
     'advanced-search'                   => 'groupmanager',
     '/(.+)?search(.+)?/i'               => 'member',
     'testEmail'                         => 'admin',
+    'testEmailConnection'               => 'admin',
     'dashboard'                         => 'member',
     'sysinfos'                          => 'staff',
     'charts'                            => 'staff',

--- a/galette/includes/routes/management.routes.php
+++ b/galette/includes/routes/management.routes.php
@@ -43,10 +43,15 @@ $app->post(
     [GaletteController::class, 'storePreferences']
 )->setName('store-preferences')->add(Authenticate::class);
 
-$app->get(
+$app->post(
     '/test/email',
     [GaletteController::class, 'testEmail']
 )->setName('testEmail')->add(Authenticate::class);
+
+$app->post(
+    '/test/email-connection',
+    [GaletteController::class, 'testEmailConnection']
+)->setName('testEmailConnection')->add(Authenticate::class);
 
 //charts
 $app->get(

--- a/galette/lib/Galette/Controllers/GaletteController.php
+++ b/galette/lib/Galette/Controllers/GaletteController.php
@@ -22,6 +22,8 @@ use Galette\Core\Logo;
 use Galette\Core\PrintLogo;
 use Galette\Core\Galette;
 use Galette\Core\GaletteMail;
+use Galette\Core\Preferences;
+use Galette\Core\PreferencesSchema;
 use Galette\Core\SysInfos;
 use Galette\Entity\FieldsCategories;
 use Galette\Entity\Status;
@@ -287,26 +289,61 @@ class GaletteController extends AbstractController
     }
 
     /**
+     * Build the preferences a mail test runs on
+     *
+     * Testing what is stored is of little help to someone who is precisely
+     * changing it: the settings displayed in the form win, so that a server can
+     * be tried out before it is saved. Nothing is written back, the live
+     * instance is left alone, and only the preferences the transport is built
+     * from are taken into account.
+     *
+     * @param Request $request PSR Request
+     */
+    private function mailerPreferences(Request $request): Preferences
+    {
+        $prefs = clone $this->preferences;
+        $posted = (array)$request->getParsedBody();
+
+        foreach (PreferencesSchema::getMailer() as $name) {
+            if (PreferencesSchema::getType($name) === PreferencesSchema::TYPE_BOOL) {
+                //an unchecked checkbox is not posted at all
+                $prefs->$name = isset($posted[$name]);
+            } elseif (array_key_exists($name, $posted)) {
+                $prefs->$name = $posted[$name];
+            }
+        }
+
+        return $prefs;
+    }
+
+    /**
      * Test mail parameters
      */
     #[Route(
         name: 'testEmail',
         pattern: '/test/email',
-        methods: ['GET']
+        methods: ['POST']
     )]
     public function testEmail(Request $request, Response $response): Response
     {
         $sent = false;
-        if (!$this->preferences->pref_mail_method > GaletteMail::METHOD_DISABLED) {
+        $prefs = $this->mailerPreferences($request);
+        $errors = $prefs->getErrors();
+
+        if ($errors !== []) {
+            foreach ($errors as $error) {
+                $this->flash->addMessage('error_detected', $error);
+            }
+        } elseif ($prefs->pref_mail_method <= GaletteMail::METHOD_DISABLED) {
             $this->flash->addMessage(
                 'error_detected',
                 _T("You asked Galette to send a test email, but email has been disabled in the preferences.")
             );
         } else {
-            $get = $request->getQueryParams();
-            $dest = ($get['adress'] ?? $this->preferences->pref_email_newadh);
+            $post = (array)$request->getParsedBody();
+            $dest = ($post['adress'] ?? $prefs->pref_email_newadh);
             if (GaletteMail::isValidEmail($dest)) {
-                $mail = new GaletteMail($this->preferences);
+                $mail = new GaletteMail($prefs);
                 $mail->setSubject(_T('Test message'));
                 $mail->setRecipients(
                     [
@@ -327,9 +364,12 @@ class GaletteController extends AbstractController
                 } else {
                     $this->flash->addMessage(
                         'error_detected',
-                        sprintf(
-                            _T('No email sent to %1$s'),
-                            $dest
+                        $this->detailedMailError(
+                            sprintf(
+                                _T('No email sent to %1$s'),
+                                $dest
+                            ),
+                            $mail
                         )
                     );
                 }
@@ -343,7 +383,7 @@ class GaletteController extends AbstractController
 
         if (!$this->isAjax($request)) {
             return $response
-                ->withStatus(301)
+                ->withStatus(302)
                 ->withHeader('Location', $this->routeparser->urlFor('preferences'));
         } else {
             return $this->withJson(
@@ -353,6 +393,78 @@ class GaletteController extends AbstractController
                 ]
             );
         }
+    }
+
+    /**
+     * Test mail parameters, without sending any message
+     */
+    #[Route(
+        name: 'testEmailConnection',
+        pattern: '/test/email-connection',
+        methods: ['POST']
+    )]
+    public function testEmailConnection(Request $request, Response $response): Response
+    {
+        $connected = false;
+        $prefs = $this->mailerPreferences($request);
+        $errors = $prefs->getErrors();
+
+        if ($errors !== []) {
+            foreach ($errors as $error) {
+                $this->flash->addMessage('error_detected', $error);
+            }
+        } else {
+            $mail = new GaletteMail($prefs);
+            $connected = $mail->testConnection();
+
+            if ($connected) {
+                $this->flash->addMessage(
+                    'success_detected',
+                    _T("Those emailing settings work.")
+                );
+            } else {
+                $this->flash->addMessage(
+                    'error_detected',
+                    $this->detailedMailError(
+                        _T("Those emailing settings do not work."),
+                        $mail
+                    )
+                );
+            }
+        }
+
+        if (!$this->isAjax($request)) {
+            return $response
+                ->withStatus(302)
+                ->withHeader('Location', $this->routeparser->urlFor('preferences'));
+        } else {
+            return $this->withJson(
+                $response,
+                [
+                    'connected' => $connected
+                ]
+            );
+        }
+    }
+
+    /**
+     * Append what the mailer has to say to a failure message
+     *
+     * A bare "no email sent" leaves nothing to act on, while PHPMailer usually
+     * knows exactly what went wrong.
+     *
+     * @param string      $message Message to complete
+     * @param GaletteMail $mail    Mailer the failure comes from
+     */
+    private function detailedMailError(string $message, GaletteMail $mail): string
+    {
+        $errors = array_filter($mail->getErrors());
+        if ($errors === []) {
+            return $message;
+        }
+
+        //a flash message is rendered as a single line of HTML; keep it one
+        return $message . ' ' . implode(' ', $errors);
     }
 
     /**

--- a/galette/lib/Galette/Core/GaletteMail.php
+++ b/galette/lib/Galette/Core/GaletteMail.php
@@ -16,6 +16,7 @@ use Throwable;
 use Analog\Analog;
 use PHPMailer\PHPMailer\PHPMailer;
 
+use function Safe\ini_get;
 use function Safe\preg_match;
 
 /**
@@ -38,6 +39,9 @@ class GaletteMail
     public const int SENDER_PREFS = 0;
     public const int SENDER_CURRENT = 1;
     public const int SENDER_OTHER = 2;
+
+    /** Timeout, in seconds, a connection test is given */
+    public const int CONNECTION_TIMEOUT = 10;
 
     private string $sender_name;
     private string $sender_address;
@@ -320,6 +324,141 @@ class GaletteMail
             unset($this->mail);
             return self::MAIL_ERROR;
         }
+    }
+
+    /**
+     * Check the configured transport can be reached, without sending anything
+     *
+     * Setting a mail server up takes several tries, and each one of them used
+     * to cost a real message. Errors, when there are any, are available from
+     * getErrors().
+     */
+    public function testConnection(): bool
+    {
+        $this->errors = [];
+
+        if ($this->preferences->pref_mail_method <= self::METHOD_DISABLED) {
+            $this->errors[] = _T("Emailing has been disabled in the preferences.");
+            return false;
+        }
+
+        $mailer = $this->getPhpMailer();
+        //someone is waiting in front of the page; do not hold it for the five
+        //minutes a real transfer is allowed to take
+        $mailer->Timeout = self::CONNECTION_TIMEOUT;
+
+        $connected = match ($this->preferences->pref_mail_method) {
+            self::METHOD_SMTP, self::METHOD_GMAIL => $this->connectSmtp($mailer),
+            self::METHOD_SENDMAIL, self::METHOD_QMAIL => $this->checkSendmailBinary($mailer),
+            self::METHOD_PHPMAIL => $this->checkPhpMail(),
+            default => $this->unknownMethod()
+        };
+
+        unset($this->mail);
+
+        return $connected;
+    }
+
+    /**
+     * Report a sending method this version knows nothing about
+     */
+    private function unknownMethod(): bool
+    {
+        $this->errors[] = sprintf(
+            _T("Unknown emailing method '%s'."),
+            (string)$this->preferences->pref_mail_method
+        );
+
+        return false;
+    }
+
+    /**
+     * Open then close an SMTP session
+     *
+     * smtpConnect() also authenticates when SMTPAuth is on, so credentials and
+     * TLS are really exercised, not just the socket.
+     *
+     * @param PHPMailer $mailer Mailer the transport has been set up on
+     */
+    private function connectSmtp(PHPMailer $mailer): bool
+    {
+        try {
+            if (!$mailer->smtpConnect()) {
+                //smtpConnect() does not fill ErrorInfo; the SMTP session holds
+                //the only account of what went wrong
+                $this->errors[] = $this->smtpErrorMessage($mailer->getSMTPInstance()->getError());
+                return false;
+            }
+        } catch (Throwable $e) {
+            $this->errors[] = $e->getMessage();
+            return false;
+        }
+
+        $mailer->smtpClose();
+        return true;
+    }
+
+    /**
+     * Turn an SMTP error into something an administrator can act on
+     *
+     * @param array<string, string> $error Error as reported by the SMTP session
+     */
+    private function smtpErrorMessage(array $error): string
+    {
+        $reason = $error['error'] ?? '';
+        if ($reason === '') {
+            return _T("Unable to reach the SMTP server.");
+        }
+
+        //what the server, or the socket, had to say about it
+        $details = array_filter([
+            $error['detail'] ?? '',
+            $error['smtp_code_ex'] ?? ''
+        ]);
+
+        if ($details === []) {
+            return $reason;
+        }
+
+        return $reason . ': ' . implode(' ', $details);
+    }
+
+    /**
+     * Check the sendmail (or qmail) binary can be run
+     *
+     * @param PHPMailer $mailer Mailer the transport has been set up on
+     */
+    private function checkSendmailBinary(PHPMailer $mailer): bool
+    {
+        //isSendmail() and isQmail() have already resolved the path and dropped
+        //the arguments it may carry
+        if (!is_executable($mailer->Sendmail)) {
+            $this->errors[] = sprintf(
+                _T("'%s' does not exist, or cannot be run."),
+                $mailer->Sendmail
+            );
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Check PHP is able to hand a message over on its own
+     */
+    private function checkPhpMail(): bool
+    {
+        if (!function_exists('mail')) {
+            $this->errors[] = _T("The PHP mail() function is not available on this server.");
+            return false;
+        }
+
+        if (DIRECTORY_SEPARATOR !== '\\' && ini_get('sendmail_path') === '') {
+            $this->errors[] = _T("PHP 'sendmail_path' directive is empty; mail() has nothing to hand messages to.");
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/galette/lib/Galette/Core/PreferencesSchema.php
+++ b/galette/lib/Galette/Core/PreferencesSchema.php
@@ -53,6 +53,7 @@ use Galette\Repository\Members;
  *     sensitive?: bool,
  *     readonly?: bool,
  *     demo_locked?: bool,
+ *     mailer?: bool,
  *     acl?: string,
  *     constant?: string,
  *     plugin?: string
@@ -330,16 +331,18 @@ final class PreferencesSchema
             'pref_cc_secondary' => ['type' => self::TYPE_COLOR, 'default' => '#ffda89'],
             'pref_cc_secondary_text' => ['type' => self::TYPE_COLOR, 'default' => '#1b1c1d'],
             /* Preferences for emails */
-            'pref_email_nom' => ['type' => self::TYPE_STRING, 'default' => 'Galette'],
+            'pref_email_nom' => ['type' => self::TYPE_STRING, 'default' => 'Galette', 'mailer' => true],
             'pref_email' => [
                 'type' => self::TYPE_EMAIL,
                 'default' => 'mail@domain.com',
                 'demo_locked' => true,
+                'mailer' => true,
             ],
             'pref_email_newadh' => [
                 'type' => self::TYPE_EMAILS,
                 'default' => 'mail@domain.com',
                 'demo_locked' => true,
+                'mailer' => true,
             ],
             'pref_bool_mailadh' => ['type' => self::TYPE_BOOL, 'default' => false],
             'pref_bool_mailowner' => ['type' => self::TYPE_BOOL, 'default' => false],
@@ -348,17 +351,19 @@ final class PreferencesSchema
                 'type' => self::TYPE_INT,
                 'default' => GaletteMail::METHOD_DISABLED,
                 'demo_locked' => true,
+                'mailer' => true,
             ],
             'pref_mail_smtp' => ['type' => self::TYPE_STRING, 'default' => ''],
-            'pref_mail_smtp_host' => ['type' => self::TYPE_STRING, 'default' => ''],
-            'pref_mail_smtp_auth' => ['type' => self::TYPE_BOOL, 'default' => false],
-            'pref_mail_smtp_secure' => ['type' => self::TYPE_BOOL, 'default' => false],
-            'pref_mail_smtp_port' => ['type' => self::TYPE_INT, 'default' => ''],
-            'pref_mail_smtp_user' => ['type' => self::TYPE_STRING, 'default' => ''],
+            'pref_mail_smtp_host' => ['type' => self::TYPE_STRING, 'default' => '', 'mailer' => true],
+            'pref_mail_smtp_auth' => ['type' => self::TYPE_BOOL, 'default' => false, 'mailer' => true],
+            'pref_mail_smtp_secure' => ['type' => self::TYPE_BOOL, 'default' => false, 'mailer' => true],
+            'pref_mail_smtp_port' => ['type' => self::TYPE_INT, 'default' => '', 'mailer' => true],
+            'pref_mail_smtp_user' => ['type' => self::TYPE_STRING, 'default' => '', 'mailer' => true],
             'pref_mail_smtp_password' => [
                 'type' => self::TYPE_STRING,
                 'default' => '',
                 'sensitive' => true,
+                'mailer' => true,
             ],
             'pref_membership_ext' => [
                 'type' => self::TYPE_INT,
@@ -377,6 +382,7 @@ final class PreferencesSchema
                 'type' => self::TYPE_EMAIL,
                 'default' => '',
                 'demo_locked' => true,
+                'mailer' => true,
             ],
             'pref_website' => ['type' => self::TYPE_URL, 'default' => ''],
             /* Preferences for labels */
@@ -461,14 +467,14 @@ final class PreferencesSchema
             'pref_bool_empty_form_link' => ['type' => self::TYPE_BOOL, 'default' => false],
             /* New contribution script */
             'pref_new_contrib_script' => ['type' => self::TYPE_STRING, 'default' => ''],
-            'pref_bool_wrap_mails' => ['type' => self::TYPE_BOOL, 'default' => true],
+            'pref_bool_wrap_mails' => ['type' => self::TYPE_BOOL, 'default' => true, 'mailer' => true],
             'pref_rss_url' => ['type' => self::TYPE_STRING, 'default' => Galette::RSS_URL],
             'pref_adhesion_form' => [
                 'type' => self::TYPE_STRING,
                 'default' => \Galette\IO\PdfAdhesionForm::class,
                 'readonly' => true,
             ],
-            'pref_mail_allow_unsecure' => ['type' => self::TYPE_BOOL, 'default' => false],
+            'pref_mail_allow_unsecure' => ['type' => self::TYPE_BOOL, 'default' => false, 'mailer' => true],
             'pref_instance_uuid' => ['type' => self::TYPE_STRING, 'default' => '', 'readonly' => true],
             'pref_registration_uuid' => ['type' => self::TYPE_STRING, 'default' => '', 'readonly' => true],
             'pref_telemetry_date' => ['type' => self::TYPE_STRING, 'default' => '', 'readonly' => true],
@@ -641,6 +647,24 @@ final class PreferencesSchema
             array_filter(
                 self::getAll(),
                 static fn(array $entry): bool => $entry['demo_locked'] ?? false
+            )
+        );
+    }
+
+    /**
+     * Get every preference the mail transport is built from
+     *
+     * These are the ones a test may run on values that have not been stored
+     * yet: anything `GaletteMail` reads, and nothing else.
+     *
+     * @return array<string>
+     */
+    public static function getMailer(): array
+    {
+        return array_keys(
+            array_filter(
+                self::getAll(),
+                static fn(array $entry): bool => $entry['mailer'] ?? false
             )
         );
     }

--- a/galette/templates/default/pages/preferences.html.twig
+++ b/galette/templates/default/pages/preferences.html.twig
@@ -722,14 +722,33 @@
                             </div>
                         </div>
                         <br/>
-                        <a
-                            href="{{ url_for('testEmail') }}"
+    {% set mail_off = pref.pref_mail_method == constant('Galette\\Core\\GaletteMail::METHOD_DISABLED') %}
+                        <button
+                            type="button"
+                            data-href="{{ url_for('testEmailConnection') }}"
+                            id="btnmailconnect"
+                            class="ui labeled icon button{% if mail_off %} disabled{% endif %}"
+                            {% if mail_off %}disabled="disabled" aria-disabled="true"{% endif %}
+                        >
+                            <i class="plug icon" aria-hidden="true"></i>
+                            {{ _T("Test connection") }}
+                        </button>
+                        <button
+                            type="button"
+                            data-href="{{ url_for('testEmail') }}"
                             id="btnmail"
-                            class="ui labeled icon button"
+                            class="ui labeled icon button{% if mail_off %} disabled{% endif %}"
+                            {% if mail_off %}disabled="disabled" aria-disabled="true"{% endif %}
                         >
                             <i class="rocket icon" aria-hidden="true"></i>
-                            {{ _T("Test email settings") }}
-                        </a>
+                            {{ _T("Send a test email") }}
+                        </button>
+                        <div id="mailtest_off" class="ui small yellow message{% if not mail_off %} displaynone{% endif %}">
+                            {{ _T("Emailing is disabled: pick a sending method to run a test.") }}
+                        </div>
+                        <div id="mailtest_hint" class="ui small blue message{% if mail_off %} displaynone{% endif %}">
+                            {{ _T("Tests run on the settings displayed above, even those not saved yet.") }}
+                        </div>
                     </div>
                     <div id="smtp_parameters" class="field">
                         <div class="field">
@@ -1166,6 +1185,15 @@
                             _smtp_parameters.addClass('displaynone');
                             _smtp_auth.addClass('displaynone');
                         }
+
+                        // Nothing to test as long as no sending method is picked
+                        var _off = ( _checked == 'no' );
+                        $('#btnmail, #btnmailconnect')
+                            .toggleClass('disabled', _off)
+                            .prop('disabled', _off)
+                            .attr('aria-disabled', _off);
+                        $('#mailtest_off').toggleClass('displaynone', !_off);
+                        $('#mailtest_hint').toggleClass('displaynone', _off);
                     }
                 });
 
@@ -1219,6 +1247,42 @@
                     return;
                 });
 
+                // Tests run on what is displayed, not on what is stored: the
+                // whole mail tab goes along, and the server keeps the settings
+                // the transport is actually built from.
+                function _mailerSettings() {
+                    return $('div[data-tab="mail"]').find(':input').serializeArray();
+                }
+
+                function _mailTestMessages() {
+                    $.ajax({
+                        url: '{{ url_for('ajaxMessages') }}',
+                        method: "GET",
+                        success: function (values) {
+                            for (var type in values) {
+                                var dtime = 0;
+                                if (type == 'success') {
+                                    dtime = 'auto';
+                                }
+                                $('body')
+                                    .toast({
+                                        displayTime: dtime,
+                                        minDisplayTime: 5000,
+                                        wordsPerMinute: 80,
+                                        showProgress: 'bottom',
+                                        closeIcon: true,
+                                        position: 'top attached',
+                                        title: values[type]['title'],
+                                        message: values[type]['messages'].join('<br/>'),
+                                        showIcon: values[type]['icon'],
+                                        class: type
+                                    })
+                                ;
+                            }
+                        }
+                    });
+                }
+
                 $('#btnmail').on('click', function(e) {
                     e.preventDefault();
                     var _this = $(this);
@@ -1229,43 +1293,18 @@
                         content: _input,
                         onApprove: function() {
                             $.ajax({
-                                url: _this.attr('href'),
-                                type: 'GET',
-                                data: {
-                                    adress: $('#email_adress').val()
-                                },
+                                url: _this.data('href'),
+                                type: 'POST',
+                                data: _mailerSettings().concat([{
+                                    name: 'adress',
+                                    value: $('#email_adress').val()
+                                }]),
                                 {% include "elements/js/loader.js.twig" with {
                                     selector: '#btnmail',
                                     loader: 'button'
                                 } %},
                                 success: function(res) {
-                                    //display message
-                                    $.ajax({
-                                        url: '{{ url_for('ajaxMessages') }}',
-                                        method: "GET",
-                                        success: function (values) {
-                                            for (var type in values) {
-                                                var dtime = 0;
-                                                if (type == 'success') {
-                                                    dtime = 'auto';
-                                                }
-                                                $('body')
-                                                    .toast({
-                                                        displayTime: dtime,
-                                                        minDisplayTime: 5000,
-                                                        wordsPerMinute: 80,
-                                                        showProgress: 'bottom',
-                                                        closeIcon: true,
-                                                        position: 'top attached',
-                                                        title: values[type]['title'],
-                                                        message: values[type]['messages'].join('<br/>'),
-                                                        showIcon: values[type]['icon'],
-                                                        class: type
-                                                    })
-                                                ;
-                                            }
-                                        }
-                                    });
+                                    _mailTestMessages();
                                 },
                                 error: function () {
                                     {% include "elements/js/modal.js.twig" with {
@@ -1289,6 +1328,32 @@
                             class   : 'icon labeled cancel'
                         }]
                     }).modal('show');
+                });
+
+                $('#btnmailconnect').on('click', function(e) {
+                    e.preventDefault();
+                    $.ajax({
+                        url: $(this).data('href'),
+                        type: 'POST',
+                        data: _mailerSettings(),
+                        {% include "elements/js/loader.js.twig" with {
+                            selector: '#btnmailconnect',
+                            loader: 'button'
+                        } %},
+                        success: function(res) {
+                            _mailTestMessages();
+                        },
+                        error: function () {
+                            {% include "elements/js/modal.js.twig" with {
+                                modal_title_twig: _T("An error occurred testing mail server connection :(")|e("js"),
+                                modal_without_content: true,
+                                modal_class: "mini",
+                                modal_deny_only: true,
+                                modal_cancel_text: _T("Close")|e("js"),
+                                modal_classname: "redalert",
+                            } %}
+                        }
+                    });
                 });
 
                 _addLegendButton('#mail_sign');

--- a/tests/Galette/Controllers/GaletteController.php
+++ b/tests/Galette/Controllers/GaletteController.php
@@ -266,7 +266,7 @@ class GaletteController extends GaletteRoutingTestCase
      */
     public function testTestEmail(): void
     {
-        $request = $this->createRequest('testEmail');
+        $request = $this->createRequest('testEmail', [], 'POST');
 
         //Refused from authenticate middleware
         $test_response = $this->app->handle($request);
@@ -276,29 +276,51 @@ class GaletteController extends GaletteRoutingTestCase
         $this->logSuperAdmin();
         $test_response = $this->app->handle($request);
         $this->assertSame(['Location' => [$this->routeparser->urlFor('preferences')]], $test_response->getHeaders());
-        $this->assertSame(301, $test_response->getStatusCode());
+        $this->assertSame(302, $test_response->getStatusCode());
         $this->expectNoLogEntry();
         $this->expectFlashData(['error_detected' => ['You asked Galette to send a test email, but email has been disabled in the preferences.']]);
 
-        $this->preferences->pref_mail_method = \Galette\Core\GaletteMail::METHOD_SMTP;
+        //settings come from the form, so a method that is disabled in database
+        //no longer stands in the way
+        $smtp = [
+            'pref_mail_method' => (string)\Galette\Core\GaletteMail::METHOD_SMTP,
+            'pref_mail_smtp_host' => '127.0.0.1',
+            'pref_mail_smtp_port' => '1'
+        ];
 
         //test invalid test email
-        $invalid_request = $request->withQueryParams(['adress' => 'invalidemail']);
+        $invalid_request = $request->withParsedBody($smtp + ['adress' => 'invalidemail']);
         $test_response = $this->app->handle($invalid_request);
         $this->assertSame(['Location' => [$this->routeparser->urlFor('preferences')]], $test_response->getHeaders());
-        $this->assertSame(301, $test_response->getStatusCode());
+        $this->assertSame(302, $test_response->getStatusCode());
         $this->expectNoLogEntry();
         $this->expectFlashData(['error_detected' => ['Invalid email adress!']]);
 
         //standard working test email - no real email provider setup so gives an error
-        $test_response = $this->app->handle($request);
+        $smtp_request = $request->withParsedBody($smtp);
+        $test_response = $this->app->handle($smtp_request);
         $this->assertSame(['Location' => [$this->routeparser->urlFor('preferences')]], $test_response->getHeaders());
-        $this->assertSame(301, $test_response->getStatusCode());
+        $this->assertSame(302, $test_response->getStatusCode());
         $this->expectNoLogEntry();
-        $this->expectFlashData(['error_detected' => ['No email sent to mail@domain.com']]);
+        //failure is detailed with what the mailer had to say
+        $this->assertStringStartsWith(
+            "No email sent to mail@domain.com ",
+            $this->flash_data['slimFlash']['error_detected'][0]
+        );
+        $this->flash_data = [];
+
+        //testing does not store anything: neither the live instance nor the
+        //database know about the settings that have just been tried
+        $this->assertSame(
+            \Galette\Core\GaletteMail::METHOD_DISABLED,
+            $this->preferences->pref_mail_method
+        );
+        $stored = new \Galette\Core\Preferences($this->zdb);
+        $this->assertSame(\Galette\Core\GaletteMail::METHOD_DISABLED, $stored->pref_mail_method);
+        $this->assertNotSame('127.0.0.1', $stored->pref_mail_smtp_host);
 
         //ajax test email - no real email provider setup so gives an error
-        $json_request = $request->withHeader('X-Requested-With', 'XMLHttpRequest');
+        $json_request = $smtp_request->withHeader('X-Requested-With', 'XMLHttpRequest');
         $test_response = $this->app->handle($json_request);
         $this->assertSame(['Content-Type' => ['application/json']], $test_response->getHeaders());
         $this->assertSame(200, $test_response->getStatusCode());
@@ -306,10 +328,70 @@ class GaletteController extends GaletteRoutingTestCase
 
         $body = (string)$test_response->getBody();
         $this->assertSame('{"sent":0}', $body);
-        $this->expectFlashData(['error_detected' => ['No email sent to mail@domain.com']]);
+        $this->assertStringStartsWith(
+            "No email sent to mail@domain.com ",
+            $this->flash_data['slimFlash']['error_detected'][0]
+        );
+        $this->flash_data = [];
+    }
 
-        //Reset mail method to default
-        $this->preferences->pref_mail_method = \Galette\Core\GaletteMail::METHOD_DISABLED;
+    /**
+     * Test email connection test route
+     */
+    public function testTestEmailConnection(): void
+    {
+        $request = $this->createRequest('testEmailConnection', [], 'POST');
+
+        //Refused from authenticate middleware
+        $test_response = $this->app->handle($request);
+        $this->expectLogin($test_response);
+
+        $this->logSuperAdmin();
+
+        //nothing to connect to as long as emailing is disabled
+        $test_response = $this->app->handle($request);
+        $this->assertSame(['Location' => [$this->routeparser->urlFor('preferences')]], $test_response->getHeaders());
+        $this->assertSame(302, $test_response->getStatusCode());
+        $this->expectNoLogEntry();
+        $this->expectFlashData([
+            'error_detected' => [
+                'Those emailing settings do not work. '
+                . 'Emailing has been disabled in the preferences.'
+            ]
+        ]);
+
+        //PHP hands messages over on its own, there is nothing to reach
+        $php_request = $request->withParsedBody(
+            ['pref_mail_method' => (string)\Galette\Core\GaletteMail::METHOD_PHPMAIL]
+        );
+        $test_response = $this->app->handle($php_request);
+        $this->assertSame(302, $test_response->getStatusCode());
+        $this->expectNoLogEntry();
+        $this->expectFlashData([
+            'success_detected' => ['Those emailing settings work.']
+        ]);
+
+        //nothing listens on port 1; connection is refused right away
+        $smtp_request = $request->withParsedBody([
+            'pref_mail_method' => (string)\Galette\Core\GaletteMail::METHOD_SMTP,
+            'pref_mail_smtp_host' => '127.0.0.1',
+            'pref_mail_smtp_port' => '1'
+        ]);
+        $test_response = $this->app->handle($smtp_request);
+        $this->assertSame(302, $test_response->getStatusCode());
+        $this->assertStringStartsWith(
+            "Those emailing settings do not work. ",
+            $this->flash_data['slimFlash']['error_detected'][0]
+        );
+        $this->flash_data = [];
+
+        //ajax variant
+        $json_request = $smtp_request->withHeader('X-Requested-With', 'XMLHttpRequest');
+        $test_response = $this->app->handle($json_request);
+        $this->assertSame(['Content-Type' => ['application/json']], $test_response->getHeaders());
+        $this->assertSame(200, $test_response->getStatusCode());
+        $this->assertSame('{"connected":false}', (string)$test_response->getBody());
+        $this->flash_data = [];
     }
 
     /**

--- a/tests/Galette/Core/GaletteMail.php
+++ b/tests/Galette/Core/GaletteMail.php
@@ -183,4 +183,51 @@ class GaletteMail extends GaletteTestCase
         $this->assertInstanceOf($mail::class, $mail->setTimeout(20)); //nothing testable
         $this->assertSame([], $mail->getErrors());
     }
+
+    /**
+     * Test connection check on a disabled emailing
+     */
+    public function testConnectionDisabled(): void
+    {
+        $this->preferences->pref_mail_method = \Galette\Core\GaletteMail::METHOD_DISABLED;
+        $mail = new \Galette\Core\GaletteMail($this->preferences);
+
+        $this->assertFalse($mail->testConnection());
+        $this->assertSame(['Emailing has been disabled in the preferences.'], $mail->getErrors());
+    }
+
+    /**
+     * Test connection check when PHP hands messages over on its own
+     */
+    public function testConnectionPhpMail(): void
+    {
+        $this->preferences->pref_mail_method = \Galette\Core\GaletteMail::METHOD_PHPMAIL;
+        $mail = new \Galette\Core\GaletteMail($this->preferences);
+
+        $this->assertTrue($mail->testConnection());
+        $this->assertSame([], $mail->getErrors());
+
+        $this->preferences->pref_mail_method = \Galette\Core\GaletteMail::METHOD_DISABLED;
+    }
+
+    /**
+     * Test connection check against a server that is not there
+     */
+    public function testConnectionSmtpRefused(): void
+    {
+        //nothing ever listens on port 1; the connection is refused right away
+        $this->preferences->pref_mail_method = \Galette\Core\GaletteMail::METHOD_SMTP;
+        $this->preferences->pref_mail_smtp_host = '127.0.0.1';
+        $this->preferences->pref_mail_smtp_port = 1;
+        $mail = new \Galette\Core\GaletteMail($this->preferences);
+
+        $this->assertFalse($mail->testConnection());
+        $errors = $mail->getErrors();
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('Failed to connect to server', $errors[0]);
+
+        $this->preferences->pref_mail_method = \Galette\Core\GaletteMail::METHOD_DISABLED;
+        $this->preferences->pref_mail_smtp_host = '';
+        $this->preferences->pref_mail_smtp_port = 0;
+    }
 }

--- a/tests/Galette/Core/PreferencesSchema.php
+++ b/tests/Galette/Core/PreferencesSchema.php
@@ -174,6 +174,36 @@ class PreferencesSchema extends GaletteTestCase
     }
 
     /**
+     * Preferences the mail transport is built from
+     *
+     * A test can run on those before they are stored, so the list must hold
+     * everything GaletteMail reads, and nothing else.
+     */
+    public function testMailer(): void
+    {
+        $expected = [
+            'pref_email_nom',
+            'pref_email',
+            'pref_email_newadh',
+            'pref_mail_method',
+            'pref_mail_smtp_host',
+            'pref_mail_smtp_auth',
+            'pref_mail_smtp_secure',
+            'pref_mail_smtp_port',
+            'pref_mail_smtp_user',
+            'pref_mail_smtp_password',
+            'pref_email_reply_to',
+            'pref_bool_wrap_mails',
+            'pref_mail_allow_unsecure',
+        ];
+
+        $mailer = Schema::getMailer();
+        sort($expected);
+        sort($mailer);
+        $this->assertSame($expected, $mailer);
+    }
+
+    /**
      * Legacy behaviour constants a preference supersedes
      */
     public function testConstants(): void


### PR DESCRIPTION
The test button built its message from the stored preferences, so an administrator who had just typed a new SMTP host tested the old one, with nothing on the page saying so. It also stayed clickable while emailing was disabled: the refusal only came back from the server, once the address modal had been filled in.

A second button has been added to test connection without sending anything.

Both tests now post the mail tab and run on what it carries. PreferencesSchema marks the preferences the transport is built from, and the controller overrides a clone of the live instance with those alone - nothing is written, so a server can be tried before it is saved.

Also, improve some failure messages.