### PR TITLE
Fix advanced settings removed on form submit

### DIFF
--- a/galette/lib/Galette/Core/Preferences.php
+++ b/galette/lib/Galette/Core/Preferences.php
@@ -435,6 +435,10 @@ class Preferences
      * is blanked, which is what lets an unchecked checkbox turn its preference
      * off.
      *
+     * A preference the settings form does not render is the exception: the
+     * payload never carries it, so blanking it would reset it every time the
+     * form is saved. It keeps what is stored instead.
+     *
      * @param array<string, mixed> $values Submitted values
      *
      * @return array<string, mixed>
@@ -452,6 +456,8 @@ class Preferences
 
             if (isset($values[$fieldname])) {
                 $value = is_string($values[$fieldname]) ? trim($values[$fieldname]) : $values[$fieldname];
+            } elseif (PreferencesSchema::isAdvanced($fieldname)) {
+                $value = $this->prefs[$fieldname];
             } else {
                 $value = "";
             }

--- a/galette/lib/Galette/Core/PreferencesSchema.php
+++ b/galette/lib/Galette/Core/PreferencesSchema.php
@@ -54,6 +54,7 @@ use Galette\Repository\Members;
  *     readonly?: bool,
  *     demo_locked?: bool,
  *     mailer?: bool,
+ *     advanced?: bool,
  *     acl?: string,
  *     constant?: string,
  *     plugin?: string
@@ -313,7 +314,7 @@ final class PreferencesSchema
             ],
             'pref_org_phone_staff_member' => ['type' => self::TYPE_INT, 'default' => ''],
             'pref_org_email' => ['type' => self::TYPE_EMAIL, 'default' => ''],
-            'pref_disable_members_socials' => ['type' => self::TYPE_BOOL, 'default' => false],
+            'pref_disable_members_socials' => ['type' => self::TYPE_BOOL, 'default' => false, 'advanced' => true],
             'pref_lang' => [
                 'type' => self::TYPE_STRING,
                 'default' => I18n::DEFAULT_LANG,
@@ -355,7 +356,7 @@ final class PreferencesSchema
                 'demo_locked' => true,
                 'mailer' => true,
             ],
-            'pref_mail_smtp' => ['type' => self::TYPE_STRING, 'default' => ''],
+            'pref_mail_smtp' => ['type' => self::TYPE_STRING, 'default' => '', 'advanced' => true],
             'pref_mail_smtp_host' => ['type' => self::TYPE_STRING, 'default' => '', 'mailer' => true],
             'pref_mail_smtp_auth' => ['type' => self::TYPE_BOOL, 'default' => false, 'mailer' => true],
             'pref_mail_smtp_secure' => ['type' => self::TYPE_BOOL, 'default' => false, 'mailer' => true],
@@ -516,66 +517,77 @@ final class PreferencesSchema
                 'default' => 5,
                 'min' => AuthThrottle::MIN_ATTEMPTS,
                 'error' => self::ERR_THROTTLE_ATTEMPTS,
+                'advanced' => true
             ],
             'pref_throttle_account_ip_window' => [
                 'type' => self::TYPE_INT,
                 'default' => 900,
                 'min' => AuthThrottle::MIN_SECONDS,
                 'error' => self::ERR_THROTTLE_SECONDS,
+                'advanced' => true
             ],
             'pref_throttle_ip_attempts' => [
                 'type' => self::TYPE_INT,
                 'default' => 30,
                 'min' => AuthThrottle::MIN_ATTEMPTS,
                 'error' => self::ERR_THROTTLE_ATTEMPTS,
+                'advanced' => true
             ],
             'pref_throttle_ip_window' => [
                 'type' => self::TYPE_INT,
                 'default' => 900,
                 'min' => AuthThrottle::MIN_SECONDS,
                 'error' => self::ERR_THROTTLE_SECONDS,
+                'advanced' => true
             ],
             'pref_throttle_account_attempts' => [
                 'type' => self::TYPE_INT,
                 'default' => 100,
                 'min' => AuthThrottle::MIN_ATTEMPTS,
                 'error' => self::ERR_THROTTLE_ATTEMPTS,
+                'advanced' => true
             ],
             'pref_throttle_account_window' => [
                 'type' => self::TYPE_INT,
                 'default' => 86400,
                 'min' => AuthThrottle::MIN_SECONDS,
                 'error' => self::ERR_THROTTLE_SECONDS,
+                'advanced' => true
             ],
             'pref_throttle_delay' => [
                 'type' => self::TYPE_INT,
                 'default' => 900,
                 'min' => AuthThrottle::MIN_SECONDS,
                 'error' => self::ERR_THROTTLE_SECONDS,
+                'advanced' => true
             ],
             'pref_throttle_recovery_attempts' => [
                 'type' => self::TYPE_INT,
                 'default' => 3,
                 'min' => AuthThrottle::MIN_ATTEMPTS,
                 'error' => self::ERR_THROTTLE_ATTEMPTS,
+                'advanced' => true
             ],
             'pref_throttle_recovery_window' => [
                 'type' => self::TYPE_INT,
                 'default' => 3600,
                 'min' => AuthThrottle::MIN_SECONDS,
                 'error' => self::ERR_THROTTLE_SECONDS,
+                'advanced' => true
             ],
             'pref_throttle_subscribe_attempts' => [
                 'type' => self::TYPE_INT,
                 'default' => 5,
                 'min' => AuthThrottle::MIN_ATTEMPTS,
                 'error' => self::ERR_THROTTLE_ATTEMPTS,
+                'advanced' => true
             ],
             'pref_throttle_subscribe_window' => [
                 'type' => self::TYPE_INT,
                 'default' => 3600,
                 'min' => AuthThrottle::MIN_SECONDS,
                 'error' => self::ERR_THROTTLE_SECONDS,
+                'advanced' => true
             ],
             /* Settings that used to live in behavior.inc.php only */
             'pref_x_forwarded_for_index' => [
@@ -584,6 +596,7 @@ final class PreferencesSchema
                 'min' => 0,
                 'error' => self::ERR_POSITIVE_NUMBER,
                 'constant' => 'GALETTE_X_FORWARDED_FOR_INDEX',
+                'advanced' => true,
             ],
             'pref_session_timeout' => [
                 'type' => self::TYPE_INT,
@@ -591,6 +604,7 @@ final class PreferencesSchema
                 'min' => 0,
                 'error' => self::ERR_POSITIVE_NUMBER,
                 'constant' => 'GALETTE_TIMEOUT',
+                'advanced' => true,
             ],
         ];
     }
@@ -738,6 +752,20 @@ final class PreferencesSchema
                 static fn(array $entry): bool => $entry['mailer'] ?? false
             )
         );
+    }
+
+    /**
+     * Is that preference left out of the settings form?
+     *
+     * Such a preference is only offered by the advanced configuration page, so
+     * a settings submission that does not carry it is not a request to turn it
+     * off: it keeps what is stored.
+     *
+     * @param string $name Preference name
+     */
+    public static function isAdvanced(string $name): bool
+    {
+        return self::getAll()[$name]['advanced'] ?? false;
     }
 
     /**

--- a/tests/Galette/Core/Preferences.php
+++ b/tests/Galette/Core/Preferences.php
@@ -1496,4 +1496,37 @@ class Preferences extends GaletteTestCase
         $this->assertTrue(isset($this->preferences->vpref_email_newadh));
         $this->assertTrue(isset($this->preferences->socials));
     }
+
+    /**
+     * Test that saving the settings form leaves advanced preferences alone
+     *
+     * They are not rendered by that form, so the payload never carries them.
+     * Blanking them, as any other missing field, would reset them on every
+     * save.
+     */
+    public function testFormSaveKeepsAdvancedPreferences(): void
+    {
+        $this->logSuperAdmin();
+
+        $this->preferences->pref_session_timeout = 42;
+        $this->preferences->pref_x_forwarded_for_index = 2;
+
+        //what the settings form submits: every preference it renders
+        $post = [];
+        foreach ($this->preferences->getFieldsNames() as $name) {
+            if (!\Galette\Core\PreferencesSchema::isAdvanced($name)) {
+                $post[$name] = $this->preferences->$name;
+            }
+        }
+        $post['pref_admin_pass'] = '';
+        $post['pref_admin_pass_bis'] = '';
+
+        $this->assertTrue(
+            $this->preferences->check($post, $this->login),
+            print_r($this->preferences->getErrors(), return: true)
+        );
+
+        $this->assertSame(42, $this->preferences->pref_session_timeout);
+        $this->assertSame(2, $this->preferences->pref_x_forwarded_for_index);
+    }
 }

--- a/tests/Galette/Core/PreferencesSchema.php
+++ b/tests/Galette/Core/PreferencesSchema.php
@@ -13,6 +13,9 @@ namespace Galette\Tests\Core;
 use Galette\Core\PreferencesSchema as Schema;
 use Galette\Tests\GaletteTestCase;
 
+use function Safe\file_get_contents;
+use function Safe\preg_match;
+
 /**
  * Preferences schema tests class
  *
@@ -275,5 +278,42 @@ class PreferencesSchema extends GaletteTestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Unknown error identifier "nope".');
         Schema::getErrorMessage('nope');
+    }
+
+    /**
+     * A preference is either on the settings form, or flagged as advanced
+     *
+     * Preferences::completeValues() blanks whatever the payload does not
+     * carry, so a preference the form does not render has to say so: without
+     * the flag, saving the settings form would reset it every time. Keeping
+     * both in step is what makes that safe.
+     *
+     * Only core preferences are concerned: a plugin's are never rendered by
+     * the core form, and completeValues() leaves them alone on their own.
+     */
+    public function testOffFormPreferencesAreFlagged(): void
+    {
+        $form = file_get_contents(
+            GALETTE_ROOT . 'templates/default/pages/preferences.html.twig'
+        );
+
+        foreach (array_keys(Schema::getCore()) as $name) {
+            //a name is a prefix of longer ones, only a whole one counts
+            $on_form = preg_match('/' . $name . '(?![a-zA-Z0-9_])/', $form) === 1;
+
+            if ($on_form) {
+                $this->assertFalse(
+                    Schema::isAdvanced($name),
+                    $name . ' is flagged as advanced but the settings form renders it'
+                );
+                continue;
+            }
+
+            $this->assertTrue(
+                Schema::isAdvanced($name) || Schema::isReadOnly($name),
+                $name . ' is not on the settings form and is not flagged as advanced,'
+                . ' so saving the form would blank it'
+            );
+        }
     }
 }


### PR DESCRIPTION
completeValues() blanks every preference missing from the payload: ref_session_timeout set to 42 from the advanced page reads back as '' after the next save.

Flag as advanced on preference so it can be properly handled when the payload omits it.